### PR TITLE
fix: Correct `expiresAt` computation when cached + inferred results

### DIFF
--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -401,15 +401,17 @@ export default class Controller<
     if (!expiresAt) {
       // expiresAt existance is equivalent to cacheResults
       if (found) {
+        const entityMeta = state.entityMeta;
         // oldest entity dictates age
-        expiresAt = Infinity;
-        // using Object.keys ensures we don't hit `toString` type members
-        entityPaths.forEach(({ pk, key }) => {
-          expiresAt = Math.min(
-            expiresAt,
-            state.entityMeta[key]?.[pk]?.expiresAt ?? Infinity,
-          );
-        });
+        expiresAt = entityPaths.reduce(
+          (expiresAt: number, { pk, key }) =>
+            Math.min(expiresAt, entityMeta[key]?.[pk]?.expiresAt ?? Infinity),
+          Infinity,
+        );
+        /*expiresAt = entityPaths
+          .map(({ pk, key }) => entityMeta[key]?.[pk]?.expiresAt)
+          .filter(a => a)
+          .reduce((a, b) => Math.min(a, b), Infinity); Alternative method - is it faster?*/
       } else {
         expiresAt = 0;
       }

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -84,13 +84,25 @@ describe('Controller.getResponse()', () => {
     const state = {
       ...initialState,
       entities,
+      entityMeta: {
+        Tacos: {
+          1: { date: 1000000, expiresAt: 1100000, fetchedAt: 1000000 },
+          2: { date: 2000000, expiresAt: 2100000, fetchedAt: 2000000 },
+        },
+      },
     };
-    const { data, expiryStatus } = controller.getResponse(
+    const { data, expiryStatus, expiresAt } = controller.getResponse(
       ep,
       { id: '1' },
       state,
     );
     expect(expiryStatus).toBe(ExpiryStatus.Valid);
     expect(data).toMatchSnapshot();
+    expect(expiresAt).toBe(1100000);
+    // test caching
+    const second = controller.getResponse(ep, { id: '1' }, state);
+    expect(second.data.data).toBe(data.data);
+    expect(second.expiryStatus).toBe(expiryStatus);
+    expect(second.expiresAt).toBe(expiresAt);
   });
 });

