### PR TITLE
enhance: Default RestEndpoint name based on url path

### DIFF
--- a/packages/endpoint/src/CSP.js
+++ b/packages/endpoint/src/CSP.js
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+export let CSP = false;
+try {
+  Function();
+} catch (e) {
+  CSP = true;
+  // TODO: figure out how to supress the error log instead of tell people it's okay
+  console.error(
+    'Content Security Policy: The previous CSP log can be safely ignored - @rest-hooks/endpoint will use setPrototypeOf instead',
+  );
+}

--- a/packages/endpoint/src/__tests__/__snapshots__/endpoint.ts.snap
+++ b/packages/endpoint/src/__tests__/__snapshots__/endpoint.ts.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Endpoint Function should console.error with autoname failures 1`] = `
+exports[`Endpoint (CSP false) Function should console.error with autoname failures 1`] = `
+[
+  [
+    "Endpoint: Autonaming failure.
+
+Endpoint initialized with anonymous function.
+Please add \`name\` option or hoist the function definition. https://resthooks.io/rest/api/Endpoint#name",
+  ],
+]
+`;
+
+exports[`Endpoint (CSP true) Function should console.error with autoname failures 1`] = `
 [
   [
     "Endpoint: Autonaming failure.

--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -75,7 +75,9 @@ describe('Endpoint', () => {
     afterEach(() => {
       errorSpy.mockRestore();
     });
-    beforeEach(() => (errorSpy = jest.spyOn(console, 'error')));
+    beforeEach(
+      () => (errorSpy = jest.spyOn(console, 'error').mockImplementation()),
+    );
 
     it('should work when called as function', async () => {
       const UserDetail = new Endpoint(fetchUsers);
@@ -129,6 +131,7 @@ describe('Endpoint', () => {
           res.json(),
         ) as Promise<typeof payload>;
       });
+      UserDetail.name;
       expect(errorSpy.mock.calls.length).toBe(1);
       expect(errorSpy.mock.calls).toMatchSnapshot();
     });
@@ -485,6 +488,7 @@ describe('Endpoint', () => {
           url,
           random: 599,
           dataExpiryLength: 5000,
+          name: 'UserDetai',
         },
       );
       const a: undefined = UserDetail.sideEffect;

--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -1,10 +1,18 @@
 import nock from 'nock';
 
-import Endpoint, { EndpointInstance } from '../endpoint';
+import type { default as TEndpoint, EndpointInstance } from '../endpoint';
 import { EndpointInterface } from '../interface';
 import Entity from '../schemas/Entity';
 
-describe('Endpoint', () => {
+describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
+  jest.resetModules();
+  jest.mock('../CSP', () => ({ CSP: mockCSP }));
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Endpoint: typeof TEndpoint = require('../endpoint').default;
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
   const payload = { id: '5', username: 'bobber' };
   const payload2 = { id: '6', username: 'tomm' };
   const assetPayload = { symbol: 'btc', price: '5.0' };

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -1,3 +1,5 @@
+import { CSP } from './CSP.js';
+
 function runCompat(endpoint, options) {
   endpoint.type = endpoint.sideEffect ? 'mutate' : 'read';
   endpoint.options = { ...options };
@@ -13,19 +15,6 @@ function runCompat(endpoint, options) {
   if (endpoint.schema === undefined) endpoint.schema = null;
 }
 
-let CSP = false;
-try {
-  Function();
-} catch (e) {
-  /* istanbul ignore next */
-  CSP = true;
-  // TODO: figure out how to supress the error log instead of tell people it's okay
-  /* istanbul ignore next */
-  console.error(
-    'Content Security Policy: The previous CSP log can be safely ignored - @rest-hooks/endpoint will use setPrototypeOf instead',
-  );
-}
-
 /**
  * Defines an async data source.
  * @see https://resthooks.io/docs/api/Endpoint
@@ -33,9 +22,6 @@ try {
 export default class Endpoint extends Function {
   constructor(fetchFunction, options) {
     let self;
-    // TODO: Test the fallback?
-    /* istanbul ignore if */
-    /* istanbul ignore next */
     if (CSP) {
       self = (...args) => self.fetch(...args);
       Object.setPrototypeOf(self, new.target.prototype);

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -48,28 +48,46 @@ export default class Endpoint extends Function {
 
     if (fetchFunction) self.fetch = fetchFunction;
 
-    if (options && 'name' in options) {
-      self.__name = options.name;
-      delete options.name;
-    } else if (fetchFunction) {
-      self.__name = fetchFunction.name;
-      if (
-        /* istanbul ignore else */ process.env.NODE_ENV !== 'production' &&
-        (fetchFunction.name === 'anonymous' || fetchFunction.name === '') &&
-        (!options || !('key' in options)) &&
-        this.key === Endpoint.prototype.key
-      ) {
-        console.error(
-          'Endpoint: Autonaming failure.\n\nEndpoint initialized with anonymous function.\nPlease add `name` option or hoist the function definition. https://resthooks.io/rest/api/Endpoint#name',
-        );
-      }
+    /** Name propery block
+     *
+     * To make things callable, we force every instance to be constructed as a function
+     * Because of this the name property will be autoset
+     * To create a usable naming inheritance pattern, we use __name as a proxy.
+     * Every instance then overrides the name property.
+     *
+     * For protocol specific extensions that wish to customize default naming
+     * behavior, be sure to add your own `Object.defineProperty(self, 'name'`
+     * in your constructor to override this one.
+     */
+    let autoName;
+    if (
+      !(options && 'name' in options) &&
+      fetchFunction &&
+      fetchFunction.name &&
+      fetchFunction.name !== 'anonymous'
+    ) {
+      autoName = fetchFunction.name;
     }
-    Object.assign(self, options);
     Object.defineProperty(self, 'name', {
-      get: function () {
-        return this.__name;
+      get() {
+        if (
+          /* istanbul ignore else */ process.env.NODE_ENV !== 'production' &&
+          self.key === Endpoint.prototype.key &&
+          !(autoName || this.__name)
+        ) {
+          console.error(
+            'Endpoint: Autonaming failure.\n\nEndpoint initialized with anonymous function.\nPlease add `name` option or hoist the function definition. https://resthooks.io/rest/api/Endpoint#name',
+          );
+        }
+        return autoName || this.__name;
+      },
+      set(v) {
+        this.__name = v;
       },
     });
+    /** End name property block */
+
+    Object.assign(self, options);
 
     /** The following is for compatibility with FetchShape */
     runCompat(self, options);

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -44,6 +44,14 @@ export default class RestEndpoint extends Endpoint {
     this.#hasBody =
       (!('body' in this) || this.body !== undefined) &&
       !['GET', 'DELETE'].includes(this.method);
+
+    Object.defineProperty(this, 'name', {
+      get() {
+        // using 'in' to ensure inheritance lookup
+        if ('__name' in this) return this.__name;
+        return this.urlPrefix + this.path;
+      },
+    });
   }
 
   key(...args) {
@@ -181,21 +189,14 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
   }
 
   extend(options) {
-    // fetch overrides are banned
-    /*if ('fetch' in options)
-      throw new Error('fetch overrides not allowed for RestEndpoint');
-      we now just only allow the same type*/
-
     // make a constructor/prototype based off this
     // extend from it and init with options sent
     class E extends this.constructor {}
 
     Object.assign(E.prototype, this);
     const instance = new E(
-      // name and fetch get overridden by function prototype, so we must set it explicitly every time
-      this.name
-        ? { name: this.name, fetch: this.fetch, ...options }
-        : { fetch: this.fetch, ...options },
+      //  fetch get overridden by function prototype, so we must set it explicitly every time
+      { fetch: this.fetch, ...options },
     );
 
     return instance;

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -57,7 +57,6 @@ export class PaginatedArticle extends Entity {
 const getArticleList = new RestEndpoint({
   urlPrefix: 'http://test.com',
   path: '/article-paginated',
-  name: 'get',
   schema: {
     nextPage: '',
     data: { results: [PaginatedArticle] },
@@ -221,6 +220,12 @@ describe('RestEndpoint', () => {
 
   it('should automatically name methods', () => {
     expect(getUser.name).toBe('User.get');
+    expect(getArticleList.name).toMatchInlineSnapshot(
+      `"http://test.com/article-paginated"`,
+    );
+    expect(
+      getArticleList.extend({ path: '/:something' }).name,
+    ).toMatchInlineSnapshot(`"http://test.com/:something"`);
   });
 
   it('should update on get for a paginated resource', async () => {
@@ -689,6 +694,7 @@ describe('RestEndpoint', () => {
       });
       getUserBase.body;
       expect(getUserBase.name).toBe('getuser');
+      expect(getUserBase.extend({ method: 'GET' }).name).toBe('getuser');
       expect(getUser.name).toBe('getuser');
       expect(getUser.additional).toBe(5);
       expect(getUser.method).toBe('GET');
@@ -826,7 +832,12 @@ describe('RestEndpoint', () => {
   });
   it('extending with name should work', () => {
     const endpoint = CoolerArticleResource.get.extend({ name: 'mything' });
+    const endpoint2 = CoolerArticleResource.get.extend({ path: '/:bob' });
+    expect(CoolerArticleResource.get.name).toMatchInlineSnapshot(
+      `"CoolerArticle.get"`,
+    );
     expect(endpoint.name).toBe('mything');
+    expect(endpoint2.name).toMatchInlineSnapshot(`"CoolerArticle.get"`);
   });
   it('should infer default method when sideEffect is set', async () => {
     const endpoint = new RestEndpoint({


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`name` can be great for logging or debugging purposes, so having better defaults is beneficial.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Note: Resources still have `Resource.method` naming convention

Set default option if name is not provided to options.urlPrefix + options.path


#### Implementation

 To make things callable, we force every instance to be constructed as a function
 Because of this the name property will be autoset
 To create a usable naming inheritance pattern, we use __name as a proxy.
 Every instance then overrides the name property.

 For protocol specific extensions that wish to customize default naming
 behavior, be sure to add your own `Object.defineProperty(self, 'name'`
 in your constructor to override this one.