### PR TITLE
enhance: Do not key on schema in result cache

### DIFF
--- a/examples/benchmark/normalizr.js
+++ b/examples/benchmark/normalizr.js
@@ -3,6 +3,7 @@ import {
   normalize,
   denormalize,
   inferResults,
+  WeakEntityMap,
 } from './dist/index.js';
 
 import data from './data.json' assert { type: 'json' };
@@ -32,7 +33,7 @@ const queryInfer = inferResults(
 export default function addNormlizrSuite(suite) {
   let denormCache = {
     entities: {},
-    results: { '/fake': new WeakMap(), '/fakeQuery': new WeakMap() },
+    results: { '/fake': new WeakEntityMap(), '/fakeQuery': new WeakEntityMap() },
   };
   // prime the cache
   denormalize(

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -385,7 +385,7 @@ export default class Controller<
     }
 
     if (isActive && !this.globalCache.results[key])
-      this.globalCache.results[key] = new WeakMap();
+      this.globalCache.results[key] = new WeakEntityMap();
 
     // second argument is false if any entities are missing
     // eslint-disable-next-line prefer-const

--- a/packages/endpoint/src/schemas/__tests__/All.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/All.test.ts
@@ -1,5 +1,5 @@
 // eslint-env jest
-import { inferResults, normalize } from '@rest-hooks/normalizr';
+import { inferResults, normalize, WeakEntityMap } from '@rest-hooks/normalizr';
 import { IDEntity } from '__tests__/new';
 import { fromJS } from 'immutable';
 
@@ -146,7 +146,7 @@ describe.each([
       ).toMatchSnapshot();
     });
 
-    test('denormalizes nested in object with primitive', () => {
+    test.only('denormalizes nested in object with primitive', () => {
       class Cat extends IDEntity {}
       const catSchema = { results: new schema.All(Cat), nextPage: '' };
       const entities = {
@@ -205,7 +205,7 @@ describe.each([
       };
       const input = createInput(inferResults(catSchema, [], {}, entities));
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
       const [value, found] = denormalize(
         input,
         catSchema,

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -1,5 +1,5 @@
 // eslint-env jest
-import { normalize } from '@rest-hooks/normalizr';
+import { normalize, WeakEntityMap } from '@rest-hooks/normalizr';
 import { DELETED } from '@rest-hooks/normalizr';
 import { IDEntity } from '__tests__/new';
 import { fromJS, Record } from 'immutable';
@@ -746,7 +746,7 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const [first] = denormalize('1', Menu, entities, entityCache, resultCache);
     const [second] = denormalize('1', Menu, entities, entityCache, resultCache);
@@ -999,7 +999,7 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
     const entityCache: any = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const [denormalizedReport] = denormalize(
       '123',
@@ -1063,7 +1063,7 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
     const entityCache: any = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = { report: '123', comment: '999' };
     const schema = {

--- a/packages/endpoint/src/schemas/__tests__/denormalize.ts
+++ b/packages/endpoint/src/schemas/__tests__/denormalize.ts
@@ -12,7 +12,7 @@ export const denormalizeSimple = <S extends Schema>(
   schema: S | undefined,
   entities: any,
   entityCache: DenormalizeCache['entities'] = {},
-  resultCache: DenormalizeCache['results'][string] = new WeakMap(),
+  resultCache: DenormalizeCache['results'][string] = new WeakEntityMap(),
 ):
   | [denormalized: Denormalize<S>, found: true, deleted: false]
   | [denormalized: DenormalizeNullable<S>, found: boolean, deleted: true]

--- a/packages/legacy/src/resource/__tests__/Entity.test.ts
+++ b/packages/legacy/src/resource/__tests__/Entity.test.ts
@@ -5,6 +5,7 @@ import {
   denormalize,
   DELETED,
   AbstractInstanceType,
+  WeakEntityMap,
 } from '@rest-hooks/normalizr';
 import { fromJS, Record } from 'immutable';
 
@@ -684,7 +685,7 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const [first] = denormalize('1', Menu, entities, entityCache, resultCache);
     const [second] = denormalize('1', Menu, entities, entityCache, resultCache);
@@ -841,7 +842,7 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
     const entityCache: any = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const [denormalizedReport] = denormalize(
       '123',

--- a/packages/legacy/src/resource/__tests__/normalizr.test.js
+++ b/packages/legacy/src/resource/__tests__/normalizr.test.js
@@ -1,5 +1,10 @@
 // eslint-env jest
-import { denormalize, normalize, DELETED } from '@rest-hooks/normalizr';
+import {
+  denormalize,
+  normalize,
+  DELETED,
+  WeakEntityMap,
+} from '@rest-hooks/normalizr';
 import { fromJS } from 'immutable';
 
 import Entity from '../Entity';
@@ -632,7 +637,7 @@ describe('denormalize', () => {
 describe('denormalize with global cache', () => {
   test('maintains referential equality with same results', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
     const entities = {
       Tacos: {
         1: { id: '1', type: 'foo' },
@@ -726,7 +731,7 @@ describe('denormalize with global cache', () => {
 
     test('maintains referential equality with nested entities', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const result = { data: '123' };
       const schema = { data: Article };
@@ -764,7 +769,7 @@ describe('denormalize with global cache', () => {
 
     test('entity equality changes', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const result = { data: '123' };
       const [first] = denormalize(
@@ -800,7 +805,7 @@ describe('denormalize with global cache', () => {
 
   test('denormalizes plain object with no entities', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = {
       firstThing: { five: 5, seven: 42 },
@@ -827,7 +832,7 @@ describe('denormalize with global cache', () => {
 
   test('passthrough for null schema and an object input', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = {
       firstThing: { five: 5, seven: 42 },
@@ -847,7 +852,7 @@ describe('denormalize with global cache', () => {
 
   test('passthrough for null schema and an number input', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = 5;
     const [denorm, found, deleted] = denormalize(
@@ -864,7 +869,7 @@ describe('denormalize with global cache', () => {
 
   test('passthrough for undefined schema and an object input', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = {
       firstThing: { five: 5, seven: 42 },
@@ -903,7 +908,7 @@ describe('denormalize with global cache', () => {
 
     test('handles null at top level', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const [denorm, found, deleted] = denormalize(
         null,
@@ -919,7 +924,7 @@ describe('denormalize with global cache', () => {
 
     test('handles undefined at top level', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const [denorm, found, deleted] = denormalize(
         undefined,
@@ -935,7 +940,7 @@ describe('denormalize with global cache', () => {
 
     test('handles null in nested place', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const input = {
         data: { id: '5', title: 'hehe', author: null, comments: [] },

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -713,7 +713,7 @@ describe('denormalize', () => {
 describe('denormalize with global cache', () => {
   test('maintains referential equality with same results', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
     const entities = {
       Tacos: {
         1: { id: '1', type: 'foo' },
@@ -807,7 +807,7 @@ describe('denormalize with global cache', () => {
 
     test('maintains referential equality with nested entities', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const result = { data: '123' };
       const schema = { data: Article };
@@ -845,7 +845,7 @@ describe('denormalize with global cache', () => {
 
     test('maintains responds to entity updates for distinct top-level results', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const result1 = { data: '123' };
       const result2 = { results: ['123'] };
@@ -914,7 +914,10 @@ describe('denormalize with global cache', () => {
         static key = 'Article';
       }
       const entityCache = {};
-      const resultCache = new WeakMap();
+      // we have different result caches because they are keyed based on the endpoint
+      const resultCacheA = new WeakEntityMap();
+      const resultCacheB = new WeakEntityMap();
+      const resultCacheC = new WeakEntityMap();
 
       const result = { data: '123' };
       const firstSchema = { data: ArticleSummary };
@@ -924,14 +927,14 @@ describe('denormalize with global cache', () => {
         firstSchema,
         entities,
         entityCache,
-        resultCache,
+        resultCacheA,
       )[0];
       const second = denormalize(
         result,
         secondSchema,
         entities,
         entityCache,
-        resultCache,
+        resultCacheB,
       )[0];
       // show distinction between how they are denormalized
       expect(first.data.author).toMatchInlineSnapshot(`"8472"`);
@@ -947,7 +950,7 @@ describe('denormalize with global cache', () => {
         firstSchema,
         entities,
         entityCache,
-        resultCache,
+        resultCacheA,
       )[0];
       expect(first).toBe(firstWithoutChange);
 
@@ -956,7 +959,7 @@ describe('denormalize with global cache', () => {
         Article,
         entities,
         entityCache,
-        resultCache,
+        resultCacheC,
       )[0];
       expect(third).toBe(second.data);
 
@@ -976,7 +979,7 @@ describe('denormalize with global cache', () => {
         firstSchema,
         nextState,
         entityCache,
-        resultCache,
+        resultCacheA,
       )[0];
       expect(firstChanged).not.toBe(first);
       const secondChanged = denormalize(
@@ -984,7 +987,7 @@ describe('denormalize with global cache', () => {
         secondSchema,
         nextState,
         entityCache,
-        resultCache,
+        resultCacheB,
       )[0];
       expect(secondChanged).not.toBe(second);
       expect(firstChanged.data.author).toMatchInlineSnapshot(`"8472"`);
@@ -998,7 +1001,7 @@ describe('denormalize with global cache', () => {
 
     test('entity equality changes', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const result = { data: '123' };
       const [first] = denormalize(
@@ -1033,7 +1036,7 @@ describe('denormalize with global cache', () => {
 
     test('nested entity equality changes', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const result = { data: '123' };
       const [first] = denormalize(
@@ -1072,7 +1075,7 @@ describe('denormalize with global cache', () => {
 
   test('denormalizes plain object with no entities', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = {
       firstThing: { five: 5, seven: 42 },
@@ -1099,7 +1102,7 @@ describe('denormalize with global cache', () => {
 
   test('passthrough for null schema and an object input', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = {
       firstThing: { five: 5, seven: 42 },
@@ -1119,7 +1122,7 @@ describe('denormalize with global cache', () => {
 
   test('passthrough for null schema and an number input', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = 5;
     const [denorm, found, deleted] = denormalize(
@@ -1136,7 +1139,7 @@ describe('denormalize with global cache', () => {
 
   test('passthrough for undefined schema and an object input', () => {
     const entityCache = {};
-    const resultCache = new WeakMap();
+    const resultCache = new WeakEntityMap();
 
     const input = {
       firstThing: { five: 5, seven: 42 },
@@ -1175,7 +1178,7 @@ describe('denormalize with global cache', () => {
 
     test('handles null at top level', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const [denorm, found, deleted] = denormalize(
         null,
@@ -1191,7 +1194,7 @@ describe('denormalize with global cache', () => {
 
     test('handles undefined at top level', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const [denorm, found, deleted] = denormalize(
         undefined,
@@ -1207,7 +1210,7 @@ describe('denormalize with global cache', () => {
 
     test('handles null in nested place', () => {
       const entityCache = {};
-      const resultCache = new WeakMap();
+      const resultCache = new WeakEntityMap();
 
       const input = {
         data: { id: '5', title: 'hehe', author: null, comments: [] },

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -55,10 +55,7 @@ export interface DenormalizeCache {
     };
   };
   results: {
-    [key: string]: WeakMap<
-      Exclude<Schema, null | string>,
-      WeakEntityMap<object, any>
-    >;
+    [key: string]: WeakEntityMap<object, any>;
   };
 }
 

--- a/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
@@ -106,7 +106,7 @@ interface DenormalizeCache {
         };
     };
     results: {
-        [key: string]: WeakMap<Exclude<Schema, null | string>, WeakEntityMap<object, any>>;
+        [key: string]: WeakEntityMap<object, any>;
     };
 }
 type DenormalizeNullableNestedSchema<S extends NestedSchemaClass> = keyof S['schema'] extends never ? S['prototype'] : string extends keyof S['schema'] ? S['prototype'] : S['prototype'];
@@ -809,7 +809,7 @@ declare class Controller<D extends GenericDispatch = CompatibleDispatch> {
      * Gets the (globally referentially stable) response for a given endpoint/args pair from state given.
      * @see https://resthooks.io/docs/api/Controller#getResponse
      */
-    getResponse: <E extends Pick<EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined>, "schema" | "key" | "invalidIfStale">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => {
+    getResponse: <E extends Pick<EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined>, "key" | "schema" | "invalidIfStale">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => {
         data: DenormalizeNullable<E["schema"]>;
         expiryStatus: ExpiryStatus;
         expiresAt: number;

--- a/website/src/components/Playground/editor-types/@rest-hooks/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/normalizr.d.ts
@@ -103,7 +103,7 @@ interface DenormalizeCache {
         };
     };
     results: {
-        [key: string]: WeakMap<Exclude<Schema, null | string>, WeakEntityMap<object, any>>;
+        [key: string]: WeakEntityMap<object, any>;
     };
 }
 type DenormalizeNullableNestedSchema<S extends NestedSchemaClass> = keyof S['schema'] extends never ? S['prototype'] : string extends keyof S['schema'] ? S['prototype'] : S['prototype'];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Since we already key on the endpoint in result cache, it is unnecessary to key on schema as well as it is assumed schema will not change.

This was previously reasoned about incorrectly as the tests were in normalizr rather than core. `core` is where the endpoint key splitting is, so I wasn't thinking about that already existing.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Remove complexities around WeakMap for schemas; use WeakEntityMap as resultCache argument to denormalize