--- a/packages/legacy/src/resource/__tests__/__snapshots__/Delete.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/Delete.test.ts.snap
@@ -43,6 +43,6 @@ exports[`UnionSchema denormalization denormalizes deleted entities as undefined 
   },
   true,
   true,
-  {},
+  [],
 ]
 `;

--- a/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
@@ -10,21 +10,16 @@ exports[`Entity denormalization can denormalize already partially denormalized d
   },
   true,
   false,
-  {
-    "Food": {
-      "1": Food {
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-    "Menu": {
-      "1": Menu {
-        "food": Food {
-          "id": "1",
-        },
-        "id": "1",
-      },
+    {
+      "key": "Food",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -38,21 +33,16 @@ exports[`Entity denormalization can denormalize already partially denormalized d
   },
   true,
   false,
-  {
-    "Food": {
-      "1": Food {
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-    "Menu": {
-      "1": Menu {
-        "food": Food {
-          "id": "1",
-        },
-        "id": "1",
-      },
+    {
+      "key": "Food",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -66,16 +56,12 @@ exports[`Entity denormalization denormalizes an entity 1`] = `
   },
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "alias": undefined,
-        "id": "1",
-        "name": "",
-        "type": "foo",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -89,16 +75,12 @@ exports[`Entity denormalization denormalizes an entity 2`] = `
   },
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "alias": undefined,
-        "id": "1",
-        "name": "",
-        "type": "foo",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -112,21 +94,16 @@ exports[`Entity denormalization denormalizes deep entities 1`] = `
   },
   true,
   false,
-  {
-    "Food": {
-      "1": Food {
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-    "Menu": {
-      "1": Menu {
-        "food": Food {
-          "id": "1",
-        },
-        "id": "1",
-      },
+    {
+      "key": "Food",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -140,21 +117,16 @@ exports[`Entity denormalization denormalizes deep entities 2`] = `
   },
   true,
   false,
-  {
-    "Food": {
-      "1": Food {
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-    "Menu": {
-      "1": Menu {
-        "food": Food {
-          "id": "1",
-        },
-        "id": "1",
-      },
+    {
+      "key": "Food",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -168,16 +140,12 @@ exports[`Entity denormalization denormalizes deep entities 3`] = `
   },
   true,
   false,
-  {
-    "Menu": {
-      "2": Menu {
-        "food": Food {
-          "id": undefined,
-        },
-        "id": "2",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "2",
     },
-  },
+  ],
 ]
 `;
 
@@ -191,16 +159,12 @@ exports[`Entity denormalization denormalizes deep entities 4`] = `
   },
   false,
   false,
-  {
-    "Menu": {
-      "2": Menu {
-        "food": Food {
-          "id": undefined,
-        },
-        "id": "2",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "2",
     },
-  },
+  ],
 ]
 `;
 
@@ -214,21 +178,16 @@ exports[`Entity denormalization denormalizes deep entities with records 1`] = `
   },
   true,
   false,
-  {
-    "Food": {
-      "1": Food {
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-    "Menu": {
-      "1": Menu {
-        "food": Food {
-          "id": "1",
-        },
-        "id": "1",
-      },
+    {
+      "key": "Food",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -242,21 +201,16 @@ exports[`Entity denormalization denormalizes deep entities with records 2`] = `
   },
   true,
   false,
-  {
-    "Food": {
-      "1": Food {
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-    "Menu": {
-      "1": Menu {
-        "food": Food {
-          "id": "1",
-        },
-        "id": "1",
-      },
+    {
+      "key": "Food",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -268,14 +222,12 @@ exports[`Entity denormalization denormalizes deep entities with records 3`] = `
   },
   true,
   false,
-  {
-    "Menu": {
-      "2": Menu {
-        "food": null,
-        "id": "2",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "2",
     },
-  },
+  ],
 ]
 `;
 
@@ -287,14 +239,12 @@ exports[`Entity denormalization denormalizes deep entities with records 4`] = `
   },
   true,
   false,
-  {
-    "Menu": {
-      "2": Menu {
-        "food": null,
-        "id": "2",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "2",
     },
-  },
+  ],
 ]
 `;
 
@@ -320,42 +270,20 @@ exports[`Entity denormalization denormalizes recursive dependencies 1`] = `
   },
   true,
   false,
-  {
-    "Report": {
-      "123": Report {
-        "draftedBy": User {
-          "id": "456",
-          "reports": [
-            [Circular],
-          ],
-          "role": "manager",
-        },
-        "id": "123",
-        "publishedBy": User {
-          "id": "456",
-          "reports": [
-            [Circular],
-          ],
-          "role": "manager",
-        },
-        "title": "Weekly report",
-      },
+  [
+    {
+      "key": "Report",
+      "pk": "123",
     },
-    "User": {
-      "456": User {
-        "id": "456",
-        "reports": [
-          Report {
-            "draftedBy": [Circular],
-            "id": "123",
-            "publishedBy": [Circular],
-            "title": "Weekly report",
-          },
-        ],
-        "role": "manager",
-      },
+    {
+      "key": "User",
+      "pk": "456",
     },
-  },
+    {
+      "key": "User",
+      "pk": "456",
+    },
+  ],
 ]
 `;
 
@@ -391,52 +319,20 @@ exports[`Entity denormalization denormalizes recursive dependencies 2`] = `
   },
   true,
   false,
-  {
-    "Report": {
-      "123": Report {
-        "draftedBy": User {
-          "id": "456",
-          "reports": Immutable.List [
-            Immutable.Map {
-              "id": "123",
-              "title": "Weekly report",
-              "draftedBy": "456",
-              "publishedBy": "456",
-            },
-          ],
-          "role": "manager",
-        },
-        "id": "123",
-        "publishedBy": User {
-          "id": "456",
-          "reports": Immutable.List [
-            Immutable.Map {
-              "id": "123",
-              "title": "Weekly report",
-              "draftedBy": "456",
-              "publishedBy": "456",
-            },
-          ],
-          "role": "manager",
-        },
-        "title": "Weekly report",
-      },
+  [
+    {
+      "key": "Report",
+      "pk": "123",
     },
-    "User": {
-      "456": User {
-        "id": "456",
-        "reports": Immutable.List [
-          Immutable.Map {
-            "id": "123",
-            "title": "Weekly report",
-            "draftedBy": "456",
-            "publishedBy": "456",
-          },
-        ],
-        "role": "manager",
-      },
+    {
+      "key": "User",
+      "pk": "456",
     },
-  },
+    {
+      "key": "User",
+      "pk": "456",
+    },
+  ],
 ]
 `;
 
@@ -456,42 +352,16 @@ exports[`Entity denormalization denormalizes recursive dependencies 3`] = `
   },
   true,
   false,
-  {
-    "Report": {
-      "123": Report {
-        "draftedBy": User {
-          "id": "456",
-          "reports": [
-            [Circular],
-          ],
-          "role": "manager",
-        },
-        "id": "123",
-        "publishedBy": User {
-          "id": "456",
-          "reports": [
-            [Circular],
-          ],
-          "role": "manager",
-        },
-        "title": "Weekly report",
-      },
+  [
+    {
+      "key": "User",
+      "pk": "456",
     },
-    "User": {
-      "456": User {
-        "id": "456",
-        "reports": [
-          Report {
-            "draftedBy": [Circular],
-            "id": "123",
-            "publishedBy": [Circular],
-            "title": "Weekly report",
-          },
-        ],
-        "role": "manager",
-      },
+    {
+      "key": "Report",
+      "pk": "123",
     },
-  },
+  ],
 ]
 `;
 
@@ -523,54 +393,16 @@ exports[`Entity denormalization denormalizes recursive dependencies 4`] = `
   },
   true,
   false,
-  {
-    "Report": {
-      "123": Report {
-        "draftedBy": Immutable.Map {
-          "id": "456",
-          "role": "manager",
-          "reports": Immutable.List [
-            "123",
-          ],
-        },
-        "id": "123",
-        "publishedBy": Immutable.Map {
-          "id": "456",
-          "role": "manager",
-          "reports": Immutable.List [
-            "123",
-          ],
-        },
-        "title": "Weekly report",
-      },
+  [
+    {
+      "key": "User",
+      "pk": "456",
     },
-    "User": {
-      "456": User {
-        "id": "456",
-        "reports": Immutable.List [
-          Report {
-            "draftedBy": Immutable.Map {
-              "id": "456",
-              "role": "manager",
-              "reports": Immutable.List [
-                "123",
-              ],
-            },
-            "id": "123",
-            "publishedBy": Immutable.Map {
-              "id": "456",
-              "role": "manager",
-              "reports": Immutable.List [
-                "123",
-              ],
-            },
-            "title": "Weekly report",
-          },
-        ],
-        "role": "manager",
-      },
+    {
+      "key": "Report",
+      "pk": "123",
     },
-  },
+  ],
 ]
 `;
 
@@ -582,14 +414,12 @@ exports[`Entity denormalization denormalizes to undefined for deleted data 1`] =
   },
   true,
   true,
-  {
-    "Menu": {
-      "1": Menu {
-        "food": undefined,
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -601,14 +431,12 @@ exports[`Entity denormalization denormalizes to undefined for deleted data 2`] =
   },
   true,
   true,
-  {
-    "Menu": {
-      "1": Menu {
-        "food": undefined,
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -617,7 +445,7 @@ exports[`Entity denormalization denormalizes to undefined for deleted data 3`] =
   undefined,
   true,
   true,
-  {},
+  [],
 ]
 `;
 
@@ -626,7 +454,7 @@ exports[`Entity denormalization denormalizes to undefined for deleted data 4`] =
   undefined,
   true,
   true,
-  {},
+  [],
 ]
 `;
 
@@ -638,14 +466,12 @@ exports[`Entity denormalization denormalizes to undefined for missing data 1`] =
   },
   true,
   false,
-  {
-    "Menu": {
-      "1": Menu {
-        "food": undefined,
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -657,14 +483,12 @@ exports[`Entity denormalization denormalizes to undefined for missing data 2`] =
   },
   false,
   false,
-  {
-    "Menu": {
-      "1": Menu {
-        "food": undefined,
-        "id": "1",
-      },
+  [
+    {
+      "key": "Menu",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -673,7 +497,7 @@ exports[`Entity denormalization denormalizes to undefined for missing data 3`] =
   undefined,
   false,
   false,
-  {},
+  [],
 ]
 `;
 
@@ -682,7 +506,7 @@ exports[`Entity denormalization denormalizes to undefined for missing data 4`] =
   undefined,
   false,
   false,
-  {},
+  [],
 ]
 `;
 

--- a/packages/legacy/src/resource/__tests__/__snapshots__/normalizr.test.js.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/normalizr.test.js.snap
@@ -37,14 +37,12 @@ exports[`denormalize denormalizes ignoring deleted entities in arrays 1`] = `
   ],
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "id": "1",
-        "type": "foo",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -60,14 +58,12 @@ exports[`denormalize denormalizes ignoring deleted entities in arrays 2`] = `
   },
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "id": "1",
-        "type": "foo",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -81,14 +77,12 @@ exports[`denormalize denormalizes ignoring unfound entities in arrays 1`] = `
   ],
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "id": "1",
-        "type": "foo",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -104,14 +98,12 @@ exports[`denormalize denormalizes ignoring unfound entities in arrays 2`] = `
   },
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "id": "1",
-        "type": "foo",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 
@@ -138,49 +130,24 @@ exports[`denormalize denormalizes nested entities 1`] = `
   },
   true,
   false,
-  {
-    "Article": {
-      "123": Article {
-        "author": User {
-          "id": "8472",
-          "name": "Paul",
-        },
-        "body": "This article is great.",
-        "comments": [
-          Comment {
-            "comment": "I like it!",
-            "id": "comment-123-4738",
-            "user": User {
-              "id": "10293",
-              "name": "Jane",
-            },
-          },
-        ],
-        "id": "123",
-        "title": "A Great Article",
-      },
+  [
+    {
+      "key": "Article",
+      "pk": "123",
     },
-    "Comment": {
-      "comment-123-4738": Comment {
-        "comment": "I like it!",
-        "id": "comment-123-4738",
-        "user": User {
-          "id": "10293",
-          "name": "Jane",
-        },
-      },
+    {
+      "key": "User",
+      "pk": "8472",
     },
-    "User": {
-      "10293": User {
-        "id": "10293",
-        "name": "Jane",
-      },
-      "8472": User {
-        "id": "8472",
-        "name": "Paul",
-      },
+    {
+      "key": "Comment",
+      "pk": "comment-123-4738",
     },
-  },
+    {
+      "key": "User",
+      "pk": "10293",
+    },
+  ],
 ]
 `;
 
@@ -212,18 +179,16 @@ exports[`denormalize denormalizes schema with extra members 1`] = `
   },
   true,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "id": "1",
-        "type": "foo",
-      },
-      "2": Tacos {
-        "id": "2",
-        "type": "bar",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+    {
+      "key": "Tacos",
+      "pk": "2",
+    },
+  ],
 ]
 `;
 
@@ -243,18 +208,16 @@ exports[`denormalize denormalizes schema with extra members but not set 1`] = `
   },
   false,
   false,
-  {
-    "Tacos": {
-      "1": Tacos {
-        "id": "1",
-        "type": "foo",
-      },
-      "2": Tacos {
-        "id": "2",
-        "type": "bar",
-      },
+  [
+    {
+      "key": "Tacos",
+      "pk": "1",
     },
-  },
+    {
+      "key": "Tacos",
+      "pk": "2",
+    },
+  ],
 ]
 `;
 
@@ -276,27 +239,20 @@ exports[`denormalize denormalizes with function as pk() 1`] = `
   ],
   true,
   false,
-  {
-    "Guest": {
-      "guest-2-1": Guest {
-        "guestId": 1,
-      },
+  [
+    {
+      "key": "Patron",
+      "pk": "1",
     },
-    "Patron": {
-      "1": Patron {
-        "guest": null,
-        "id": "1",
-        "name": "Esther",
-      },
-      "2": Patron {
-        "guest": Guest {
-          "guestId": 1,
-        },
-        "id": "2",
-        "name": "Tom",
-      },
+    {
+      "key": "Patron",
+      "pk": "2",
     },
-  },
+    {
+      "key": "Guest",
+      "pk": "guest-2-1",
+    },
+  ],
 ]
 `;
 
@@ -307,7 +263,7 @@ exports[`denormalize denormalizes without entities fills undefined 1`] = `
   },
   false,
   false,
-  {},
+  [],
 ]
 `;
 
@@ -318,7 +274,7 @@ exports[`denormalize denormalizes without entities fills undefined 2`] = `
   },
   false,
   false,
-  {},
+  [],
 ]
 `;
 
@@ -339,30 +295,16 @@ exports[`denormalize set to undefined if schema key is not in entities 1`] = `
   },
   true,
   false,
-  {
-    "Article": {
-      "123": Article {
-        "author": undefined,
-        "body": "",
-        "comments": [
-          Comment {
-            "comment": "",
-            "id": "1",
-            "user": undefined,
-          },
-        ],
-        "id": "123",
-        "title": "",
-      },
+  [
+    {
+      "key": "Article",
+      "pk": "123",
     },
-    "Comment": {
-      "1": Comment {
-        "comment": "",
-        "id": "1",
-        "user": undefined,
-      },
+    {
+      "key": "Comment",
+      "pk": "1",
     },
-  },
+  ],
 ]
 `;
 

--- a/packages/legacy/src/resource/__tests__/normalizr.test.js
+++ b/packages/legacy/src/resource/__tests__/normalizr.test.js
@@ -358,7 +358,7 @@ describe('normalize', () => {
 describe('denormalize', () => {
   test('passthrough with undefined schema', () => {
     const input = {};
-    expect(denormalize(input)).toStrictEqual([input, true, false, {}]);
+    expect(denormalize(input)).toStrictEqual([input, true, false, []]);
   });
 
   test('returns the input if undefined', () => {
@@ -366,12 +366,12 @@ describe('denormalize', () => {
       undefined,
       false,
       false,
-      {},
+      [],
     ]);
   });
 
   test('returns the input if string', () => {
-    expect(denormalize('bob', '', {})).toEqual(['bob', true, false, {}]);
+    expect(denormalize('bob', '', {})).toEqual(['bob', true, false, []]);
   });
 
   test('denormalizes entities', () => {
@@ -389,7 +389,7 @@ describe('denormalize', () => {
     expect(
       denormalize(fromJS({ data: '1' }), { data: Tacos }, {}),
     ).toMatchSnapshot();
-    expect(denormalize('1', Tacos, {})).toEqual([undefined, false, false, {}]);
+    expect(denormalize('1', Tacos, {})).toEqual([undefined, false, false, []]);
   });
 
   test('denormalizes ignoring unfound entities in arrays', () => {

--- a/packages/normalizr/src/WeakEntityMap.ts
+++ b/packages/normalizr/src/WeakEntityMap.ts
@@ -1,4 +1,5 @@
 import { isImmutable } from './schemas/ImmutableUtils.js';
+import { Path } from './types.js';
 
 /** Maps entity dependencies to a value (usually their denormalized form)
  *
@@ -10,14 +11,14 @@ export default class WeakEntityMap<K extends object, V> {
 
   get(entity: K, getEntity: GetEntity<K | symbol>) {
     let curLink = this.next.get(entity);
-    if (!curLink) return;
+    if (!curLink) return EMPTY;
     while (curLink.nextPath) {
       const nextEntity = getEntity(curLink.nextPath);
       curLink = curLink.next.get(nextEntity as any);
-      if (!curLink) return;
+      if (!curLink) return EMPTY;
     }
     // curLink exists, but has no path - so must have a value
-    return curLink.value;
+    return [curLink.value, curLink.journey] as [V, Path[]];
   }
 
   set(dependencies: Dep<K>[], value: V) {
@@ -35,8 +36,12 @@ export default class WeakEntityMap<K extends object, V> {
     // in case there used to be more
     delete curLink.nextPath;
     curLink.value = value;
+    // we could recompute this on get, but it would have a cost and we optimize for `get`
+    curLink.journey = depToPaths(dependencies);
   }
 }
+
+const EMPTY = [undefined, undefined] as const;
 
 export function getEntities<K extends object>(state: State<K>): GetEntity<K> {
   const entityIsImmutable = isImmutable(state);
@@ -48,22 +53,22 @@ export function getEntities<K extends object>(state: State<K>): GetEntity<K> {
   }
 }
 
+export function depToPaths(dependencies: Dep[]) {
+  return dependencies.map(dep => dep.path);
+}
+
 export type GetEntity<K = object | symbol> = (lookup: Path) => K;
 
 /** Link in a chain */
 class Link<K extends object, V> {
   next = new WeakMap<K, Link<K, V>>();
   declare value?: V;
+  declare journey?: Path[];
   declare nextPath?: Path;
 }
 
 class KeySize extends Error {
   message = 'Keys must include at least one member';
-}
-
-export interface Path {
-  key: string;
-  pk: string;
 }
 
 export interface Dep<K = object> {

--- a/packages/normalizr/src/__tests__/WeakEntityMap.test.ts
+++ b/packages/normalizr/src/__tests__/WeakEntityMap.test.ts
@@ -29,10 +29,10 @@ describe('WeakEntityMap', () => {
     const deps = [depA];
     wem.set(deps, 'myvalue');
 
-    expect(wem.get(a, getEntity)).toBe('myvalue');
+    expect(wem.get(a, getEntity)[0]).toBe('myvalue');
 
-    expect(wem.get(b, getEntity)).toBeUndefined();
-    expect(wem.get(c, getEntity)).toBeUndefined();
+    expect(wem.get(b, getEntity)[0]).toBeUndefined();
+    expect(wem.get(c, getEntity)[0]).toBeUndefined();
   });
 
   it('should set multiple on same path', () => {
@@ -52,7 +52,7 @@ describe('WeakEntityMap', () => {
     for (const attempt of attempts) {
       wem.set(attempt.key, attempt.value);
     }
-    expect(wem.get(a, getEntity)).toBe('third');
+    expect(wem.get(a, getEntity)[0]).toBe('third');
   });
 
   it('should set multiple on distinct paths', () => {
@@ -80,11 +80,11 @@ describe('WeakEntityMap', () => {
     for (const attempt of attempts) {
       wem.set(attempt.key, attempt.value);
     }
-    expect(wem.get(a, getEntity)).toBe('fourth');
-    expect(wem.get(b, getEntity)).toBe('second');
-    expect(wem.get(c, getEntity)).toBe('fifth');
+    expect(wem.get(a, getEntity)[0]).toBe('fourth');
+    expect(wem.get(b, getEntity)[0]).toBe('second');
+    expect(wem.get(c, getEntity)[0]).toBe('fifth');
 
-    expect(wem.get({}, getEntity)).toBeUndefined();
+    expect(wem.get({}, getEntity)[0]).toBeUndefined();
   });
 
   it('considers empty key list invalid', () => {
@@ -93,6 +93,6 @@ describe('WeakEntityMap', () => {
       `"Keys must include at least one member"`,
     );
 
-    expect(wem.get([], getEntity)).toBeUndefined();
+    expect(wem.get([], getEntity)[0]).toBeUndefined();
   });
 });

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -87,6 +87,7 @@ const unvisitEntity = (
     if (cacheValue) {
       localCacheKey[pk] = cacheValue.value[0];
       // TODO: can we store the cache values instead of tracking *all* their sources?
+      // this is only used for setting results cache correctly. if we got this far we will def need to set as we would have already tried getting it
       dependencies.push(...cacheValue.dependencies);
       return cacheValue.value;
     }
@@ -228,8 +229,12 @@ const getUnvisit = (
       Object(input) === input &&
       Object(schema) === schema &&
       getResultCache(resultCache, schema);
-    if (!resultSchemaCache)
-      return [...unvisit(input, schema), depToPaths(dependencies)];
+    if (!resultSchemaCache) {
+      const ret = unvisit(input, schema);
+      // this is faster than spread
+      // https://www.measurethat.net/Benchmarks/Show/23636/0/spread-with-tuples
+      return [ret[0], ret[1], ret[2], depToPaths(dependencies)];
+    }
 
     let [ret, entityPaths] = resultSchemaCache.get(input, getEntity);
 
@@ -242,7 +247,7 @@ const getUnvisit = (
       resultSchemaCache.set(dependencies, ret);
     }
 
-    return [...ret, entityPaths as Path[]];
+    return [ret[0], ret[1], ret[2], entityPaths as Path[]];
   };
 };
 

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -16,6 +16,7 @@ export type {
   NormalizedSchema,
   DenormalizeReturnType,
   DenormalizeCache,
+  Path,
 } from './types.js';
 export * from './endpoint/types.js';
 export * from './interface.js';

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -7,6 +7,11 @@ import type {
 } from './interface.js';
 import type WeakEntityMap from './WeakEntityMap.js';
 
+export interface Path {
+  key: string;
+  pk: string;
+}
+
 export type AbstractInstanceType<T> = T extends { prototype: infer U }
   ? U
   : never;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

The improved caching in #2444, caused localEntities to not be filled out when the result cache was used. This was previously used to determine what entities should be used to determine expiresAt in the case that an endpoint doesn't have its own meta (its results were inferred).

We should ensure this is computed properly even in cached case - added a test to reflect this condition.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since we're already computing a path list for dependencies, we can simply store that in our cache and use that to do entityMeta lookups, rather than returning the full local cache list.