### PR TITLE
enhance: Improve autonaming failure detection for Endpoint

### DIFF
--- a/docs/rest/api/Endpoint.md
+++ b/docs/rest/api/Endpoint.md
@@ -130,15 +130,21 @@ Serializes the parameters. This is used to build a lookup key in global stores.
 Default:
 
 ```typescript
-`${this.fetch.name} ${JSON.stringify(params)}`;
+`${this.name} ${JSON.stringify(params)}`;
 ```
+
+### name: string {#name}
+
+Used in [key](#key) to distinguish endpoints. Should be globally unique.
+
+Defaults to `this.fetch.name`
 
 :::caution
 
-This may break in production builds that change class names.
-This is often know as [class name mangling](https://terser.org/docs/api-reference#mangle-options).
+This may break in production builds that change function names.
+This is often know as [function name mangling](https://terser.org/docs/api-reference#mangle-options).
 
-In these cases you can override `key` or disable class mangling.
+In these cases you can override `name` or disable function mangling.
 
 :::
 

--- a/packages/endpoint/src/__tests__/__snapshots__/endpoint.ts.snap
+++ b/packages/endpoint/src/__tests__/__snapshots__/endpoint.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Endpoint Function should console.error with autoname failures 1`] = `
+[
+  [
+    "Endpoint: Autonaming failure.
+
+Endpoint initialized with anonymous function.
+Please add \`name\` option or hoist the function definition. https://resthooks.io/rest/api/Endpoint#name",
+  ],
+]
+`;

--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -71,6 +71,12 @@ describe('Endpoint', () => {
   });
 
   describe('Function', () => {
+    let errorSpy: jest.SpyInstance;
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
+    beforeEach(() => (errorSpy = jest.spyOn(console, 'error')));
+
     it('should work when called as function', async () => {
       const UserDetail = new Endpoint(fetchUsers);
 
@@ -115,6 +121,16 @@ describe('Endpoint', () => {
       expect(Fourth.name).toBe('fetchUserList');
       const Weird = new Endpoint(fetchUsersIdParam, { fetch: fetchUserList });
       expect(Weird.name).toBe(`fetchUsersIdParam`);
+    });
+
+    it('should console.error with autoname failures', () => {
+      const UserDetail = new Endpoint(function (this: any, id: string) {
+        return fetch(`/${this.root || 'users'}/${id}`).then(res =>
+          res.json(),
+        ) as Promise<typeof payload>;
+      });
+      expect(errorSpy.mock.calls.length).toBe(1);
+      expect(errorSpy.mock.calls).toMatchSnapshot();
     });
 
     it('should work when called with string parameter', async () => {

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -53,6 +53,16 @@ export default class Endpoint extends Function {
       delete options.name;
     } else if (fetchFunction) {
       self.__name = fetchFunction.name;
+      if (
+        /* istanbul ignore else */ process.env.NODE_ENV !== 'production' &&
+        (fetchFunction.name === 'anonymous' || fetchFunction.name === '') &&
+        (!options || !('key' in options)) &&
+        this.key === Endpoint.prototype.key
+      ) {
+        console.error(
+          'Endpoint: Autonaming failure.\n\nEndpoint initialized with anonymous function.\nPlease add `name` option or hoist the function definition. https://resthooks.io/rest/api/Endpoint#name',
+        );
+      }
     }
     Object.assign(self, options);
     Object.defineProperty(self, 'name', {
@@ -100,7 +110,7 @@ export default class Endpoint extends Function {
   /* istanbul ignore next */
   static {
     /* istanbul ignore if */
-    if (this.name !== 'Endpoint') {
+    if (runCompat.name !== 'runCompat') {
       this.prototype.key = function (...args) {
         console.error('Rest Hooks Error: https://resthooks.io/errors/osid');
         return `${this.name} ${JSON.stringify(args)}`;

--- a/website/src/pages/errors/osid.tsx
+++ b/website/src/pages/errors/osid.tsx
@@ -1,22 +1,20 @@
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
-import TabItem from '@theme/TabItem';
-import Tabs from '@theme/Tabs';
 import React from 'react';
 
-export default function MangledClassnames() {
+export default function MangledFunctionnames() {
   return (
-    <Layout title="Rest Hooks Error: Mangled class names detected">
+    <Layout title="Rest Hooks Error: Mangled function names detected">
       <header>
         <div className="container">
-          <h2>Error: Mangled class names detected</h2>
+          <h2>Error: Mangled function names detected</h2>
         </div>
       </header>
       <main>
         <div className="container">
           <p>
             Either add a custom{' '}
-            <Link to="/rest/api/Endpoint#key">Endpoint key</Link>
+            <Link to="/rest/api/Endpoint#name">Endpoint name</Link>
           </p>
 
           <p>
@@ -26,7 +24,7 @@ export default function MangledClassnames() {
               target="_blank"
               rel="noreferrer"
             >
-              disable class name mangling
+              disable function name mangling
             </a>
           </p>
         </div>


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Earlier visibility into potential key issues.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- log when Endpoint autonaming fails. Only do this if key is not overridden. (So we know it relies on name)
- Add `name` option to docs
- Update mangling detection for Endpoint to use function mangling, as name is based on a function name, not the class name.
