### PR TITLE
enhance: Alert users of class mangling issues

### DIFF
--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -58,6 +58,10 @@ export class Article extends Entity {
     author: User,
     createdAt: Date,
   }
+
+  static get key() {
+    return 'Article';
+  }
 }
 
 export const ArticleResource = createResource({
@@ -88,6 +92,10 @@ export class Article extends Entity {
   static schema = {
     author: User,
     createdAt: Date,
+  }
+
+  static get key() {
+    return 'Article';
   }
 }
 export const ArticleResource = createResource({

--- a/docs/rest/api/Endpoint.md
+++ b/docs/rest/api/Endpoint.md
@@ -133,6 +133,15 @@ Default:
 `${this.fetch.name} ${JSON.stringify(params)}`;
 ```
 
+:::caution
+
+This may break in production builds that change class names.
+This is often know as [class name mangling](https://terser.org/docs/api-reference#mangle-options).
+
+In these cases you can override `key` or disable class mangling.
+
+:::
+
 ### sideEffect: true | undefined {#sideeffect}
 
 Used to indicate endpoint might have side-effects (non-idempotent). This restricts it

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -136,6 +136,16 @@ pk() {
 This defines the key for the Entity itself, rather than an instance. This needs to be a globally
 unique value.
 
+:::caution
+
+This defaults to `this.name`; however this may break in production builds that change class names.
+This is often know as [class name mangling](https://terser.org/docs/api-reference#mangle-options).
+
+In these cases you can override `key` or disable class mangling.
+
+:::
+
+
 ### static merge(existing, incoming): mergedValue {#merge}
 
 ```typescript

--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -84,13 +84,14 @@ export function createGithubResource<U extends string, S extends Schema>({
   path,
   schema,
   Endpoint = GithubEndpoint,
+  ...options
 }: {
   readonly path: U;
   readonly schema: S;
   readonly Endpoint?: typeof GithubEndpoint;
   urlPrefix?: string;
 } & EndpointExtraOptions): GithubResource<U, S> {
-  const baseResource = createResource({ path, schema, Endpoint });
+  const baseResource = createResource({ path, schema, Endpoint, ...options });
 
   const getList: GetEndpoint<
     PathArgs<ShortenPath<U>>,

--- a/examples/github-app/webpack.config.js
+++ b/examples/github-app/webpack.config.js
@@ -9,6 +9,7 @@ const options = {
     template: 'index.ejs',
   },
   globalStyleDir: 'style',
+  terserOptions: { keep_classnames: true },
 };
 
 const generateConfig = makeConfig(options);

--- a/examples/nextjs/pages/api/ExchangeRates.ts
+++ b/examples/nextjs/pages/api/ExchangeRates.ts
@@ -9,6 +9,11 @@ export class ExchangeRates extends Entity {
   pk(): string {
     return this.currency;
   }
+
+  // implementing `key` makes us robust against class name mangling
+  static get key() {
+    return 'ExchangeRates';
+  }
 }
 
 export const getExchangeRates = new RestEndpoint({

--- a/examples/todo-app/src/resources/TodoResource.ts
+++ b/examples/todo-app/src/resources/TodoResource.ts
@@ -9,6 +9,10 @@ export class Todo extends PlaceholderEntity {
   readonly userId: number = 0;
   readonly title: string = '';
   readonly completed: boolean = false;
+
+  static get key() {
+    return 'Todo';
+  }
 }
 
 const TodoResourceBase = createPlaceholderResource({

--- a/examples/todo-app/src/resources/UserResource.ts
+++ b/examples/todo-app/src/resources/UserResource.ts
@@ -31,6 +31,10 @@ export class User extends PlaceholderEntity {
   get profileImage() {
     return `https://i.pravatar.cc/256?img=${this.id + 4}`;
   }
+
+  static get key() {
+    return 'User';
+  }
 }
 
 export const UserResource = createPlaceholderResource({

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -96,5 +96,16 @@ export default class Endpoint extends Function {
 
     return instance;
   }
+
+  /* istanbul ignore next */
+  static {
+    /* istanbul ignore if */
+    if (this.name !== 'Endpoint') {
+      this.prototype.key = function (...args) {
+        console.error('Rest Hooks Error: https://resthooks.io/errors/osid');
+        return `${this.name} ${JSON.stringify(args)}`;
+      };
+    }
+  }
 }
 export const ExtendableEndpoint = Endpoint;

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -446,6 +446,19 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
   protected static set(entity: any, key: string, value: any) {
     entity[key] = value;
   }
+
+  /* istanbul ignore next */
+  static {
+    /* istanbul ignore if */
+    if (this.name !== 'Entity') {
+      Object.defineProperty(this, 'key', {
+        get() {
+          console.error('Rest Hooks Error: https://resthooks.io/errors/dklj');
+          return this.name;
+        },
+      });
+    }
+  }
 }
 
 /* istanbul ignore else */

--- a/website/src/pages/errors/dklj.tsx
+++ b/website/src/pages/errors/dklj.tsx
@@ -1,0 +1,36 @@
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+import React from 'react';
+
+export default function MangledClassnames() {
+  return (
+    <Layout title="Rest Hooks Error: Mangled class names detected">
+      <header>
+        <div className="container">
+          <h2>Error: Mangled class names detected</h2>
+        </div>
+      </header>
+      <main>
+        <div className="container">
+          <p>
+            Either add a custom{' '}
+            <Link to="/rest/api/Entity#key">Entity key</Link>
+          </p>
+
+          <p>
+            Or{' '}
+            <a
+              href="https://terser.org/docs/api-reference#mangle-options"
+              target="_blank"
+              rel="noreferrer"
+            >
+              disable class name mangling
+            </a>
+          </p>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/pages/errors/osid.tsx
+++ b/website/src/pages/errors/osid.tsx
@@ -1,0 +1,36 @@
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+import React from 'react';
+
+export default function MangledClassnames() {
+  return (
+    <Layout title="Rest Hooks Error: Mangled class names detected">
+      <header>
+        <div className="container">
+          <h2>Error: Mangled class names detected</h2>
+        </div>
+      </header>
+      <main>
+        <div className="container">
+          <p>
+            Either add a custom{' '}
+            <Link to="/rest/api/Endpoint#key">Endpoint key</Link>
+          </p>
+
+          <p>
+            Or{' '}
+            <a
+              href="https://terser.org/docs/api-reference#mangle-options"
+              target="_blank"
+              rel="noreferrer"
+            >
+              disable class name mangling
+            </a>
+          </p>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Commonly minification programs like terser will change class names to something shorter. However, this can cause issues when using `this.name` to generate easy keys (like in Entity and Endpoint).

- The risk of collisions increases since these become very short words
- There will be serialization mismatches in SSR if the server side code does not also mangle in the exact same way (they usually don't at all)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

We can run detection upon Entity static class creation. We know the name *should* be Entity, so this comparison will detect the issue. If so we will override the default implementation with a console.error.

```ts
  static {
    if (this.name !== 'Entity') {
      Object.defineProperty(this, 'key', {
        get() {
          console.error('Rest Hooks Error: https://resthooks.io/errors/dklj');
          return this.name;
        },
      });
    }
  }
```

Aside from adding the console error we will keep the existing implementation, to not cause breakages in many cases where the mangling wasn't causing issue.

In the future we may decide to throw an error somewhere to make this problem more obvious. That is TBD.

Also:

- Add https://resthooks.io/errors/dklj and https://resthooks.io/errors/osid page will longer error description - since this shows in production
- Update examples to avoid this issue
- Update Entity.key and Endpoint.key to elaborate on its importance.