### PR TITLE
enhance: Use self-overwriting memoization pattern

### DIFF
--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -425,12 +425,15 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     return [entityCopy, true, deleted];
   }
 
-  private declare static __defaults: any;
   /** All instance defaults set */
-  protected static get defaults() {
-    if (!Object.hasOwn(this, '__defaults'))
-      this.__defaults = new (this as any)();
-    return this.__defaults;
+  protected static get defaults(): any {
+    // memoization pattern from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters
+    delete (this as any).defaults;
+    // this is necessary to overcome inheritance limitations
+    Object.defineProperty(this, 'defaults', {
+      value: new (this as any)(),
+    });
+    return this.defaults;
   }
 
   /** Used by denormalize to set nested members */


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Less object crowding; more performance

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters

```ts
const obj = {
  get notifier() {
    delete this.notifier;
    this.notifier = document.getElementById("bookmarked-notification-anchor");
    return this.notifier;
  },
};
```

We apply this to Entity.defaults

We had to slightly alter the pattern to use `Object.defineProperty` for assignment, since the object we are operating on might be a descendant of the original getter.