### PR TITLE
fix: Entity.defaults should work with inheritance

### DIFF
--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -425,15 +425,13 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     return [entityCopy, true, deleted];
   }
 
+  private declare static __defaults: any;
   /** All instance defaults set */
-  protected static get defaults(): any {
-    // memoization pattern from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters
-    delete (this as any).defaults;
-    // this is necessary to overcome inheritance limitations
-    Object.defineProperty(this, 'defaults', {
-      value: new (this as any)(),
-    });
-    return this.defaults;
+  protected static get defaults() {
+    // we use hasOwn because we don't want to use a parents' defaults
+    if (!Object.hasOwn(this, '__defaults'))
+      this.__defaults = new (this as any)();
+    return this.__defaults;
   }
 
   /** Used by denormalize to set nested members */

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -1271,3 +1271,41 @@ describe(`${Entity.name} denormalization`, () => {
     });
   });
 });
+
+describe('Entity.defaults', () => {
+  it('should work with inheritance', () => {
+    abstract class DefaultsEntity extends Entity {
+      static getMyDefaults() {
+        return this.defaults;
+      }
+    }
+
+    class ID extends DefaultsEntity {
+      id = '';
+      pk() {
+        return this.id;
+      }
+    }
+    class UserEntity extends ID {
+      username = '';
+      createdAt = new Date(0);
+
+      static schema = {
+        createdAt: Date,
+      };
+    }
+
+    expect(ID.getMyDefaults()).toMatchInlineSnapshot(`
+      ID {
+        "id": "",
+      }
+    `);
+    expect(UserEntity.getMyDefaults()).toMatchInlineSnapshot(`
+      UserEntity {
+        "createdAt": 1970-01-01T00:00:00.000Z,
+        "id": "",
+        "username": "",
+      }
+    `);
+  });
+});

--- a/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
@@ -654,6 +654,10 @@ interface EndpointInstanceInterface<
 
   fetch: F;
 
+  /* utilities */
+  /** @see https://resthooks.io/rest/api/Endpoint#testKey */
+  testKey(key: string): boolean;
+
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
   readonly type: M extends undefined
@@ -800,6 +804,7 @@ declare abstract class Entity {
         fetchedAt: number;
     }, input: any): number;
     static denormalize<T extends typeof Entity>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
+    private static __defaults;
     /** All instance defaults set */
     protected static get defaults(): any;
     /** Used by denormalize to set nested members */

--- a/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
@@ -654,6 +654,10 @@ interface EndpointInstanceInterface<
 
   fetch: F;
 
+  /* utilities */
+  /** @see https://resthooks.io/rest/api/Endpoint#testKey */
+  testKey(key: string): boolean;
+
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
   readonly type: M extends undefined
@@ -800,6 +804,7 @@ declare abstract class Entity {
         fetchedAt: number;
     }, input: any): number;
     static denormalize<T extends typeof Entity>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
+    private static __defaults;
     /** All instance defaults set */
     protected static get defaults(): any;
     /** Used by denormalize to set nested members */
@@ -864,6 +869,7 @@ declare class GQLEndpoint<Variables, S extends Schema | undefined = Schema | und
     signal?: AbortSignal;
     constructor(url: string, options?: GQLOptions<Variables, S, M>);
     key(variables: Variables): string;
+    testKey(key: string): boolean;
     getQuery(variables: Variables): string;
     getHeaders(headers: HeadersInit): HeadersInit;
     getRequestInit(variables: any): RequestInit;

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -650,6 +650,10 @@ interface EndpointInstanceInterface<
 
   fetch: F;
 
+  /* utilities */
+  /** @see https://resthooks.io/rest/api/Endpoint#testKey */
+  testKey(key: string): boolean;
+
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
   readonly type: M extends undefined
@@ -796,6 +800,7 @@ declare abstract class Entity {
         fetchedAt: number;
     }, input: any): number;
     static denormalize<T extends typeof Entity>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
+    private static __defaults;
     /** All instance defaults set */
     protected static get defaults(): any;
     /** Used by denormalize to set nested members */

--- a/website/src/components/Playground/editor-types/rest-hooks.d.ts
+++ b/website/src/components/Playground/editor-types/rest-hooks.d.ts
@@ -276,6 +276,10 @@ interface EndpointInstanceInterface<
 
   fetch: F;
 
+  /* utilities */
+  /** @see https://resthooks.io/rest/api/Endpoint#testKey */
+  testKey(key: string): boolean;
+
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
   readonly type: M extends undefined


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The pattern from https://github.com/data-client/rest-hooks/pull/2437 only works if there are no descendants. However, we want to allow users to add more defaults with children entities. For instance, having a base class for their whole API, base class for Unions, or simply having partial fields sometimes.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Revert #2437, but also add tests to ensure we cover this case, as the bug will only be triggered with multiple calls in the inheritance chain.