### PR TITLE
fix: Incoming entities should always be processed if existing fails validation

### DIFF
--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -79,7 +79,10 @@ export default abstract class Entity {
     existing: any,
     incoming: any,
   ) {
-    return existingMeta.fetchedAt <= incomingMeta.fetchedAt;
+    return (
+      existingMeta.fetchedAt <= incomingMeta.fetchedAt ||
+      !!this.validate(existing)
+    );
   }
 
   /** Creates new instance copying over defined values of arguments */


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This can happen with partial responses - requiring a merge even with 'newer' version

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

