### PR TITLE
fix: Typing when using .extend({body}) with no path

### DIFF
--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -105,7 +105,7 @@ type OptionsToRestEndpoint<
   ? RestType<
       'searchParams' extends keyof O
         ? O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>
-        : UrlParamsFromFunction<Parameters<E>>,
+        : PathArgs<Exclude<E['path'], undefined>>,
       O['body'],
       'schema' extends keyof O ? O['schema'] : E['schema'],
       'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
@@ -162,7 +162,7 @@ type OptionsToFunction<
   ? RestFetch<
       'searchParams' extends keyof O
         ? O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>
-        : UrlParamsFromFunction<Parameters<E>>,
+        : PathArgs<Exclude<E['path'], undefined>>,
       O['body'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>
     >
@@ -178,10 +178,6 @@ type OptionsToFunction<
     ) => Promise<
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>
     >;
-
-type UrlParamsFromFunction<Args extends any[]> = 1 extends keyof Args
-  ? Args[0]
-  : undefined;
 
 export type RestExtendedEndpoint<
   O extends PartialRestGenerics,


### PR DESCRIPTION
Fixes #2330 .

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
The previous heuristic fails in certain edge cases. Now that we track the components reliably, simply use existing path to recompute function arguments.