### PR TITLE
enhance: Make endpoint a normal dep

### DIFF
--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -68,10 +68,10 @@
     "url": "https://github.com/data-client/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0"
+    "@babel/runtime": "^7.17.0",
+    "@rest-hooks/endpoint": "^3.4.1"
   },
   "peerDependencies": {
-    "@rest-hooks/endpoint": "^1.0.3 || ^2.0.0-0 || ^3.0.0",
     "@rest-hooks/react": "^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4363,6 +4363,7 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
+    "@rest-hooks/endpoint": ^3.4.1
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
@@ -4374,7 +4375,6 @@ __metadata:
     rollup-plugin-replace: ^2.2.0
     rollup-plugin-terser: ^7.0.2
   peerDependencies:
-    "@rest-hooks/endpoint": ^1.0.3 || ^2.0.0-0 || ^3.0.0
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Now people don't have to manually install [@rest-hooks/endpoint](https://www.npmjs.com/package/@rest-hooks/endpoint)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
[@rest-hooks/endpoint](https://www.npmjs.com/package/@rest-hooks/endpoint) moved from peerDeps to deps