### PR TITLE
enhance: Use null-object over Object.hasOwn when possible

### DIFF
--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -34,7 +34,7 @@ export class ResetError extends Error {
  * @see https://resthooks.io/docs/api/NetworkManager
  */
 export default class NetworkManager implements Manager {
-  protected fetched: { [k: string]: Promise<any> } = {};
+  protected fetched: { [k: string]: Promise<any> } = Object.create(null);
   protected resolvers: { [k: string]: (value?: any) => void } = {};
   protected rejectors: { [k: string]: (value?: any) => void } = {};
   protected fetchedAt: { [k: string]: number } = {};
@@ -109,9 +109,7 @@ export default class NetworkManager implements Manager {
   /** Used by DevtoolsManager to determine whether to log an action */
   skipLogging(action: ActionTypes) {
     /* istanbul ignore next */
-    return (
-      action.type === FETCH_TYPE && Object.hasOwn(this.fetched, action.meta.key)
-    );
+    return action.type === FETCH_TYPE && action.meta.key in this.fetched;
   }
 
   /** On mount */
@@ -280,7 +278,7 @@ export default class NetworkManager implements Manager {
    */
   protected handleReceive(action: ReceiveAction) {
     // this can still turn out to be untrue since this is async
-    if (Object.hasOwn(this.fetched, action.meta.key)) {
+    if (action.meta.key in this.fetched) {
       let promiseHandler: (value?: any) => void;
       if (action.error) {
         promiseHandler = this.rejectors[action.meta.key];

--- a/packages/normalizr/src/WeakListMap.ts
+++ b/packages/normalizr/src/WeakListMap.ts
@@ -29,7 +29,7 @@ export default class WeakListMap<K extends object, V> {
   has(key: K[]): boolean {
     const link = this.traverse(key);
     if (!link) return false;
-    return Object.hasOwn(link, 'value');
+    return 'value' in link;
   }
 
   set(key: K[], value: V): WeakListMap<K, V> {

--- a/packages/react/src/components/NetworkErrorBoundary.tsx
+++ b/packages/react/src/components/NetworkErrorBoundary.tsx
@@ -2,7 +2,7 @@ import type { NetworkError } from '@rest-hooks/core';
 import React from 'react';
 
 function isNetworkError(error: NetworkError | unknown): error is NetworkError {
-  return Object.hasOwn(error as any, 'status');
+  return 'status' in (error as any);
 }
 
 interface Props<E extends NetworkError> {

--- a/packages/rest/src/RestHelpers.ts
+++ b/packages/rest/src/RestHelpers.ts
@@ -2,9 +2,9 @@ import { compile, PathFunction, parse } from 'path-to-regexp';
 
 import { ShortenPath } from './pathTypes.js';
 
-const urlBaseCache: Record<string, PathFunction<object>> = {};
+const urlBaseCache: Record<string, PathFunction<object>> = Object.create(null);
 export function getUrlBase(path: string): PathFunction {
-  if (!Object.hasOwn(urlBaseCache, path)) {
+  if (!(path in urlBaseCache)) {
     urlBaseCache[path] = compile(path, {
       encode: encodeURIComponent,
       validate: false,
@@ -13,9 +13,9 @@ export function getUrlBase(path: string): PathFunction {
   return urlBaseCache[path];
 }
 
-const urlTokensCache: Record<string, Set<string>> = {};
+const urlTokensCache: Record<string, Set<string>> = Object.create(null);
 export function getUrlTokens(path: string): Set<string> {
-  if (!Object.hasOwn(urlTokensCache, path)) {
+  if (!(path in urlTokensCache)) {
     urlTokensCache[path] = new Set(
       parse(path).map(t => (typeof t === 'string' ? t : `${t['name']}`)),
     );


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- https://www.measurethat.net/Benchmarks/Show/23523/2/vs-hasown-vs-in-with-null-obj shows null object performance is better
- Object.hasOwn is fairly new and less browser support
- 'in' checks are easier to read and probably compile to less bytes

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Any time we simply have a fixed lookup table where we want to check arbitrary keys, we can use Object.create(null) to make a simple dictionary without prototype pollution.

This unfortunately does not work in cases where we want to spread, like the store itself - those must continue using Object.hasOwn
