### PR TITLE
feat: Add mixin schema.Entity()

### DIFF
--- a/docs/core/getting-started/endpoint.md
+++ b/docs/core/getting-started/endpoint.md
@@ -17,7 +17,7 @@ import ProtocolTabs from '@site/src/components/ProtocolTabs';
 import PkgInstall from '@site/src/components/PkgInstall';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 
-[Endpoints](/rest/api/RestEndpoint) are the [_methods_](<https://en.wikipedia.org/wiki/Method_(computer_programming)>) of your data. [Schemas](../concepts/normalization.md) define the data model. [Resources](/rest/api/createResource) are
+[Endpoints](/rest/api/RestEndpoint) are the [_methods_](<https://en.wikipedia.org/wiki/Method_(computer_programming)>) of your data. [Entities](/rest/api/Entity) are a type of [Schema](../concepts/normalization.md), which define the data model. [Resources](/rest/api/createResource) are
 a collection of `endpoints` around one `schema`.
 
 <Tabs

--- a/docs/graphql/api/schema.Entity.md
+++ b/docs/graphql/api/schema.Entity.md
@@ -1,0 +1,271 @@
+---
+title: schema.Entity
+---
+
+<head>
+  <title>schema.Entity - Entity mixin</title>
+  <meta name="docsearch:pagerank" content="10"/>
+</head>
+
+import HooksPlayground from '@site/src/components/HooksPlayground';
+import LanguageTabs from '@site/src/components/LanguageTabs';
+import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+
+If you already have classes for your data-types, `schema.Entity` mixin may be for you.
+
+<TypeScriptEditor>
+
+```typescript {10}
+import { schema } from '@rest-hooks/graphql';
+
+export class Article {
+  id = '';
+  title = '';
+  content = '';
+  tags: string[] = [];
+}
+
+export class ArticleEntity extends schema.Entity(Article) {}
+```
+
+</TypeScriptEditor>
+
+## Options
+
+The second argument to the mixin can be used to conveniently customize construction. If not specified the `Base`
+class' static members will be used. Alternatively, just like with [Entity](./Entity.md), you can always specify
+these as static members of the final class.
+
+<TypeScriptEditor>
+
+```typescript
+class User {
+  username = '';
+  createdAt = new Date(0);
+}
+class UserEntity extends schema.Entity(User, {
+  pk: 'username',
+  key: 'User',
+  schema: { createdAt: Date },
+}) {}
+```
+
+</TypeScriptEditor>
+
+### pk: string | (value, parent?, key?) => string | undefined = 'id'
+
+Specifies the [Entity.pk](./Entity.md#pk)
+
+A `string` indicates the field to use for pk.
+
+A `function` is used just like [Entity.pk](./Entity.md#pk), but the first argument (`value`) is `this`
+
+Defaults to 'id'; which means pk is a required option _unless_ the `Base` class has a serializable `id` member.
+
+<TypeScriptEditor>
+
+```typescript title="multi-column primary key"
+class Thread {
+  forum = '';
+  slug = '';
+  content = '';
+}
+class ThreadEntity extends schema.Entity(Thread, {
+  pk(value) {
+    return [value.forum, value.slug].join(',');
+  },
+}) {}
+```
+
+</TypeScriptEditor>
+
+### key: string
+
+Specifies the [Entity.key](./Entity.md#key)
+
+### schema: {[k:string]: Schema}
+
+Specifies the [Entity.schema](./Entity.md#schema)
+
+## Methods
+
+`schema.Entity` has the same methods as [Entity](./Entity.md) with an improved `mergeWithStore()` lifecycle.
+
+This method uses [shouldReorder()](#shouldReorder) to handle race conditions rather than [useIncoming()](#useIncoming),
+which is better able to handle [partial field entities](../guides/summary-list.md).
+
+Eventually `Entity` will also be converted to use this default implementation. You can prepare for this by copying
+the [mergeWithStore](#mergeWithStore) default implementation below.
+
+### static mergeWithStore(existingMeta, incomingMeta, existing, incoming): mergedValue {#mergeWithStore}
+
+```typescript
+static mergeWithStore(
+  existingMeta: {
+    date: number;
+    fetchedAt: number;
+  },
+  incomingMeta: { date: number; fetchedAt: number },
+  existing: any,
+  incoming: any,
+) {
+  const useIncoming = this.useIncoming(
+    existingMeta,
+    incomingMeta,
+    existing,
+    incoming,
+  );
+
+  if (useIncoming) {
+    // distinct types are not mergeable (like delete symbol), so just replace
+    if (typeof incoming !== typeof existing) {
+      return incoming;
+    } else {
+      return this.shouldReorder(
+        existingMeta,
+        incomingMeta,
+        existing,
+        incoming,
+      )
+        ? this.merge(incoming, existing)
+        : this.merge(existing, incoming);
+    }
+  } else {
+    return existing;
+  }
+}
+```
+
+`mergeWithStore()` is called during normalization when a processed entity is already found in the store.
+
+This calls [useIncoming()](#useIncoming), [shouldReorder()](#shouldOrder) and potentially [merge()](#merge)
+
+### static useIncoming(existingMeta, incomingMeta, existing, incoming): boolean {#useIncoming}
+
+```typescript
+static useIncoming(
+  existingMeta: { date: number; fetchedAt: number },
+  incomingMeta: { date: number; fetchedAt: number },
+  existing: any,
+  incoming: any,
+) {
+  return true;
+}
+```
+
+#### Preventing updates
+
+useIncoming can also be used to short-circuit an entity update.
+
+```typescript
+import deepEqual from 'deep-equal';
+
+class ArticleEntity extends schema.Entity(
+  class {
+    id = '';
+    title = '';
+    content = '';
+    published = false;
+  },
+) {
+  static useIncoming(
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return !deepEqual(incoming, existing);
+  }
+}
+```
+
+### static shouldReorder(existingMeta, incomingMeta, existing, incoming): boolean {#shouldReorder}
+
+```typescript
+static shouldReorder(
+  existingMeta: { date: number; fetchedAt: number },
+  incomingMeta: { date: number; fetchedAt: number },
+  existing: any,
+  incoming: any,
+) {
+  return incomingMeta.fetchedAt < existingMeta.fetchedAt;
+}
+```
+
+`true` return value will reorder incoming vs in-store entity argument order in merge. With
+the default merge, this will cause the fields of existing entities to override those of incoming,
+rather than the other way around.
+
+#### Example
+
+<TypeScriptEditor>
+
+```typescript
+class LatestPriceEntity extends schema.Entity(
+  class {
+    id = '';
+    updatedAt = 0;
+    price = '0.0';
+    symbol = '';
+  },
+) {
+  static shouldReorder(
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
+    existing: { updatedAt: number },
+    incoming: { updatedAt: number },
+  ) {
+    return incoming.updatedAt < existing.updatedAt;
+  }
+}
+```
+
+</TypeScriptEditor>
+
+### static merge(existing, incoming): mergedValue {#merge}
+
+```typescript
+static merge(existing: any, incoming: any) {
+  return {
+    ...existing,
+    ...incoming,
+  };
+}
+```
+
+Merge is used to handle cases when an incoming entity is already found. This is called directly
+when the same entity is found in one response. By default it is also called when [mergeWithStore()](#mergeWithStore)
+determines the incoming entity should be merged with an entity already persisted in the Rest Hooks store.
+
+## const vs class
+
+If you don't need to further customize the entity, you can use a `const` declaration instead
+of `extend` to another class.
+
+There is a subtle difference when referring to the `class token` in TypeScript - as
+`class` declarations will refer to the instance type; whereas `const tokens` refer to the value, so you
+must use `typeof`, but additionally typeof gives the class type, so you must layer `InstanceType`
+on top.
+
+<TypeScriptEditor>
+
+```typescript
+import { schema } from '@rest-hooks/graphql';
+
+export class Article {
+  id = '';
+  title = '';
+  content = '';
+  tags: string[] = [];
+}
+
+export class ArticleEntity extends schema.Entity(Article) {}
+export const ArticleEntity2 = schema.Entity(Article);
+
+const article: ArticleEntity = ArticleEntity.fromJS();
+const articleFails: ArticleEntity2 = ArticleEntity2.fromJS();
+const articleWorks: InstanceType<typeof ArticleEntity2> =
+  ArticleEntity2.fromJS();
+```
+
+</TypeScriptEditor>

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -21,7 +21,13 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 [RestEndpoint](/rest/api/RestEndpoint) are the _methods_ of your data. [Schemas](api/schema.md) define the data model. [Resources](./api/createResource.md) are
 a collection of `endpoints` around one `schema`.
 
-<LanguageTabs>
+<Tabs
+defaultValue="Class"
+values={[
+{ label: 'Class', value: 'Class' },
+{ label: 'Mixin', value: 'Mixin' },
+]}>
+<TabItem value="Class">
 
 <TypeScriptEditor>
 
@@ -57,7 +63,7 @@ export class Article extends Entity {
   static schema = {
     author: User,
     createdAt: Date,
-  }
+  };
 
   static key = 'Article';
 }
@@ -71,37 +77,54 @@ export const ArticleResource = createResource({
 
 </TypeScriptEditor>
 
+</TabItem>
+<TabItem value="Mixin">
 
-```js title="api/Article.js"
-import { Entity, createResource } from '@rest-hooks/rest';
+<TypeScriptEditor>
 
-export class Article extends Entity {
-  id = undefined;
+```typescript title="api/User" collapsed
+import { schema } from '@rest-hooks/rest';
+
+export class User {
+  id: number | undefined = undefined;
+  username = '';
+}
+export class UserEntity extends schema.Entity(User) {}
+```
+
+```typescript title="api/Article"
+import { schema, createResource } from '@rest-hooks/rest';
+import { UserEntity } from './User';
+
+export class Article {
+  id: number | undefined = undefined;
   title = '';
   content = '';
-  author = User.fromJS({});
-  tags = [];
+  author = UserEntity.fromJS({});
+  tags: string[] = [];
   createdAt = new Date(0);
-
-  pk() {
-    return this.id?.toString();
-  }
-
-  static schema = {
-    author: User,
-    createdAt: Date,
-  }
-
-  static key = 'Article';
 }
+
+export class ArticleEntity extends schema.Entity(Article, {
+  schema: {
+    author: UserEntity,
+    createdAt: Date,
+  },
+  key: 'Article',
+}) {}
+
 export const ArticleResource = createResource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
-  schema: Article,
+  schema: ArticleEntity,
 });
 ```
 
-</LanguageTabs>
+</TypeScriptEditor>
+
+</TabItem>
+
+</Tabs>
 
 [Entity](./api/Entity.md) is a kind of schema that [has a primary key (pk)](/docs/concepts/normalization). This is what allows us
 to [avoid state duplication](https://beta.reactjs.org/learn/choosing-the-state-structure#principles-for-structuring-state), which
@@ -114,7 +137,7 @@ TypeScript enforces the arguments specified with a prefixed colon like `:id` in 
 
 ```ts
 // GET http://test.com/article/5
-TodoResource.get({ id: 5 })
+TodoResource.get({ id: 5 });
 ```
 
 ## Bind the data with Suspense
@@ -186,9 +209,7 @@ export default function NewArticleForm() {
   const ctrl = useController();
   return (
     <Form
-      onSubmit={e =>
-        ctrl.fetch(ArticleResource.create, new FormData(e.target))
-      }
+      onSubmit={e => ctrl.fetch(ArticleResource.create, new FormData(e.target))}
     >
       <FormField name="title" />
       <FormField name="content" type="textarea" />
@@ -244,9 +265,7 @@ export default function ArticleWithDelete({ article }: { article: Article }) {
       <h2>{article.title}</h2>
       <div>{article.content}</div>
       <button
-        onClick={() =>
-          ctrl.fetch(ArticleResource.delete, { id: article.id })
-        }
+        onClick={() => ctrl.fetch(ArticleResource.delete, { id: article.id })}
       >
         Delete
       </button>
@@ -262,5 +281,5 @@ We use [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Form
 the example since it doesn't require any opinionated form state management solution.
 Feel free to use whichever one you prefer.
 
-[Mutations](/docs/getting-started/mutations) automatically updates *all* usages without the need for
+[Mutations](/docs/getting-started/mutations) automatically updates _all_ usages without the need for
 additional requests.

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -14,14 +14,14 @@ import { RestEndpoint } from '@rest-hooks/rest';
 <LanguageTabs>
 
 ```typescript
-import { Entity } from '@rest-hooks/endpoint';
+import { Entity } from '@rest-hooks/rest';
 
 export default class Article extends Entity {
-  readonly id: number | undefined = undefined;
-  readonly title: string = '';
-  readonly content: string = '';
-  readonly author: number | null = null;
-  readonly tags: string[] = [];
+  id: number | undefined = undefined;
+  title = '';
+  content = '';
+  author: number | null = null;
+  tags: string[] = [];
 
   pk() {
     return this.id?.toString();
@@ -32,7 +32,7 @@ export default class Article extends Entity {
 ```
 
 ```js
-import { Entity } from '@rest-hooks/endpoint';
+import { Entity } from '@rest-hooks/rest';
 
 export default class Article extends Entity {
   id = undefined;
@@ -65,6 +65,13 @@ Entities are bound to Endpoints using [createResource.schema](./createResource.m
 
 :::
 
+:::tip
+
+If you already have your classes defined, [schema.Entity](./schema.Entity.md) mixin can also be
+used to make Entities.
+
+:::
+
 ## Data lifecycle
 
 import Lifecycle from '../diagrams/\_entity_lifecycle.mdx';
@@ -72,17 +79,6 @@ import Lifecycle from '../diagrams/\_entity_lifecycle.mdx';
 <Lifecycle/>
 
 ## Methods
-
-### static fromJS(props): Entity {#fromJS}
-
-Factory method that copies props to a new instance. Use this instead of `new MyEntity()`
-
-### process(input, parent, key): processedEntity {#process}
-
-Run at the start of normalization for this entity. Return value is saved in store
-and sent to [pk()](#pk).
-
-**Defaults** to simply copying the response (`{...input}`)
 
 ### abstract pk: (parent?, key?): pk? {#pk}
 
@@ -154,6 +150,17 @@ class User extends Entity {
 }
 ```
 
+### static fromJS(props): Entity {#fromJS}
+
+Factory method that copies props to a new instance. Use this instead of `new MyEntity()`
+
+### process(input, parent, key): processedEntity {#process}
+
+Run at the start of normalization for this entity. Return value is saved in store
+and sent to [pk()](#pk).
+
+**Defaults** to simply copying the response (`{...input}`)
+
 ### static merge(existing, incoming): mergedValue {#merge}
 
 ```typescript
@@ -184,7 +191,7 @@ static mergeWithStore(
 
 This calls [useIncoming()](#useIncoming) and potentially [merge()](#merge)
 
-### static useIncoming(existingMeta, incomingMeta, existing, incoming): mergedValue {#useincoming}
+### static useIncoming(existingMeta, incomingMeta, existing, incoming): boolean {#useincoming}
 
 ```typescript
 static useIncoming(
@@ -294,6 +301,8 @@ By **default** uses the first argument to lookup in [pk()](#pk) and [indexes](#i
 This determines expiry time when entity is part of a result that is inferred.
 
 Overriding can be used to change TTL policy specifically for inferred responses.
+
+## Members
 
 ### static indexes?: (keyof this)[] {#indexes}
 

--- a/docs/rest/api/schema.Entity.md
+++ b/docs/rest/api/schema.Entity.md
@@ -1,0 +1,272 @@
+---
+title: schema.Entity
+---
+
+<head>
+  <title>schema.Entity - Entity mixin</title>
+  <meta name="docsearch:pagerank" content="10"/>
+</head>
+
+import HooksPlayground from '@site/src/components/HooksPlayground';
+import LanguageTabs from '@site/src/components/LanguageTabs';
+import { RestEndpoint } from '@rest-hooks/rest';
+import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+
+If you already have classes for your data-types, `schema.Entity` mixin may be for you.
+
+<TypeScriptEditor>
+
+```typescript {10}
+import { schema } from '@rest-hooks/rest';
+
+export class Article {
+  id = '';
+  title = '';
+  content = '';
+  tags: string[] = [];
+}
+
+export class ArticleEntity extends schema.Entity(Article) {}
+```
+
+</TypeScriptEditor>
+
+## Options
+
+The second argument to the mixin can be used to conveniently customize construction. If not specified the `Base`
+class' static members will be used. Alternatively, just like with [Entity](./Entity.md), you can always specify
+these as static members of the final class.
+
+<TypeScriptEditor>
+
+```typescript
+class User {
+  username = '';
+  createdAt = new Date(0);
+}
+class UserEntity extends schema.Entity(User, {
+  pk: 'username',
+  key: 'User',
+  schema: { createdAt: Date },
+}) {}
+```
+
+</TypeScriptEditor>
+
+### pk: string | (value, parent?, key?) => string | undefined = 'id'
+
+Specifies the [Entity.pk](./Entity.md#pk)
+
+A `string` indicates the field to use for pk.
+
+A `function` is used just like [Entity.pk](./Entity.md#pk), but the first argument (`value`) is `this`
+
+Defaults to 'id'; which means pk is a required option _unless_ the `Base` class has a serializable `id` member.
+
+<TypeScriptEditor>
+
+```typescript title="multi-column primary key"
+class Thread {
+  forum = '';
+  slug = '';
+  content = '';
+}
+class ThreadEntity extends schema.Entity(Thread, {
+  pk(value) {
+    return [value.forum, value.slug].join(',');
+  },
+}) {}
+```
+
+</TypeScriptEditor>
+
+### key: string
+
+Specifies the [Entity.key](./Entity.md#key)
+
+### schema: {[k:string]: Schema}
+
+Specifies the [Entity.schema](./Entity.md#schema)
+
+## Methods
+
+`schema.Entity` has the same methods as [Entity](./Entity.md) with an improved `mergeWithStore()` lifecycle.
+
+This method uses [shouldReorder()](#shouldReorder) to handle race conditions rather than [useIncoming()](#useIncoming),
+which is better able to handle [partial field entities](../guides/summary-list.md).
+
+Eventually `Entity` will also be converted to use this default implementation. You can prepare for this by copying
+the [mergeWithStore](#mergeWithStore) default implementation below.
+
+### static mergeWithStore(existingMeta, incomingMeta, existing, incoming): mergedValue {#mergeWithStore}
+
+```typescript
+static mergeWithStore(
+  existingMeta: {
+    date: number;
+    fetchedAt: number;
+  },
+  incomingMeta: { date: number; fetchedAt: number },
+  existing: any,
+  incoming: any,
+) {
+  const useIncoming = this.useIncoming(
+    existingMeta,
+    incomingMeta,
+    existing,
+    incoming,
+  );
+
+  if (useIncoming) {
+    // distinct types are not mergeable (like delete symbol), so just replace
+    if (typeof incoming !== typeof existing) {
+      return incoming;
+    } else {
+      return this.shouldReorder(
+        existingMeta,
+        incomingMeta,
+        existing,
+        incoming,
+      )
+        ? this.merge(incoming, existing)
+        : this.merge(existing, incoming);
+    }
+  } else {
+    return existing;
+  }
+}
+```
+
+`mergeWithStore()` is called during normalization when a processed entity is already found in the store.
+
+This calls [useIncoming()](#useIncoming), [shouldReorder()](#shouldOrder) and potentially [merge()](#merge)
+
+### static useIncoming(existingMeta, incomingMeta, existing, incoming): boolean {#useIncoming}
+
+```typescript
+static useIncoming(
+  existingMeta: { date: number; fetchedAt: number },
+  incomingMeta: { date: number; fetchedAt: number },
+  existing: any,
+  incoming: any,
+) {
+  return true;
+}
+```
+
+#### Preventing updates
+
+useIncoming can also be used to short-circuit an entity update.
+
+```typescript
+import deepEqual from 'deep-equal';
+
+class ArticleEntity extends schema.Entity(
+  class {
+    id = '';
+    title = '';
+    content = '';
+    published = false;
+  },
+) {
+  static useIncoming(
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return !deepEqual(incoming, existing);
+  }
+}
+```
+
+### static shouldReorder(existingMeta, incomingMeta, existing, incoming): boolean {#shouldReorder}
+
+```typescript
+static shouldReorder(
+  existingMeta: { date: number; fetchedAt: number },
+  incomingMeta: { date: number; fetchedAt: number },
+  existing: any,
+  incoming: any,
+) {
+  return incomingMeta.fetchedAt < existingMeta.fetchedAt;
+}
+```
+
+`true` return value will reorder incoming vs in-store entity argument order in merge. With
+the default merge, this will cause the fields of existing entities to override those of incoming,
+rather than the other way around.
+
+#### Example
+
+<TypeScriptEditor>
+
+```typescript
+class LatestPriceEntity extends schema.Entity(
+  class {
+    id = '';
+    updatedAt = 0;
+    price = '0.0';
+    symbol = '';
+  },
+) {
+  static shouldReorder(
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
+    existing: { updatedAt: number },
+    incoming: { updatedAt: number },
+  ) {
+    return incoming.updatedAt < existing.updatedAt;
+  }
+}
+```
+
+</TypeScriptEditor>
+
+### static merge(existing, incoming): mergedValue {#merge}
+
+```typescript
+static merge(existing: any, incoming: any) {
+  return {
+    ...existing,
+    ...incoming,
+  };
+}
+```
+
+Merge is used to handle cases when an incoming entity is already found. This is called directly
+when the same entity is found in one response. By default it is also called when [mergeWithStore()](#mergeWithStore)
+determines the incoming entity should be merged with an entity already persisted in the Rest Hooks store.
+
+## const vs class
+
+If you don't need to further customize the entity, you can use a `const` declaration instead
+of `extend` to another class.
+
+There is a subtle difference when referring to the `class token` in TypeScript - as
+`class` declarations will refer to the instance type; whereas `const tokens` refer to the value, so you
+must use `typeof`, but additionally typeof gives the class type, so you must layer `InstanceType`
+on top.
+
+<TypeScriptEditor>
+
+```typescript
+import { schema } from '@rest-hooks/rest';
+
+export class Article {
+  id = '';
+  title = '';
+  content = '';
+  tags: string[] = [];
+}
+
+export class ArticleEntity extends schema.Entity(Article) {}
+export const ArticleEntity2 = schema.Entity(Article);
+
+const article: ArticleEntity = ArticleEntity.fromJS();
+const articleFails: ArticleEntity2 = ArticleEntity2.fromJS();
+const articleWorks: InstanceType<typeof ArticleEntity2> =
+  ArticleEntity2.fromJS();
+```
+
+</TypeScriptEditor>

--- a/examples/benchmark/entity.js
+++ b/examples/benchmark/entity.js
@@ -1,0 +1,80 @@
+import data from './data.json' assert { type: 'json' };
+import {
+  Entity,
+  normalize,
+  denormalize,
+  inferResults,
+  WeakEntityMap,
+} from './dist/index.js';
+import { printStatus } from './printStatus.js';
+import {
+  ProjectSchema,
+  ProjectQuery,
+  ProjectQuerySorted,
+  BuildTypeDescription,
+  BuildTypeDescriptionEntity,
+  BuildTypeDescriptionEmpty,
+  ProjectWithBuildTypesDescription,
+  ProjectWithBuildTypesDescriptionEmpty,
+  ProjectWithBuildTypesDescriptionEntity,
+} from './schemas.js';
+
+export default function addEntitySuite(suite) {
+  return suite
+    .add('pk()', () => {
+      data.project.forEach(project => {
+        ProjectWithBuildTypesDescription.pk(project);
+        project.buildTypes.buildType.forEach(buildtype => {
+          BuildTypeDescription.pk(buildtype);
+        });
+      });
+    })
+    .add('no-defaults pk()', () => {
+      data.project.forEach(project => {
+        ProjectWithBuildTypesDescriptionEmpty.pk(project);
+        project.buildTypes.buildType.forEach(buildtype => {
+          BuildTypeDescriptionEmpty.pk(buildtype);
+        });
+      });
+    })
+    .add('mixin pk()', () => {
+      data.project.forEach(project => {
+        ProjectWithBuildTypesDescriptionEntity.pk(project);
+        project.buildTypes.buildType.forEach(buildtype => {
+          BuildTypeDescriptionEntity.pk(buildtype);
+        });
+      });
+    })
+    .add('fromJS()', () => {
+      data.project.forEach(project => {
+        ProjectWithBuildTypesDescription.fromJS(project);
+        project.buildTypes.buildType.forEach(buildtype => {
+          BuildTypeDescription.fromJS(buildtype);
+        });
+      });
+    })
+    .add('no-defaults fromJS()', () => {
+      data.project.forEach(project => {
+        ProjectWithBuildTypesDescriptionEmpty.fromJS(project);
+        project.buildTypes.buildType.forEach(buildtype => {
+          BuildTypeDescriptionEmpty.fromJS(buildtype);
+        });
+      });
+    })
+    .add('mixin fromJS()', () => {
+      data.project.forEach(project => {
+        ProjectWithBuildTypesDescriptionEntity.fromJS(project);
+        project.buildTypes.buildType.forEach(buildtype => {
+          BuildTypeDescriptionEntity.fromJS(buildtype);
+        });
+      });
+    })
+    .on('complete', function () {
+      if (process.env.SHOW_OPTIMIZATION) {
+        printStatus(Entity.fromJS);
+        printStatus(Entity.pk);
+        printStatus(ProjectWithBuildTypesDescription.prototype.pk);
+        printStatus(Entity.merge);
+      }
+    });
+}

--- a/examples/benchmark/index.js
+++ b/examples/benchmark/index.js
@@ -3,16 +3,46 @@ import vm from 'node:vm';
 import v8 from 'v8';
 
 import addCoreSuite from './core.js';
+import addEntitySuite from './entity.js';
 import addNormlizrSuite from './normalizr.js';
 
 v8.setFlagsFromString('--expose_gc');
 const gc = vm.runInNewContext('gc');
 
-addCoreSuite(addNormlizrSuite(new Benchmark.Suite()))
-  .on('cycle', event => {
-    // Output benchmark result by converting benchmark result to string
-    console.log(String(event.target));
-    // collect garbage between runs to make results more consistent
-    gc();
-  })
-  .run();
+if (process.argv[2] === 'entity') {
+  addEntitySuite(new Benchmark.Suite())
+    .on('cycle', event => {
+      // Output benchmark result by converting benchmark result to string
+      console.log(String(event.target));
+      // collect garbage between runs to make results more consistent
+      gc();
+    })
+    .run();
+} else if (process.argv[2] === 'normalizr') {
+  addNormlizrSuite(new Benchmark.Suite())
+    .on('cycle', event => {
+      // Output benchmark result by converting benchmark result to string
+      console.log(String(event.target));
+      // collect garbage between runs to make results more consistent
+      gc();
+    })
+    .run();
+} else if (process.argv[2] === 'core') {
+  addCoreSuite(new Benchmark.Suite())
+    .on('cycle', event => {
+      // Output benchmark result by converting benchmark result to string
+      console.log(String(event.target));
+      // collect garbage between runs to make results more consistent
+      gc();
+    })
+    .run();
+} else {
+  addCoreSuite(addNormlizrSuite(new Benchmark.Suite()))
+    .on('cycle', event => {
+      // Output benchmark result by converting benchmark result to string
+      console.log(String(event.target));
+      // collect garbage between runs to make results more consistent
+      gc();
+    })
+    .run();
+}

--- a/examples/benchmark/normalizr.js
+++ b/examples/benchmark/normalizr.js
@@ -1,3 +1,4 @@
+import data from './data.json' assert { type: 'json' };
 import {
   Entity,
   normalize,
@@ -5,14 +6,13 @@ import {
   inferResults,
   WeakEntityMap,
 } from './dist/index.js';
-
-import data from './data.json' assert { type: 'json' };
 import { printStatus } from './printStatus.js';
 import {
   ProjectSchema,
   ProjectQuery,
   ProjectQuerySorted,
   ProjectWithBuildTypesDescription,
+  ProjectSchemaMixin,
 } from './schemas.js';
 
 const { result, entities } = normalize(data, ProjectSchema);
@@ -33,7 +33,10 @@ const queryInfer = inferResults(
 export default function addNormlizrSuite(suite) {
   let denormCache = {
     entities: {},
-    results: { '/fake': new WeakEntityMap(), '/fakeQuery': new WeakEntityMap() },
+    results: {
+      '/fake': new WeakEntityMap(),
+      '/fakeQuery': new WeakEntityMap(),
+    },
   };
   // prime the cache
   denormalize(
@@ -67,6 +70,9 @@ export default function addNormlizrSuite(suite) {
     })
     .add('denormalizeLong', () => {
       return denormalize(result, ProjectSchema, entities);
+    })
+    .add('denormalizeLong with mixin Entity', () => {
+      return denormalize(result, ProjectSchemaMixin, entities);
     })
     .add('denormalizeLong withCache', () => {
       return denormalize(

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -1,14 +1,51 @@
 import { Entity, schema, Query } from './dist/index.js';
 
-class BuildTypeDescription extends Entity {
+export class BuildTypeDescription extends Entity {
+  id = '';
+  internalId = 'bt17590';
+  name = 'Auto build with Scala 2.11';
+  type = 'regular';
+  paused = false;
+  projectId = 'OpenSourceProjects_AbsaOSS_Commons';
+
   pk() {
     return this.id;
   }
 
   static key = 'BuildTypeDescription';
 }
+export class BuildTypeDescriptionEmpty extends Entity {
+  pk() {
+    return this.id;
+  }
+
+  static key = 'BuildTypeDescription';
+}
+export const BuildTypeDescriptionEntity = schema.Entity(
+  class {
+    id = '';
+    internalId = 'bt17590';
+    name = 'Auto build with Scala 2.11';
+    type = 'regular';
+    paused = false;
+    projectId = 'OpenSourceProjects_AbsaOSS_Commons';
+  },
+  {
+    pk: 'id',
+    key: 'BuildTypeDescription',
+  },
+);
 
 export class ProjectWithBuildTypesDescription extends Entity {
+  id = '';
+  internalId = 'project3239';
+  name = 'AbsaOSS';
+  parentProjectId = 'OpenSourceProjects';
+  archived = false;
+  buildTypes = {
+    buildType: [],
+  };
+
   pk() {
     return this.id;
   }
@@ -19,8 +56,43 @@ export class ProjectWithBuildTypesDescription extends Entity {
 
   static key = 'ProjectWithBuildTypesDescription';
 }
+export class ProjectWithBuildTypesDescriptionEmpty extends Entity {
+  pk() {
+    return this.id;
+  }
 
-export const ProjectSchema = { project: [ProjectWithBuildTypesDescription] };
+  static schema = {
+    buildTypes: { buildType: [BuildTypeDescriptionEmpty] },
+  };
+
+  static key = 'ProjectWithBuildTypesDescription';
+}
+export const ProjectWithBuildTypesDescriptionEntity = schema.Entity(
+  class {
+    id = '';
+    internalId = 'project3239';
+    name = 'AbsaOSS';
+    parentProjectId = 'OpenSourceProjects';
+    archived = false;
+    buildTypes = {
+      buildType: [],
+    };
+  },
+  {
+    pk: 'id',
+    key: 'ProjectWithBuildTypesDescription',
+    schema: {
+      buildTypes: { buildType: [BuildTypeDescriptionEntity] },
+    },
+  },
+);
+
+export const ProjectSchema = {
+  project: [ProjectWithBuildTypesDescription],
+};
+export const ProjectSchemaMixin = {
+  project: [ProjectWithBuildTypesDescriptionEntity],
+};
 
 export const ProjectQuery = {
   project: new schema.All(ProjectWithBuildTypesDescription),

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -24,6 +24,8 @@ export function createPlaceholderResource<U extends string, S extends Schema>({
     schema,
     Endpoint,
     urlPrefix: 'https://jsonplaceholder.typicode.com',
+    // hour expiry time since we want to keep our example mutations and the api itself never actually changes
+    dataExpiryLength: 1000 * 60 * 60,
   });
   const partialUpdate = base.partialUpdate.extend({
     fetch: async function (...args: any) {

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -6,7 +6,10 @@ import type {
   SchemaClass,
 } from './interface.js';
 
-export type AbstractInstanceType<T> = T extends { prototype: infer U }
+// TypeScript <4.2 InstanceType<> does not work on abstract classes
+export type AbstractInstanceType<T> = T extends new (...args: any) => infer U
+  ? U
+  : T extends { prototype: infer U }
   ? U
   : never;
 

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -19,6 +19,15 @@ import type {
   EntityMap,
 } from './normal.js';
 import { default as Delete } from './schemas/Delete.js';
+import {
+  EntityOptions,
+  IEntityClass,
+  IEntityInstance,
+  RequiredPKOptions,
+  IDClass,
+  Constructor,
+  PKClass,
+} from './schemas/EntitySchema';
 
 export { Delete, EntityMap };
 
@@ -316,3 +325,36 @@ export interface SchemaClass<T = any, N = T | undefined>
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
   _denormalizeNullable(): [N, boolean, boolean];
 }
+
+// id is in Instance, so we default to that as pk
+/**
+ * Represents data that should be deduped by specifying a primary key.
+ * @see https://resthooks.io/docs/api/schema.Entity
+ */
+export function Entity<TBase extends PKClass>(
+  Base: TBase,
+  opt?: EntityOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase;
+
+// id is in Instance, so we default to that as pk
+export function Entity<TBase extends IDClass>(
+  Base: TBase,
+  opt?: EntityOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+
+// pk was specified in options, so we don't need to redefine
+export function Entity<TBase extends Constructor>(
+  Base: TBase,
+  opt: RequiredPKOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+
+/* TODO: figure out how to make abstract class mixins work. until then we will require PK in options
+export function Entity<TBase extends Constructor>(
+  Base: TBase,
+  opt?: EntityOptions<keyof InstanceType<TBase>>,
+): (abstract new (...args: any[]) => {
+  pk(parent?: any, key?: string): string | undefined;
+}) &
+  IEntityClass<TBase> &
+  TBase;
+*/

--- a/packages/endpoint/src/schema.js
+++ b/packages/endpoint/src/schema.js
@@ -5,3 +5,4 @@ export { default as Array } from './schemas/Array.js';
 export { default as All } from './schemas/All.js';
 export { default as Object } from './schemas/Object.js';
 export { default as Delete } from './schemas/Delete.js';
+export { default as Entity } from './schemas/EntitySchema.js';

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -1,0 +1,592 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+import type { Schema, NormalizedIndex, UnvisitFunction } from '../interface.js';
+import { AbstractInstanceType } from '../normal.js';
+
+export type Constructor = abstract new (...args: any[]) => {};
+export type IDClass = abstract new (...args: any[]) => {
+  id: string | number | undefined;
+};
+export type PKClass = abstract new (...args: any[]) => {
+  pk(parent?: any, key?: string): string | undefined;
+};
+
+// TODO: Figure out what Schema must be for each key
+type ValidSchemas<TInstance> = { [k in keyof TInstance]?: Schema };
+
+export interface EntityOptions<TInstance> {
+  readonly schema?: ValidSchemas<TInstance>;
+  readonly pk?:
+    | ((value: TInstance, parent?: any, key?: string) => string | undefined)
+    | keyof TInstance;
+  readonly key?: string;
+}
+
+export interface RequiredPKOptions<TInstance> extends EntityOptions<TInstance> {
+  readonly pk:
+    | ((value: TInstance, parent?: any, key?: string) => string | undefined)
+    | keyof TInstance;
+}
+
+export default function EntitySchema<TBase extends Constructor>(
+  Base: TBase,
+  options: EntityOptions<InstanceType<TBase>> = {},
+) {
+  /**
+   * Represents data that should be deduped by specifying a primary key.
+   * @see https://resthooks.io/docs/api/Entity
+   */
+  abstract class EntityMixin extends Base {
+    static toJSON() {
+      return {
+        name: this.name,
+        schema: this.schema,
+        key: this.key,
+      };
+    }
+
+    /** Defines nested entities */
+    declare static schema: { [k: string]: Schema };
+
+    /**
+     * A unique identifier for each Entity
+     *
+     * @param [parent] When normalizing, the object which included the entity
+     * @param [key] When normalizing, the key where this entity was found
+     */
+    abstract pk(parent?: any, key?: string): string | undefined;
+
+    /** Returns the globally unique identifier for the static Entity */
+    declare static key: string;
+    // default implementation in class static block at bottom of definition
+
+    /** Defines indexes to enable lookup by */
+    declare static indexes?: readonly string[];
+
+    /**
+     * A unique identifier for each Entity
+     *
+     * @param [value] POJO of the entity or subset used
+     * @param [parent] When normalizing, the object which included the entity
+     * @param [key] When normalizing, the key where this entity was found
+     */
+    static pk<T extends typeof EntityMixin>(
+      this: T,
+      value: Partial<AbstractInstanceType<T>>,
+      parent?: any,
+      key?: string,
+    ): string | undefined {
+      return this.prototype.pk.call(value, parent, key);
+    }
+
+    /** Return true to merge incoming data; false keeps existing entity
+     *
+     * @see https://resthooks.io/docs/api/schema.Entity#useIncoming
+     */
+    static useIncoming(
+      existingMeta: { date: number; fetchedAt: number },
+      incomingMeta: { date: number; fetchedAt: number },
+      existing: any,
+      incoming: any,
+    ) {
+      return true;
+    }
+
+    /** Determines the order of incoming entity vs entity already in store\
+     *
+     * @see https://resthooks.io/docs/api/schema.Entity#shouldReorder
+     * @returns true if incoming entity should be first argument of merge()
+     */
+    static shouldReorder(
+      existingMeta: { date: number; fetchedAt: number },
+      incomingMeta: { date: number; fetchedAt: number },
+      existing: any,
+      incoming: any,
+    ) {
+      return incomingMeta.fetchedAt < existingMeta.fetchedAt;
+    }
+
+    /** Creates new instance copying over defined values of arguments */
+    static merge(existing: any, incoming: any) {
+      return {
+        ...existing,
+        ...incoming,
+      };
+    }
+
+    /** Run when an existing entity is found in the store */
+    static mergeWithStore(
+      existingMeta: {
+        date: number;
+        fetchedAt: number;
+      },
+      incomingMeta: { date: number; fetchedAt: number },
+      existing: any,
+      incoming: any,
+    ) {
+      const useIncoming = this.useIncoming(
+        existingMeta,
+        incomingMeta,
+        existing,
+        incoming,
+      );
+
+      if (useIncoming) {
+        // distinct types are not mergeable (like delete symbol), so just replace
+        if (typeof incoming !== typeof existing) {
+          return incoming;
+        } else {
+          return this.shouldReorder(
+            existingMeta,
+            incomingMeta,
+            existing,
+            incoming,
+          )
+            ? this.merge(incoming, existing)
+            : this.merge(existing, incoming);
+        }
+      } else {
+        return existing;
+      }
+    }
+
+    /** Factory method to convert from Plain JS Objects.
+     *
+     * @param [props] Plain Object of properties to assign.
+     */
+    static fromJS<T extends typeof EntityMixin>(
+      this: T,
+      // TODO: this should only accept members that are not functions
+      props: Partial<AbstractInstanceType<T>> = {},
+    ): AbstractInstanceType<T> {
+      // we type guarded abstract case above, so ok to force typescript to allow constructor call
+      const instance = new (this as any)(props) as AbstractInstanceType<T>;
+      // we can't rely on constructors and override the defaults provided as property assignments
+      // all occur after the constructor
+      Object.assign(instance, props);
+      return instance;
+    }
+
+    /** Factory method to convert from Plain JS Objects.
+     *
+     * @param [props] Plain Object of properties to assign.
+     */
+    static createIfValid<T extends typeof EntityMixin>(
+      this: T,
+      // TODO: this should only accept members that are not functions
+      props: Partial<AbstractInstanceType<T>>,
+    ): AbstractInstanceType<T> | undefined {
+      if (this.validate(props)) {
+        return undefined as any;
+      }
+      return this.fromJS(props);
+    }
+
+    /** Do any transformations when first receiving input */
+    static process(input: any, parent: any, key: string | undefined): any {
+      return { ...input };
+    }
+
+    static normalize(
+      input: any,
+      parent: any,
+      key: string | undefined,
+      visit: (...args: any) => any,
+      addEntity: (...args: any) => any,
+      visitedEntities: Record<string, any>,
+    ): any {
+      const processedEntity = this.process(input, parent, key);
+      const id = this.pk(processedEntity, parent, key);
+      if (id === undefined || id === '') {
+        if (process.env.NODE_ENV !== 'production') {
+          const error = new Error(
+            `Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
+
+  Entity: ${this.name}
+  Value (processed): ${
+    processedEntity && JSON.stringify(processedEntity, null, 2)
+  }
+  `,
+          );
+          (error as any).status = 400;
+          throw error;
+        } else {
+          // these make the keys get deleted
+          return undefined;
+        }
+      }
+      const entityType = this.key;
+
+      if (!(entityType in visitedEntities)) {
+        visitedEntities[entityType] = {};
+      }
+      if (!(id in visitedEntities[entityType])) {
+        visitedEntities[entityType][id] = [];
+      }
+      if (
+        visitedEntities[entityType][id].some((entity: any) => entity === input)
+      ) {
+        return id;
+      }
+      const errorMessage = this.validate(processedEntity);
+      throwValidationError(errorMessage);
+
+      visitedEntities[entityType][id].push(input);
+
+      Object.keys(this.schema).forEach(key => {
+        if (Object.hasOwn(processedEntity, key)) {
+          const schema = this.schema[key];
+          processedEntity[key] = visit(
+            processedEntity[key],
+            processedEntity,
+            key,
+            schema,
+            addEntity,
+            visitedEntities,
+          );
+        }
+      });
+
+      addEntity(this, processedEntity, id);
+      return id;
+    }
+
+    static validate(processedEntity: any): string | undefined {
+      if (process.env.NODE_ENV !== 'production') {
+        for (const key of Object.keys(this.schema)) {
+          if (!Object.hasOwn(processedEntity, key)) {
+            if (!Object.hasOwn(this.defaults, key)) {
+              return `Schema key is missing in Entity
+
+  Be sure all schema members are also part of the entity
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about nesting schemas: https://resthooks.io/rest/guides/nested-response
+
+  Entity keys: ${Object.keys(this.defaults)}
+  Schema key(missing): ${key}
+  `;
+            }
+          }
+        }
+      }
+    }
+
+    static infer(
+      args: readonly any[],
+      indexes: NormalizedIndex,
+      recurse: any,
+    ): any {
+      if (!args[0]) return undefined;
+      if (['string', 'number'].includes(typeof args[0])) {
+        return `${args[0]}`;
+      }
+      const id = this.pk(args[0], undefined, '');
+      // Was able to infer the entity's primary key from params
+      if (id !== undefined && id !== '') return id;
+      // now attempt lookup in indexes
+      const indexName = indexFromParams(args[0], this.indexes);
+      if (indexName && indexes[this.key]) {
+        // 'as Record<string, any>': indexName can only be found if params is a string key'd object
+        const id =
+          indexes[this.key][indexName][
+            (args[0] as Record<string, any>)[indexName]
+          ];
+        return id;
+      }
+      return undefined;
+    }
+
+    static expiresAt(
+      meta: { expiresAt: number; date: number; fetchedAt: number },
+      input: any,
+    ): number {
+      return meta.expiresAt;
+    }
+
+    static denormalize<T extends typeof EntityMixin>(
+      this: T,
+      input: any,
+      unvisit: UnvisitFunction,
+    ): [
+      denormalized: AbstractInstanceType<T>,
+      found: boolean,
+      suspend: boolean,
+    ] {
+      // TODO: remove codecov ignore once denormalize is modified to expect this
+      /* istanbul ignore if */
+      if (typeof input === 'symbol') {
+        return [undefined, true, true] as any;
+      }
+
+      let deleted = false;
+      // note: iteration order must be stable
+      Object.keys(this.schema).forEach(key => {
+        const schema = this.schema[key];
+        const nextInput = (input as any)[key];
+        const [value, , deletedItem] = unvisit(nextInput, schema);
+
+        if (deletedItem && !!this.defaults[key]) {
+          deleted = true;
+        }
+        input[key] = value;
+      });
+
+      return [input, true, deleted];
+    }
+
+    /** All instance defaults set */
+    static get defaults() {
+      // we use hasOwn because we don't want to use a parents' defaults
+      if (!Object.hasOwn(this, '__defaults'))
+        Object.defineProperty(this, '__defaults', {
+          value: new (this as any)(),
+          writable: true,
+          configurable: true,
+        });
+      return (this as any).__defaults;
+    }
+  }
+
+  if ('schema' in options) {
+    EntityMixin.schema = options.schema as any;
+  } else if (!(Base as any).schema) {
+    EntityMixin.schema = {};
+  }
+  if ('pk' in options) {
+    if (typeof options.pk === 'function') {
+      EntityMixin.prototype.pk = function (parent?: any, key?: string) {
+        return (options.pk as any)(this, parent, key);
+      };
+    } else {
+      EntityMixin.prototype.pk = function () {
+        return this[options.pk];
+      };
+    }
+    // default to 'id' field if the base class doesn't have a pk
+  } else if (typeof Base.prototype.pk !== 'function') {
+    EntityMixin.prototype.pk = function () {
+      return this.id;
+    };
+  }
+  if ('key' in options) {
+    Object.defineProperty(EntityMixin, 'key', {
+      value: options.key,
+      configurable: true,
+      writable: true,
+    });
+  } else if (!('key' in Base)) {
+    // this allows assignment in strict-mode
+    // eslint-disable-next-line no-inner-declarations
+    function set(this: any, value: string) {
+      Object.defineProperty(this, 'key', {
+        value,
+        writable: true,
+        enumerable: true,
+      });
+    }
+    const CLASSNAMEMANGLING = EntityMixin.name !== 'EntityMixin';
+    const get =
+      /* istanbul ignore if */
+      CLASSNAMEMANGLING
+        ? /* istanbul ignore next */ function (this: {
+            name: string;
+            key: string;
+          }): string {
+            console.error('Rest Hooks Error: https://resthooks.io/errors/dklj');
+            Object.defineProperty(this, 'key', {
+              get() {
+                return Base.name;
+              },
+              set,
+            });
+            return this.key;
+          }
+        : function (this: { name: string }): string {
+            const name = this.name === 'EntityMixin' ? Base.name : this.name;
+            /* istanbul ignore next */
+            if (
+              process.env.NODE_ENV !== 'production' &&
+              (name === '' || name === 'EntityMixin' || name === '_temp')
+            )
+              throw new Error(
+                'Entity classes without a name must define `static key`\nSee: https://resthooks.io/rest/api/Entity#key',
+              );
+            return name;
+          };
+
+    Object.defineProperty(EntityMixin, 'key', {
+      get,
+      set,
+    });
+  }
+
+  return EntityMixin as any;
+}
+
+function indexFromParams<I extends string>(
+  params: Readonly<object>,
+  indexes?: Readonly<I[]>,
+) {
+  if (!indexes) return undefined;
+  return indexes.find(index => Object.hasOwn(params, index));
+}
+
+// part of the reason for pulling this out is that all functions that throw are deoptimized
+function throwValidationError(errorMessage: string | undefined) {
+  if (errorMessage) {
+    const error = new Error(errorMessage);
+    (error as any).status = 400;
+    throw error;
+  }
+}
+
+export interface IEntityClass<TBase extends Constructor = any> {
+  toJSON(): {
+    name: string;
+    schema: {
+      [k: string]: Schema;
+    };
+    key: string;
+  };
+  /** Defines nested entities */
+  schema: {
+    [k: string]: Schema;
+  };
+  /** Returns the globally unique identifier for the static Entity */
+  key: string;
+  /** Defines indexes to enable lookup by */
+  indexes?: readonly string[] | undefined;
+  /**
+   * A unique identifier for each Entity
+   *
+   * @param [value] POJO of the entity or subset used
+   * @param [parent] When normalizing, the object which included the entity
+   * @param [key] When normalizing, the key where this entity was found
+   */
+  pk<
+    T extends (abstract new (...args: any[]) => IEntityInstance &
+      InstanceType<TBase>) &
+      IEntityClass &
+      TBase,
+  >(
+    this: T,
+    value: Partial<AbstractInstanceType<T>>,
+    parent?: any,
+    key?: string,
+  ): string | undefined;
+  /** Return true to merge incoming data; false keeps existing entity
+   *
+   * @see https://resthooks.io/docs/api/schema.Entity#useIncoming
+   */
+  useIncoming(
+    existingMeta: {
+      date: number;
+      fetchedAt: number;
+    },
+    incomingMeta: {
+      date: number;
+      fetchedAt: number;
+    },
+    existing: any,
+    incoming: any,
+  ): boolean;
+  /** Determines the order of incoming entity vs entity already in store\
+   *
+   * @see https://resthooks.io/docs/api/schema.Entity#shouldReorder
+   * @returns true if incoming entity should be first argument of merge()
+   */
+  shouldReorder(
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
+    existing: any,
+    incoming: any,
+  ): boolean;
+  /** Creates new instance copying over defined values of arguments */
+  merge(existing: any, incoming: any): any;
+  /** Run when an existing entity is found in the store */
+  mergeWithStore(
+    existingMeta: {
+      date: number;
+      fetchedAt: number;
+    },
+    incomingMeta: {
+      date: number;
+      fetchedAt: number;
+    },
+    existing: any,
+    incoming: any,
+  ): any;
+  /** Factory method to convert from Plain JS Objects.
+   *
+   * @param [props] Plain Object of properties to assign.
+   */
+  fromJS<
+    T extends (abstract new (...args: any[]) => IEntityInstance &
+      InstanceType<TBase>) &
+      IEntityClass &
+      TBase,
+  >(
+    this: T,
+    props?: Partial<AbstractInstanceType<T>>,
+  ): AbstractInstanceType<T>;
+  /** Factory method to convert from Plain JS Objects.
+   *
+   * @param [props] Plain Object of properties to assign.
+   */
+  createIfValid<
+    T extends (abstract new (...args: any[]) => IEntityInstance &
+      InstanceType<TBase>) &
+      IEntityClass &
+      TBase,
+  >(
+    this: T,
+    props: Partial<AbstractInstanceType<T>>,
+  ): AbstractInstanceType<T> | undefined;
+  /** Do any transformations when first receiving input */
+  process(input: any, parent: any, key: string | undefined): any;
+  normalize(
+    input: any,
+    parent: any,
+    key: string | undefined,
+    visit: (...args: any) => any,
+    addEntity: (...args: any) => any,
+    visitedEntities: Record<string, any>,
+  ): any;
+  validate(processedEntity: any): string | undefined;
+  infer(args: readonly any[], indexes: NormalizedIndex, recurse: any): any;
+  expiresAt(
+    meta: {
+      expiresAt: number;
+      date: number;
+      fetchedAt: number;
+    },
+    input: any,
+  ): number;
+  denormalize<
+    T extends (abstract new (...args: any[]) => IEntityInstance &
+      InstanceType<TBase>) &
+      IEntityClass &
+      TBase,
+  >(
+    this: T,
+    input: any,
+    unvisit: UnvisitFunction,
+  ): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
+  /** All instance defaults set */
+  readonly defaults: any;
+  //set(entity: any, key: string, value: any): void;
+}
+export interface IEntityInstance {
+  /**
+   * A unique identifier for each Entity
+   *
+   * @param [parent] When normalizing, the object which included the entity
+   * @param [key] When normalizing, the key where this entity was found
+   */
+  pk(parent?: any, key?: string): string | undefined;
+}

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -84,6 +84,30 @@ describe(`${Entity.name} normalization`, () => {
     ).toMatchSnapshot();
   });
 
+  test('normalizes does not change value when useIncoming() returns false', () => {
+    class MyEntity extends IDEntity {
+      id = '';
+      title = '';
+      static useIncoming() {
+        return false;
+      }
+    }
+
+    const { entities, entityMeta } = normalize(
+      { id: '1', title: 'hi' },
+      MyEntity,
+    );
+    const secondEntities = normalize(
+      { id: '1', title: 'second' },
+      MyEntity,
+      entities,
+      {},
+      entityMeta,
+    ).entities;
+    expect(entities.MyEntity['1']).toBeDefined();
+    expect(entities.MyEntity['1']).toBe(secondEntities.MyEntity['1']);
+  });
+
   it('should throw a custom error if data does not include pk', () => {
     class MyEntity extends Entity {
       readonly name: string = '';

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -1,0 +1,1383 @@
+// eslint-env jest
+import { normalize, WeakEntityMap } from '@rest-hooks/normalizr';
+import { DELETED } from '@rest-hooks/normalizr';
+import { fromJS, Record } from 'immutable';
+
+import denormalize from './denormalize';
+import { schema } from '../..';
+
+let dateSpy: jest.SpyInstance;
+beforeAll(() => {
+  dateSpy = jest
+    // eslint-disable-next-line no-undef
+    .spyOn(global.Date, 'now')
+    .mockImplementation(() => new Date('2019-05-14T11:01:58.135Z').valueOf());
+});
+afterAll(() => {
+  dateSpy.mockRestore();
+});
+
+const values = <T extends { [k: string]: any }>(obj: T) =>
+  Object.keys(obj).map(key => obj[key]);
+
+class TacoData {
+  id = '';
+  name = '';
+  alias: string | undefined = undefined;
+}
+class Tacos extends schema.Entity(TacoData) {}
+
+class ArticleData {
+  readonly id: string = '';
+  readonly title: string = '';
+  readonly author: string = '';
+  readonly content: string = '';
+}
+class ArticleEntity extends schema.Entity(ArticleData) {}
+
+class OptionalData {
+  readonly id: string = '';
+  readonly article: ArticleEntity | null = null;
+  readonly requiredArticle = ArticleEntity.fromJS();
+  readonly nextPage: string = '';
+}
+class WithOptional extends schema.Entity(OptionalData, {
+  schema: {
+    article: ArticleEntity,
+    requiredArticle: ArticleEntity,
+  },
+}) {}
+
+class IDData {
+  id = '';
+}
+
+describe(`${schema.Entity.name} construction`, () => {
+  describe('pk', () => {
+    it('should use provided pk if part of class', () => {
+      class MyData {
+        username = '';
+        title = '';
+        pk() {
+          return this.username;
+        }
+      }
+      const MyEntity = schema.Entity(MyData);
+      expect(MyEntity.pk({ username: 'bob' })).toBe('bob');
+      const entity = MyEntity.fromJS({ username: 'bob' });
+      expect(entity.pk()).toBe('bob');
+      // @ts-expect-error
+      entity.lksdfl;
+    });
+    it('should use pk overide in Entity', () => {
+      class MyData {
+        username = '';
+        title = '';
+        pk() {
+          return this.username;
+        }
+      }
+      class MyEntity extends schema.Entity(MyData) {
+        pk() {
+          return this.title;
+        }
+      }
+      expect(MyEntity.pk({ title: 'hi' })).toBe('hi');
+      expect(MyEntity.fromJS({ title: 'hi' }).pk()).toBe('hi');
+    });
+    it('should use pk overide in Entity when base is set via options', () => {
+      class MyData {
+        username = '';
+        title = '';
+      }
+      class MyEntity extends schema.Entity(MyData, { pk: 'username' }) {
+        pk() {
+          return this.title;
+        }
+      }
+      expect(MyEntity.pk({ title: 'hi' })).toBe('hi');
+      expect(MyEntity.fromJS({ title: 'hi' }).pk()).toBe('hi');
+    });
+    it('should use pk field names', () => {
+      class MyData {
+        username = '';
+        title = '';
+      }
+      class MyEntity extends schema.Entity(MyData, { pk: 'username' }) {}
+      expect(MyEntity.pk({ username: 'bob' })).toBe('bob');
+      expect(MyEntity.fromJS({ username: 'bob' }).pk()).toBe('bob');
+    });
+    it('should use pk function option', () => {
+      class MyData {
+        username = '';
+        title = '';
+      }
+      class MyEntity extends schema.Entity(MyData, {
+        pk(v) {
+          //@ts-expect-error
+          v.sdlfkjsd;
+          return v.username;
+        },
+      }) {}
+      expect(MyEntity.pk({ username: 'bob' })).toBe('bob');
+      expect(MyEntity.fromJS({ username: 'bob' }).pk()).toBe('bob');
+    });
+    it('should fail with bad pk field name', () => {
+      class MyData {
+        username = '';
+        title = '';
+      }
+      // @ts-expect-error
+      class MyEntity extends schema.Entity(MyData, { pk: 'id' }) {}
+      // @ts-expect-error
+      expect(MyEntity.pk({ username: 'bob' })).toBeUndefined();
+      // @ts-expect-error
+      expect(MyEntity.fromJS({ username: 'bob' }).pk()).toBeUndefined();
+    });
+    it('should fail with no id and pk unspecified', () => {
+      class MyData {
+        username = '';
+        title = '';
+      }
+      // @ts-expect-error
+      class MyEntity extends schema.Entity(MyData) {}
+      // @ts-expect-error
+      expect(MyEntity.pk({ username: 'bob' })).toBeUndefined();
+      // @ts-expect-error
+      expect(MyEntity.fromJS({ username: 'bob' }).pk()).toBeUndefined();
+    });
+    it('should use id field if no pk specified', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+      }
+      class MyEntity extends schema.Entity(MyData) {}
+      expect(MyEntity.pk({ id: '5' })).toBe('5');
+      expect(MyEntity.fromJS({ id: '5' }).pk()).toBe('5');
+    });
+  });
+  describe('key', () => {
+    it('should use class name with no key in options', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+      }
+      const MyEntity = schema.Entity(MyData);
+      expect(MyEntity.key).toBe('MyData');
+    });
+    it('should error with no discernable name', () => {
+      const MyEntity = schema.Entity(
+        class {
+          id = '';
+          username = '';
+          title = '';
+        },
+      );
+      expect(() => MyEntity.key).toThrowErrorMatchingInlineSnapshot(`
+        "Entity classes without a name must define \`static key\`
+        See: https://resthooks.io/rest/api/Entity#key"
+      `);
+    });
+    it('should use entity class name with no key in options', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+      }
+      class MyEntity extends schema.Entity(MyData) {}
+      expect(MyEntity.key).toBe('MyEntity');
+    });
+    it('should use key in options', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+      }
+      const MyEntity = schema.Entity(MyData, { key: 'MYKEY' });
+      expect(MyEntity.key).toBe('MYKEY');
+      class MyEntity2 extends schema.Entity(MyData, { key: 'MYKEY' }) {}
+      expect(MyEntity2.key).toBe('MYKEY');
+    });
+    it('should use static key in base class', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+
+        static key = 'MYKEY';
+      }
+      const MyEntity = schema.Entity(MyData);
+      expect(MyEntity.key).toBe('MYKEY');
+    });
+    it('should have options.key override base class', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+
+        static key = 'MYKEY';
+      }
+      const MyEntity = schema.Entity(MyData, { key: 'OVERRIDE' });
+      expect(MyEntity.key).toBe('OVERRIDE');
+    });
+    it('static key in Entity should override options', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+      }
+      class MyEntity extends schema.Entity(MyData, { key: 'OPTIONSKEY' }) {
+        static key = 'STATICKEY';
+      }
+      expect(MyEntity.key).toBe('STATICKEY');
+    });
+  });
+  describe('schema', () => {
+    it('options.schema should set schema', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+        createdAt = new Date(0);
+      }
+      class MyEntity extends schema.Entity(MyData, {
+        schema: { createdAt: Date },
+      }) {}
+      expect(MyEntity.schema).toEqual({ createdAt: Date });
+    });
+    it('options.schema should override base schema', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+        createdAt = new Date(0);
+        static schema = {
+          user: Date,
+        };
+      }
+      class MyEntity extends schema.Entity(MyData, {
+        schema: { createdAt: Date },
+      }) {}
+      expect(MyEntity.schema).toEqual({ createdAt: Date });
+    });
+    it('static schema in base should be used', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+        createdAt = new Date(0);
+        static schema = {
+          createdAt: Date,
+        };
+      }
+      class MyEntity extends schema.Entity(MyData) {}
+      expect(MyEntity.schema).toEqual({ createdAt: Date });
+    });
+    it('static schema in Entity should override options', () => {
+      class MyData {
+        id = '';
+        username = '';
+        title = '';
+        createdAt = new Date(0);
+      }
+      class MyEntity extends schema.Entity(MyData, {
+        schema: { createdAt: Date },
+      }) {
+        static schema = {
+          user: Date,
+        };
+      }
+      expect(MyEntity.schema).toEqual({ user: Date });
+    });
+  });
+});
+
+describe(`${schema.Entity.name} normalization`, () => {
+  let warnSpy: jest.SpyInstance;
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+  beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
+
+  test('normalizes an entity', () => {
+    class MyEntity extends schema.Entity(IDData) {}
+    expect(normalize({ id: '1' }, MyEntity)).toMatchSnapshot();
+  });
+
+  test('normalizes already processed entities', () => {
+    class MyEntity extends schema.Entity(IDData) {}
+    class MyData {
+      id = '';
+      title = '';
+      nest = MyEntity.fromJS();
+    }
+    class Nested extends schema.Entity(MyData, {
+      schema: {
+        nest: MyEntity,
+      },
+    }) {}
+
+    expect(normalize(['1'], new schema.Array(MyEntity))).toMatchSnapshot();
+    expect(
+      normalize({ data: '1' }, new schema.Object({ data: MyEntity })),
+    ).toMatchSnapshot();
+    expect(
+      normalize({ title: 'hi', id: '5', nest: '10' }, Nested),
+    ).toMatchSnapshot();
+  });
+
+  test('normalizes does not change value when useIncoming() returns false', () => {
+    class MyData {
+      id = '';
+      title = '';
+    }
+    class MyEntity extends schema.Entity(MyData) {
+      static useIncoming() {
+        return false;
+      }
+    }
+    const { entities, entityMeta } = normalize(
+      { id: '1', title: 'hi' },
+      MyEntity,
+    );
+    const secondEntities = normalize(
+      { id: '1', title: 'second' },
+      MyEntity,
+      entities,
+      {},
+      entityMeta,
+    ).entities;
+    expect(entities.MyEntity['1']).toBeDefined();
+    expect(entities.MyEntity['1']).toBe(secondEntities.MyEntity['1']);
+  });
+
+  it('should throw a custom error if data does not include pk', () => {
+    class MyData {
+      name = '';
+      secondthing = '';
+    }
+    const MyEntity = schema.Entity(MyData, { pk: 'name' });
+
+    function normalizeBad() {
+      normalize({ secondthing: 'hi' }, MyEntity);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+
+    // @ts-expect-error
+    schema.Entity(MyData, { pk: 'sdfasd' });
+  });
+
+  it('should throw a custom error if schema key is missing from Entity', () => {
+    class MyData {
+      name = '';
+      secondthing = '';
+    }
+    // @ts-expect-error
+    const MyEntity = schema.Entity(MyData, {
+      pk: 'name',
+      schema: {
+        blarb: Date,
+      },
+    });
+
+    function normalizeBad() {
+      normalize({ name: 'bob', secondthing: 'hi' }, MyEntity);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should handle optional schema entries Entity', () => {
+    class MyData {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly blarb: Date | undefined = undefined;
+    }
+    class MyEntity extends schema.Entity(MyData, {
+      pk: 'name',
+      schema: {
+        blarb: Date,
+      },
+    }) {}
+
+    expect(normalize({ name: 'bob', secondthing: 'hi' }, MyEntity))
+      .toMatchInlineSnapshot(`
+      {
+        "entities": {
+          "MyEntity": {
+            "bob": {
+              "name": "bob",
+              "secondthing": "hi",
+            },
+          },
+        },
+        "entityMeta": {
+          "MyEntity": {
+            "bob": {
+              "date": 1557831718135,
+              "expiresAt": Infinity,
+              "fetchedAt": 0,
+            },
+          },
+        },
+        "indexes": {},
+        "result": "bob",
+      }
+    `);
+  });
+
+  it('should throw a custom error if data loads with no matching props', () => {
+    class MyData {
+      name = '';
+      secondthing = '';
+    }
+    const MyEntity = schema.Entity(MyData, { pk: 'name' });
+    function normalizeBad() {
+      normalize({}, MyEntity);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw a custom error loads with array', () => {
+    class MyData {
+      name = '';
+      secondthing = '';
+    }
+    const MyEntity = schema.Entity(MyData, { pk: 'name' });
+    function normalizeBad() {
+      normalize(
+        [
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+        ],
+        MyEntity,
+      );
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should error if no matching keys are found', () => {
+    class MyData {
+      readonly name: string = '';
+    }
+    // @ts-expect-error
+    class MyEntity extends schema.Entity(MyData, { pk: 'e' }) {}
+
+    expect(() =>
+      normalize(
+        {
+          name: 0,
+        },
+        MyEntity,
+      ),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should allow many unexpected as long as none are missing', () => {
+    class MyData {
+      readonly name: string = '';
+      readonly a: string = '';
+    }
+    class MyEntity extends schema.Entity(MyData, { pk: 'name' }) {}
+
+    expect(
+      normalize(
+        {
+          name: 'hi',
+          a: 'a',
+          b: 'b',
+          c: 'c',
+          d: 'e',
+          e: 0,
+          f: 0,
+          g: 0,
+          h: 0,
+          i: 0,
+          j: 0,
+          k: 0,
+          l: 0,
+          m: 0,
+          n: 0,
+          o: 0,
+          p: 0,
+          q: 0,
+          r: 0,
+          s: 0,
+          t: 0,
+          u: 0,
+        },
+        MyEntity,
+      ),
+    ).toMatchSnapshot();
+    expect(warnSpy.mock.calls.length).toBe(0);
+  });
+
+  it('should not expect getters returned', () => {
+    class MyData {
+      readonly name: string = '';
+      get other() {
+        return this.name + 5;
+      }
+
+      get another() {
+        return 'another';
+      }
+
+      get yetAnother() {
+        return 'another2';
+      }
+    }
+    class MyEntity extends schema.Entity(MyData, { pk: 'name' }) {}
+    function normalizeBad() {
+      normalize({ name: 'bob' }, MyEntity);
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(warnSpy.mock.calls.length).toBe(0);
+  });
+
+  it('should throw a custom error if data loads with string', () => {
+    class MyData {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      pk() {
+        return this.name;
+      }
+    }
+    const MyEntity = schema.Entity(MyData);
+    function normalizeBad() {
+      normalize('hibho', { data: MyEntity });
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  describe('key', () => {
+    test('key name must be a string', () => {
+      class MyData {
+        id = '';
+      }
+      // @ts-expect-error
+      class MyEntity extends schema.Entity(MyData) {
+        static get key() {
+          return 42;
+        }
+      }
+    });
+  });
+
+  describe('pk()', () => {
+    test('can use a custom pk() string', () => {
+      class User {
+        readonly idStr: string = '';
+        readonly name: string = '';
+      }
+      const UserEntity = schema.Entity(User, { pk: 'idStr' });
+      expect(
+        normalize({ idStr: '134351', name: 'Kathy' }, UserEntity),
+      ).toMatchSnapshot();
+    });
+
+    test('can normalize entity IDs based on their object key', () => {
+      class User {
+        readonly name: string = '';
+      }
+      const UserEntity = schema.Entity(User, {
+        pk(value, parent, key) {
+          return key;
+        },
+      });
+
+      const inputSchema = new schema.Values(
+        { users: UserEntity },
+        () => 'users',
+      );
+
+      expect(
+        normalize(
+          { '4': { name: 'taco' }, '56': { name: 'burrito' } },
+          inputSchema,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    test("can build the entity's ID from the parent object", () => {
+      class User {
+        readonly id: string = '';
+        readonly name: string = '';
+      }
+      const UserEntity = schema.Entity(User, {
+        pk(value, parent, key) {
+          return `${parent.name}-${key}-${value.id}`;
+        },
+      });
+
+      const inputSchema = new schema.Object({ user: UserEntity });
+
+      expect(
+        normalize(
+          { name: 'tacos', user: { id: '4', name: 'Jimmy' } },
+          inputSchema,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('mergeStrategy', () => {
+    test('defaults to plain merging', () => {
+      expect(
+        normalize(
+          [
+            { id: '1', name: 'foo' },
+            { id: '1', name: 'bar', alias: 'bar' },
+          ],
+          [Tacos],
+        ),
+      ).toMatchSnapshot();
+    });
+
+    test('can use a custom merging strategy', () => {
+      class MergeTaco extends Tacos {
+        static merge(existing: any, incoming: any) {
+          const props = Object.assign({}, existing, incoming, {
+            name: (existing as MergeTaco).name,
+          });
+          return this.fromJS(props);
+        }
+      }
+
+      expect(
+        normalize(
+          [
+            { id: '1', name: 'foo' },
+            { id: '1', name: 'bar', alias: 'bar' },
+          ],
+          [MergeTaco],
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('process', () => {
+    test('can use a custom processing strategy', () => {
+      class ProcessTaco extends Tacos {
+        readonly slug: string = '';
+        static process(input: any, parent: any, key: string | undefined): any {
+          return {
+            ...input,
+            slug: `thing-${(input as unknown as ProcessTaco).id}`,
+          };
+        }
+      }
+      const { entities, result } = normalize(
+        { id: '1', name: 'foo' },
+        ProcessTaco,
+      );
+      const [final] = denormalize(result, ProcessTaco, entities);
+      expect(final?.slug).toEqual('thing-1');
+      expect(final).toMatchSnapshot();
+    });
+
+    test('can use information from the parent in the process strategy', () => {
+      class Child {
+        id = '';
+        readonly content: string = '';
+        readonly parentId: string = '';
+        readonly parentKey: string = '';
+      }
+      class ChildEntity extends schema.Entity(Child) {
+        static process(input: any, parent: any, key: string | undefined): any {
+          return {
+            ...input,
+            parentId: parent?.id,
+            parentKey: key,
+          };
+        }
+      }
+      class Parent {
+        id = '';
+        readonly content: string = '';
+        readonly child: ChildEntity = ChildEntity.fromJS({});
+      }
+      const ParentEntity = schema.Entity(Parent, {
+        schema: { child: ChildEntity },
+      });
+
+      const { entities, result } = normalize(
+        {
+          id: '1',
+          content: 'parent',
+          child: { id: '4', content: 'child' },
+        },
+        ParentEntity,
+      );
+      const [final] = denormalize(result, ParentEntity, entities);
+      expect(final?.child?.parentId).toEqual('1');
+      expect(final).toMatchSnapshot();
+    });
+
+    test('is run before and passed to the schema denormalization', () => {
+      class AttachmentsEntity extends schema.Entity(
+        class {
+          id = '';
+        },
+      ) {}
+      expect(AttachmentsEntity.key).toBe('AttachmentsEntity');
+      class Entries {
+        id = '';
+        readonly type: string = '';
+      }
+      class EntriesEntity extends schema.Entity(Entries) {
+        static schema = {
+          data: { attachment: AttachmentsEntity },
+        };
+
+        static process(input: any, parent: any, key: string | undefined): any {
+          return {
+            ...values(input)[0],
+            type: Object.keys(input)[0],
+          };
+        }
+      }
+
+      const { entities, result } = normalize(
+        { message: { id: '123', data: { attachment: { id: '456' } } } },
+        EntriesEntity,
+      );
+      const [final] = denormalize(result, EntriesEntity, entities);
+      expect(final?.type).toEqual('message');
+      expect(final).toMatchSnapshot();
+    });
+  });
+});
+
+describe(`${schema.Entity.name} denormalization`, () => {
+  test('denormalizes an entity', () => {
+    const entities = {
+      Tacos: {
+        '1': { id: '1', name: 'foo' },
+      },
+    };
+    expect(denormalize('1', Tacos, entities)).toMatchSnapshot();
+    expect(denormalize('1', Tacos, fromJS(entities))).toMatchSnapshot();
+  });
+
+  class Food extends schema.Entity(
+    class {
+      id = '';
+    },
+  ) {}
+  class MenuData {
+    id = '';
+    readonly food: Food = Food.fromJS();
+  }
+  class Menu extends schema.Entity(MenuData, { schema: { food: Food } }) {}
+
+  test('denormalizes deep entities', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '1' },
+        '2': { id: '2' },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+
+    const de1 = denormalize('1', Menu, entities);
+    expect(de1).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toEqual(de1);
+
+    const de2 = denormalize('2', Menu, entities);
+    expect(de2).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toEqual(de2);
+  });
+
+  test('denormalizes deep entities while maintaining referential equality', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '1' },
+        '2': { id: '2' },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+    const entityCache = {};
+    const resultCache = new WeakEntityMap();
+
+    const [first] = denormalize('1', Menu, entities, entityCache, resultCache);
+    const [second] = denormalize('1', Menu, entities, entityCache, resultCache);
+    expect(first).toBe(second);
+    expect(first?.food).toBe(second?.food);
+  });
+
+  test('denormalizes to undefined when validate() returns string', () => {
+    class MyTacos extends Tacos {
+      static validate(entity) {
+        if (!Object.hasOwn(entity, 'name')) return 'no name';
+      }
+    }
+    const entities = {
+      MyTacos: {
+        '1': { id: '1' },
+      },
+    };
+    expect(denormalize('1', MyTacos, entities)).toStrictEqual([
+      undefined,
+      false,
+      true,
+    ]);
+    expect(denormalize('1', MyTacos, fromJS(entities))).toStrictEqual([
+      undefined,
+      false,
+      true,
+    ]);
+  });
+
+  test('denormalizes to undefined for missing data', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '2' },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  it('should handle optional schema entries Entity', () => {
+    class MyData {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly blarb: Date | undefined = undefined;
+    }
+    class MyEntity extends schema.Entity(MyData, {
+      pk: 'name',
+      schema: { blarb: Date },
+    }) {}
+
+    expect(
+      denormalize('bob', MyEntity, {
+        MyEntity: { bob: { name: 'bob', secondthing: 'hi' } },
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        MyEntity {
+          "blarb": undefined,
+          "name": "bob",
+          "secondthing": "hi",
+        },
+        true,
+        false,
+      ]
+    `);
+  });
+
+  it('should handle null schema entries Entity', () => {
+    class MyData {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly blarb: Date | null = null;
+    }
+    class MyEntity extends schema.Entity(MyData, {
+      pk: 'name',
+      schema: { blarb: Date },
+    }) {}
+
+    expect(
+      denormalize('bob', MyEntity, {
+        MyEntity: { bob: { name: 'bob', secondthing: 'hi', blarb: null } },
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        MyEntity {
+          "blarb": null,
+          "name": "bob",
+          "secondthing": "hi",
+        },
+        true,
+        false,
+      ]
+    `);
+  });
+
+  test('denormalizes to undefined for deleted data', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '2' },
+        '2': DELETED,
+      },
+      Food: {
+        '1': { id: '1' },
+        '2': DELETED,
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  test('denormalizes deep entities with records', () => {
+    const Food = Record<{ id: null | string }>({ id: null });
+    const MenuR = Record<{ id: null | string; food: null | string }>({
+      id: null,
+      food: null,
+    });
+
+    const entities = {
+      Menu: {
+        '1': new MenuR({ id: '1', food: '1' }),
+        '2': new MenuR({ id: '2' }),
+      },
+      Food: {
+        '1': new Food({ id: '1' }),
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  test('can denormalize already partially denormalized data', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: { id: '1' } },
+      },
+      Food: {
+        // TODO: BREAKING CHANGE: Update this to use main entity and only return nested as 'fallback' in case main entity is not set
+        '1': { id: '1', extra: 'hi' },
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  describe('nesting', () => {
+    class UserData {
+      id = '';
+      readonly role = '';
+      readonly reports: Report[] = [];
+    }
+    class User extends schema.Entity(UserData) {}
+    class ReportData {
+      id = '';
+      readonly title: string = '';
+      readonly draftedBy: User = User.fromJS();
+      readonly publishedBy: User = User.fromJS();
+    }
+    class Report extends schema.Entity(ReportData, {
+      schema: {
+        draftedBy: User,
+        publishedBy: User,
+      },
+    }) {}
+    User.schema = {
+      reports: [Report],
+    };
+    class CommentData {
+      id = '';
+      readonly body: string = '';
+      readonly author: User = User.fromJS();
+    }
+    class Comment extends schema.Entity(CommentData, {
+      schema: { author: User },
+    }) {}
+
+    test('denormalizes recursive dependencies', () => {
+      const entities = {
+        Report: {
+          '123': {
+            id: '123',
+            title: 'Weekly report',
+            draftedBy: '456',
+            publishedBy: '456',
+          },
+        },
+        User: {
+          '456': {
+            id: '456',
+            role: 'manager',
+            reports: ['123'],
+          },
+        },
+      };
+
+      expect(denormalize('123', Report, entities)[0]).toMatchSnapshot();
+      expect(denormalize('123', Report, fromJS(entities))[0]).toMatchSnapshot();
+
+      expect(denormalize('456', User, entities)[0]).toMatchSnapshot();
+      expect(denormalize('456', User, fromJS(entities))[0]).toMatchSnapshot();
+    });
+
+    test('denormalizes recursive entities with referential equality', () => {
+      const entities = {
+        Report: {
+          '123': {
+            id: '123',
+            title: 'Weekly report',
+            draftedBy: '456',
+            publishedBy: '456',
+          },
+        },
+        Comment: {
+          '999': {
+            id: '999',
+            body: 'Good morning',
+            author: '456',
+          },
+        },
+        User: {
+          '456': {
+            id: '456',
+            role: 'manager',
+            reports: ['123'],
+          },
+          '457': {
+            id: '457',
+            role: 'servant',
+            reports: ['123'],
+          },
+        },
+      };
+      const entityCache: any = {};
+      const resultCache = new WeakEntityMap();
+
+      const [denormalizedReport] = denormalize(
+        '123',
+        Report,
+        entities,
+        entityCache,
+        resultCache,
+      );
+
+      expect(denormalizedReport).toBeDefined();
+      // This is just for TypeScript, the above line actually determines this
+      if (!denormalizedReport) throw new Error('expected to be defined');
+      expect(denormalizedReport).toBe(denormalizedReport.draftedBy?.reports[0]);
+      expect(denormalizedReport.publishedBy).toBe(denormalizedReport.draftedBy);
+      expect(denormalizedReport.draftedBy?.reports[0].draftedBy).toBe(
+        denormalizedReport.draftedBy,
+      );
+
+      const [denormalizedReport2] = denormalize(
+        '123',
+        Report,
+        entities,
+        entityCache,
+        resultCache,
+      );
+
+      expect(denormalizedReport2).toStrictEqual(denormalizedReport);
+      expect(denormalizedReport2).toBe(denormalizedReport);
+      // NOTE: Given how immutable data works, referential equality can't be
+      // maintained with nested denormalization.
+    });
+
+    test('denormalizes maintain referential equality when appropriate', () => {
+      const entities = {
+        Report: {
+          '123': {
+            id: '123',
+            title: 'Weekly report',
+            draftedBy: '456',
+            publishedBy: '456',
+          },
+        },
+        Comment: {
+          '999': {
+            id: '999',
+            body: 'Good morning',
+            author: '456',
+          },
+        },
+        User: {
+          '456': {
+            id: '456',
+            role: 'manager',
+            reports: ['123'],
+          },
+          '457': {
+            id: '457',
+            role: 'servant',
+            reports: ['123'],
+          },
+        },
+      };
+      const entityCache: any = {};
+      const resultCache = new WeakEntityMap();
+
+      const input = { report: '123', comment: '999' };
+      const schema = {
+        report: Report,
+        comment: Comment,
+      };
+
+      const [denormalizedReport] = denormalize(
+        input,
+        schema,
+        entities,
+        entityCache,
+        resultCache,
+      );
+
+      expect(denormalizedReport.report).toBeDefined();
+      expect(denormalizedReport.comment).toBeDefined();
+      // This is just for TypeScript, the above line actually determines this
+      if (!denormalizedReport.report || !denormalizedReport.comment)
+        throw new Error('expected to be defined');
+      expect(denormalizedReport.report.publishedBy).toBe(
+        denormalizedReport.comment.author,
+      );
+
+      const [denormalizedReport2] = denormalize(
+        input,
+        schema,
+        entities,
+        entityCache,
+        resultCache,
+      );
+
+      expect(denormalizedReport2).toStrictEqual(denormalizedReport);
+      expect(denormalizedReport2).toBe(denormalizedReport);
+
+      // should update all uses of user
+      const nextEntities = {
+        ...entities,
+        User: {
+          ...entities.User,
+          '456': {
+            ...entities.User[456],
+            role: 'supervisor',
+          },
+        },
+      };
+
+      const [denormalizedReport3] = denormalize(
+        input,
+        schema,
+        nextEntities,
+        entityCache,
+        resultCache,
+      );
+
+      expect(denormalizedReport3.comment?.author?.role).toBe('supervisor');
+      expect(denormalizedReport3.report?.draftedBy?.role).toBe('supervisor');
+      // NOTE: Given how immutable data works, referential equality can't be
+      // maintained with nested denormalization.
+    });
+
+    describe('optional entities', () => {
+      it('should be marked as found even when optional is not there', () => {
+        const [denormalized, found] = denormalize('abc', WithOptional, {
+          [WithOptional.key]: {
+            abc: {
+              id: 'abc',
+              // this is typed because we're actually sending wrong data to it
+              requiredArticle: '5' as any,
+              nextPage: 'blob',
+            },
+          },
+          [ArticleEntity.key]: {
+            ['5']: { id: '5' },
+          },
+        });
+        expect(found).toBe(true);
+        const response = denormalized;
+        expect(response).toBeDefined();
+        expect(response).toBeInstanceOf(WithOptional);
+        expect(response).toEqual({
+          id: 'abc',
+          article: null,
+          requiredArticle: ArticleEntity.fromJS({ id: '5' }),
+          nextPage: 'blob',
+        });
+      });
+
+      it('should be marked as found when nested entity is missing', () => {
+        const [denormalized, found, deleted] = denormalize(
+          'abc',
+          WithOptional,
+          {
+            [WithOptional.key]: {
+              abc: WithOptional.fromJS({
+                id: 'abc',
+                // this is typed because we're actually sending wrong data to it
+                article: '5' as any,
+                nextPage: 'blob',
+              }),
+            },
+            [ArticleEntity.key]: {
+              ['5']: ArticleEntity.fromJS({ id: '5' }),
+            },
+          },
+        );
+        expect(found).toBe(true);
+        expect(deleted).toBe(false);
+        const response = denormalized;
+        expect(response).toBeDefined();
+        expect(response).toBeInstanceOf(WithOptional);
+        expect(response).toEqual({
+          id: 'abc',
+          article: ArticleEntity.fromJS({ id: '5' }),
+          requiredArticle: ArticleEntity.fromJS(),
+          nextPage: 'blob',
+        });
+      });
+
+      it('should be marked as deleted when required entity is deleted symbol', () => {
+        const [denormalized, found, deleted] = denormalize(
+          'abc',
+          WithOptional,
+          {
+            [WithOptional.key]: {
+              abc: {
+                id: 'abc',
+                // this is typed because we're actually sending wrong data to it
+                requiredArticle: '5' as any,
+                nextPage: 'blob',
+              },
+            },
+            [ArticleEntity.key]: {
+              ['5']: DELETED,
+            },
+          },
+        );
+        expect(found).toBe(true);
+        expect(deleted).toBe(true);
+        const response = denormalized;
+        expect(response).toBeDefined();
+        expect(response).toBeInstanceOf(WithOptional);
+        expect(response).toEqual({
+          id: 'abc',
+          article: null,
+          requiredArticle: undefined,
+          nextPage: 'blob',
+        });
+      });
+
+      it('should be non-required deleted members should not result in deleted indicator', () => {
+        const [denormalized, found, deleted] = denormalize(
+          'abc',
+          WithOptional,
+          {
+            [WithOptional.key]: {
+              abc: WithOptional.fromJS({
+                id: 'abc',
+                // this is typed because we're actually sending wrong data to it
+                article: '5' as any,
+                requiredArticle: '6' as any,
+                nextPage: 'blob',
+              }),
+            },
+            [ArticleEntity.key]: {
+              ['5']: DELETED,
+              ['6']: ArticleEntity.fromJS({ id: '6' }),
+            },
+          },
+        );
+        expect(found).toBe(true);
+        expect(deleted).toBe(false);
+        const response = denormalized;
+        expect(response).toBeDefined();
+        expect(response).toBeInstanceOf(WithOptional);
+        expect(response).toEqual({
+          id: 'abc',
+          article: undefined,
+          requiredArticle: ArticleEntity.fromJS({ id: '6' }),
+          nextPage: 'blob',
+        });
+      });
+
+      it('should be both deleted and not found when both are true in different parts of schema', () => {
+        const [denormalized, found, deleted] = denormalize(
+          { data: 'abc' },
+          { data: WithOptional, other: ArticleEntity },
+          {
+            [WithOptional.key]: {
+              abc: WithOptional.fromJS({
+                id: 'abc',
+                // this is typed because we're actually sending wrong data to it
+                article: '6' as any,
+                requiredArticle: '5' as any,
+                nextPage: 'blob',
+              }),
+            },
+            [ArticleEntity.key]: {
+              ['5']: DELETED,
+              ['6']: ArticleEntity.fromJS({ id: '6' }),
+            },
+          },
+        );
+        expect(found).toBe(false);
+        expect(deleted).toBe(true);
+        const response = denormalized;
+        expect(response).toBeDefined();
+        expect(response).toEqual({
+          data: {
+            id: 'abc',
+            article: ArticleEntity.fromJS({ id: '6' }),
+            requiredArticle: undefined,
+            nextPage: 'blob',
+          },
+        });
+      });
+    });
+  });
+});
+
+describe('Entity.defaults', () => {
+  it('should work with inheritance', () => {
+    abstract class DefaultsEntity extends schema.Entity(
+      class {
+        id = '';
+      },
+    ) {
+      static getMyDefaults() {
+        return this.defaults;
+      }
+    }
+
+    class ID extends DefaultsEntity {
+      id = '';
+      pk() {
+        return this.id;
+      }
+    }
+    class UserEntity extends ID {
+      username = '';
+      createdAt = new Date(0);
+
+      static schema = {
+        createdAt: Date,
+      };
+    }
+
+    expect(ID.getMyDefaults()).toMatchInlineSnapshot(`
+      ID {
+        "id": "",
+      }
+    `);
+    expect(UserEntity.getMyDefaults()).toMatchInlineSnapshot(`
+      UserEntity {
+        "createdAt": 1970-01-01T00:00:00.000Z,
+        "id": "",
+        "username": "",
+      }
+    `);
+  });
+});

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
@@ -666,7 +666,7 @@ exports[`Entity normalization should throw a custom error if data does not inclu
   This is likely due to a malformed response.
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
   Entity: MyEntity
   Value (processed): {
@@ -699,7 +699,7 @@ exports[`Entity normalization should throw a custom error if data loads with no 
   This is likely due to a malformed response.
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
   Entity: MyEntity
   Value (processed): {}
@@ -724,7 +724,7 @@ exports[`Entity normalization should throw a custom error if schema key is missi
 
   Be sure all schema members are also part of the entity
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about nesting schemas: https://resthooks.io/docs/guides/nested-response
+  Learn more about nesting schemas: https://resthooks.io/rest/guides/nested-response
 
   Entity keys: name,secondthing
   Schema key(missing): blarb

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
@@ -1,0 +1,662 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntitySchema denormalization can denormalize already partially denormalized data 1`] = `
+[
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization can denormalize already partially denormalized data 2`] = `
+[
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes an entity 1`] = `
+[
+  Tacos {
+    "alias": undefined,
+    "id": "1",
+    "name": "foo",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes an entity 2`] = `
+[
+  Tacos {
+    "alias": undefined,
+    "id": "1",
+    "name": "foo",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities 1`] = `
+[
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities 2`] = `
+[
+  Menu {
+    "food": Food {
+      "id": "",
+    },
+    "id": "2",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 1`] = `
+[
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 2`] = `
+[
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 3`] = `
+[
+  Menu {
+    "food": null,
+    "id": "2",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 4`] = `
+[
+  Menu {
+    "food": null,
+    "id": "2",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for deleted data 1`] = `
+[
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  true,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for deleted data 2`] = `
+[
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  true,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for deleted data 3`] = `
+[
+  undefined,
+  true,
+  true,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for deleted data 4`] = `
+[
+  undefined,
+  true,
+  true,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 1`] = `
+[
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 2`] = `
+[
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 3`] = `
+[
+  undefined,
+  false,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 4`] = `
+[
+  undefined,
+  false,
+  false,
+]
+`;
+
+exports[`EntitySchema denormalization nesting denormalizes recursive dependencies 1`] = `
+Report {
+  "draftedBy": User {
+    "id": "456",
+    "reports": [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "id": "123",
+  "publishedBy": User {
+    "id": "456",
+    "reports": [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "title": "Weekly report",
+}
+`;
+
+exports[`EntitySchema denormalization nesting denormalizes recursive dependencies 2`] = `
+Report {
+  "draftedBy": User {
+    "id": "456",
+    "reports": Immutable.List [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "id": "123",
+  "publishedBy": User {
+    "id": "456",
+    "reports": Immutable.List [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "title": "Weekly report",
+}
+`;
+
+exports[`EntitySchema denormalization nesting denormalizes recursive dependencies 3`] = `
+User {
+  "id": "456",
+  "reports": [
+    Report {
+      "draftedBy": [Circular],
+      "id": "123",
+      "publishedBy": [Circular],
+      "title": "Weekly report",
+    },
+  ],
+  "role": "manager",
+}
+`;
+
+exports[`EntitySchema denormalization nesting denormalizes recursive dependencies 4`] = `
+User {
+  "id": "456",
+  "reports": Immutable.List [
+    Report {
+      "draftedBy": [Circular],
+      "id": "123",
+      "publishedBy": [Circular],
+      "title": "Weekly report",
+    },
+  ],
+  "role": "manager",
+}
+`;
+
+exports[`EntitySchema normalization mergeStrategy can use a custom merging strategy 1`] = `
+{
+  "entities": {
+    "MergeTaco": {
+      "1": MergeTaco {
+        "alias": "bar",
+        "id": "1",
+        "name": "foo",
+      },
+    },
+  },
+  "entityMeta": {
+    "MergeTaco": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    "1",
+    "1",
+  ],
+}
+`;
+
+exports[`EntitySchema normalization mergeStrategy defaults to plain merging 1`] = `
+{
+  "entities": {
+    "Tacos": {
+      "1": {
+        "alias": "bar",
+        "id": "1",
+        "name": "bar",
+      },
+    },
+  },
+  "entityMeta": {
+    "Tacos": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    "1",
+    "1",
+  ],
+}
+`;
+
+exports[`EntitySchema normalization normalizes already processed entities 1`] = `
+{
+  "entities": {},
+  "entityMeta": {},
+  "indexes": {},
+  "result": [
+    "1",
+  ],
+}
+`;
+
+exports[`EntitySchema normalization normalizes already processed entities 2`] = `
+{
+  "entities": {},
+  "entityMeta": {},
+  "indexes": {},
+  "result": {
+    "data": "1",
+  },
+}
+`;
+
+exports[`EntitySchema normalization normalizes already processed entities 3`] = `
+{
+  "entities": {
+    "Nested": {
+      "5": {
+        "id": "5",
+        "nest": "10",
+        "title": "hi",
+      },
+    },
+  },
+  "entityMeta": {
+    "Nested": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "5",
+}
+`;
+
+exports[`EntitySchema normalization normalizes an entity 1`] = `
+{
+  "entities": {
+    "MyEntity": {
+      "1": {
+        "id": "1",
+      },
+    },
+  },
+  "entityMeta": {
+    "MyEntity": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "1",
+}
+`;
+
+exports[`EntitySchema normalization pk() can build the entity's ID from the parent object 1`] = `
+{
+  "entities": {
+    "User": {
+      "tacos-user-4": {
+        "id": "4",
+        "name": "Jimmy",
+      },
+    },
+  },
+  "entityMeta": {
+    "User": {
+      "tacos-user-4": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": {
+    "name": "tacos",
+    "user": "tacos-user-4",
+  },
+}
+`;
+
+exports[`EntitySchema normalization pk() can normalize entity IDs based on their object key 1`] = `
+{
+  "entities": {
+    "User": {
+      "4": {
+        "name": "taco",
+      },
+      "56": {
+        "name": "burrito",
+      },
+    },
+  },
+  "entityMeta": {
+    "User": {
+      "4": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "56": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": {
+    "4": {
+      "id": "4",
+      "schema": "users",
+    },
+    "56": {
+      "id": "56",
+      "schema": "users",
+    },
+  },
+}
+`;
+
+exports[`EntitySchema normalization pk() can use a custom pk() string 1`] = `
+{
+  "entities": {
+    "User": {
+      "134351": {
+        "idStr": "134351",
+        "name": "Kathy",
+      },
+    },
+  },
+  "entityMeta": {
+    "User": {
+      "134351": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "134351",
+}
+`;
+
+exports[`EntitySchema normalization process can use a custom processing strategy 1`] = `
+ProcessTaco {
+  "alias": undefined,
+  "id": "1",
+  "name": "foo",
+  "slug": "thing-1",
+}
+`;
+
+exports[`EntitySchema normalization process can use information from the parent in the process strategy 1`] = `
+EntityMixin {
+  "child": ChildEntity {
+    "content": "child",
+    "id": "4",
+    "parentId": "1",
+    "parentKey": "child",
+  },
+  "content": "parent",
+  "id": "1",
+}
+`;
+
+exports[`EntitySchema normalization process is run before and passed to the schema denormalization 1`] = `
+EntriesEntity {
+  "data": {
+    "attachment": AttachmentsEntity {
+      "id": "456",
+    },
+  },
+  "id": "123",
+  "type": "message",
+}
+`;
+
+exports[`EntitySchema normalization should allow many unexpected as long as none are missing 1`] = `
+{
+  "entities": {
+    "MyEntity": {
+      "hi": {
+        "a": "a",
+        "b": "b",
+        "c": "c",
+        "d": "e",
+        "e": 0,
+        "f": 0,
+        "g": 0,
+        "h": 0,
+        "i": 0,
+        "j": 0,
+        "k": 0,
+        "l": 0,
+        "m": 0,
+        "n": 0,
+        "name": "hi",
+        "o": 0,
+        "p": 0,
+        "q": 0,
+        "r": 0,
+        "s": 0,
+        "t": 0,
+        "u": 0,
+      },
+    },
+  },
+  "entityMeta": {
+    "MyEntity": {
+      "hi": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "hi",
+}
+`;
+
+exports[`EntitySchema normalization should error if no matching keys are found 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
+
+  Entity: MyEntity
+  Value (processed): {
+  "name": 0
+}
+  "
+`;
+
+exports[`EntitySchema normalization should throw a custom error if data does not include pk 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
+
+  Entity: EntityMixin
+  Value (processed): {
+  "secondthing": "hi"
+}
+  "
+`;
+
+exports[`EntitySchema normalization should throw a custom error if data loads with no matching props 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
+
+  Entity: EntityMixin
+  Value (processed): {}
+  "
+`;
+
+exports[`EntitySchema normalization should throw a custom error if data loads with string 1`] = `
+"Unexpected input given to normalize. Expected type to be "object", found "string".
+
+          Schema: {
+  "data": {
+    "name": "EntityMixin",
+    "schema": {},
+    "key": "MyData"
+  }
+}
+          Input: "hibho""
+`;
+
+exports[`EntitySchema normalization should throw a custom error if schema key is missing from Entity 1`] = `
+"Schema key is missing in Entity
+
+  Be sure all schema members are also part of the entity
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about nesting schemas: https://resthooks.io/rest/guides/nested-response
+
+  Entity keys: name,secondthing
+  Schema key(missing): blarb
+  "
+`;
+
+exports[`EntitySchema normalization should throw a custom error loads with array 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
+
+  Entity: EntityMixin
+  Value (processed): {
+  "0": {
+    "name": "hi",
+    "secondthing": "ho"
+  },
+  "1": {
+    "name": "hi",
+    "secondthing": "ho"
+  },
+  "2": {
+    "name": "hi",
+    "secondthing": "ho"
+  }
+}
+  "
+`;

--- a/packages/endpoint/src/schemas/__tests__/legacy-compat/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/legacy-compat/__snapshots__/Entity.test.ts.snap
@@ -688,7 +688,7 @@ exports[`Entity normalization should throw a custom error if data does not inclu
   This is likely due to a malformed response.
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
   Entity: MyEntity
   Value (processed): {
@@ -721,7 +721,7 @@ exports[`Entity normalization should throw a custom error if data loads with no 
   This is likely due to a malformed response.
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
   Entity: MyEntity
   Value (processed): {}
@@ -746,7 +746,7 @@ exports[`Entity normalization should throw a custom error if schema key is missi
 
   Be sure all schema members are also part of the entity
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about nesting schemas: https://resthooks.io/docs/guides/nested-response
+  Learn more about nesting schemas: https://resthooks.io/rest/guides/nested-response
 
   Entity keys: name,secondthing
   Schema key(missing): blarb

--- a/packages/endpoint/src/schemas/__tests__/validateRequired.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/validateRequired.test.ts
@@ -31,7 +31,7 @@ class Tacos extends IDEntity {
   readonly name: string = '';
   readonly alias?: string = undefined;
 
-  protected static validate(processedEntity: any): string | undefined {
+  static validate(processedEntity: any): string | undefined {
     return validateRequired(processedEntity, exclude(this.defaults, ['alias']));
   }
 }
@@ -47,7 +47,7 @@ class MyEntity extends Entity {
     blarb: Date,
   };
 
-  protected static validate(processedEntity: any): string | undefined {
+  static validate(processedEntity: any): string | undefined {
     return validateRequired(processedEntity, exclude(this.defaults, ['blarb']));
   }
 }

--- a/packages/legacy/src/rest-3/__tests__/__snapshots__/resource.ts.snap
+++ b/packages/legacy/src/rest-3/__tests__/__snapshots__/resource.ts.snap
@@ -45,7 +45,7 @@ exports[`Resource nested schema should throw a custom error if data does not inc
   This is likely due to a malformed response.
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
   Entity: CoolerArticleResource
   Value (processed): {

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -12,7 +12,10 @@ export interface Path {
   pk: string;
 }
 
-export type AbstractInstanceType<T> = T extends { prototype: infer U }
+// TypeScript <4.2 InstanceType<> does not work on abstract classes
+export type AbstractInstanceType<T> = T extends new (...args: any) => infer U
+  ? U
+  : T extends { prototype: infer U }
   ? U
   : never;
 

--- a/packages/rest-hooks/src/selectors/useDenormalized.ts
+++ b/packages/rest-hooks/src/selectors/useDenormalized.ts
@@ -14,7 +14,7 @@ import { ReadShape, ParamsFromShape } from '../endpoint/index.js';
  * using params and schema. This increases cache hit rate for many
  * detail shapes.
  *
- * @returns [denormalizedValue, ready]
+ * @returns {denormalizedValue, expiryStatus,expiresAt}
  */
 export default function useDenormalized<
   Shape extends Pick<

--- a/website/sidebars-endpoint.json
+++ b/website/sidebars-endpoint.json
@@ -17,6 +17,10 @@
   },
   {
     "type": "doc",
+    "id": "api/schema.Entity"
+  },
+  {
+    "type": "doc",
     "id": "api/Object"
   },
   {

--- a/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
@@ -77,7 +77,7 @@ interface Path {
     key: string;
     pk: string;
 }
-type AbstractInstanceType<T> = T extends {
+type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
 type DenormalizeObject<S extends Record<string, any>> = {
@@ -166,7 +166,7 @@ interface SnapshotInterface {
 }
 
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): InferReturn<F, S>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -723,14 +723,14 @@ declare class Controller<D extends GenericDispatch = CompatibleDispatch> {
      * Fetches the endpoint with given args, updating the Rest Hooks cache with the response or error upon completion.
      * @see https://resthooks.io/docs/api/Controller#fetch
      */
-    fetch: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined> & {
+    fetch: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E, Record<string, any>> | undefined;
     }>(endpoint: E, ...args_0: Parameters<E>) => ReturnType<E>;
     /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://resthooks.io/docs/api/Controller#invalidate
      */
-    invalidate: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) => Promise<void>;
+    invalidate: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) => Promise<void>;
     /**
      * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
      * @see https://resthooks.io/docs/api/Controller#invalidateAll
@@ -747,35 +747,35 @@ declare class Controller<D extends GenericDispatch = CompatibleDispatch> {
      * Stores response in cache for given Endpoint and args.
      * @see https://resthooks.io/docs/api/Controller#set
      */
-    setResponse: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined> & {
+    setResponse: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E, Record<string, any>> | undefined;
     }>(endpoint: E, ...rest: readonly [...Parameters<E>, any]) => Promise<void>;
     /**
      * Another name for setResponse
      * @see https://resthooks.io/docs/api/Controller#setResponse
      */
-    receive: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined> & {
+    receive: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E, Record<string, any>> | undefined;
     }>(endpoint: E, ...rest: readonly [...Parameters<E>, any]) => Promise<void>;
     /**
      * Stores the result of Endpoint and args as the error provided.
      * @see https://resthooks.io/docs/api/Controller#setError
      */
-    setError: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined> & {
+    setError: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E, Record<string, any>> | undefined;
     }>(endpoint: E, ...rest: readonly [...Parameters<E>, Error]) => Promise<void>;
     /**
      * Another name for setError
      * @see https://resthooks.io/docs/api/Controller#setError
      */
-    receiveError: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined> & {
+    receiveError: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E, Record<string, any>> | undefined;
     }>(endpoint: E, ...rest: readonly [...Parameters<E>, Error]) => Promise<void>;
     /**
      * Resolves an inflight fetch. `fetchedAt` should `fetch`'s `createdAt`
      * @see https://resthooks.io/docs/api/Controller#resolve
      */
-    resolve: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined> & {
+    resolve: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E, Record<string, any>> | undefined;
     }>(endpoint: E, meta: {
         args: readonly [...Parameters<E>];
@@ -792,24 +792,24 @@ declare class Controller<D extends GenericDispatch = CompatibleDispatch> {
      * Marks a new subscription to a given Endpoint.
      * @see https://resthooks.io/docs/api/Controller#subscribe
      */
-    subscribe: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, undefined>>(endpoint: E, ...args: readonly [null] | readonly [...Parameters<E>]) => Promise<void>;
+    subscribe: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, false | undefined>>(endpoint: E, ...args: readonly [null] | readonly [...Parameters<E>]) => Promise<void>;
     /**
      * Marks completion of subscription to a given Endpoint.
      * @see https://resthooks.io/docs/api/Controller#unsubscribe
      */
-    unsubscribe: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, undefined>>(endpoint: E, ...args: readonly [null] | readonly [...Parameters<E>]) => Promise<void>;
+    unsubscribe: <E extends EndpointInterface<FetchFunction<any, any>, Schema | undefined, false | undefined>>(endpoint: E, ...args: readonly [null] | readonly [...Parameters<E>]) => Promise<void>;
     /*************** More ***************/
     snapshot: (state: State<unknown>, fetchedAt?: number) => SnapshotInterface;
     /**
      * Gets the error, if any, for a given endpoint. Returns undefined for no errors.
      * @see https://resthooks.io/docs/api/Controller#getError
      */
-    getError: <E extends Pick<EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined>, "key">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => ErrorTypes | undefined;
+    getError: <E extends Pick<EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined>, "key">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => ErrorTypes | undefined;
     /**
      * Gets the (globally referentially stable) response for a given endpoint/args pair from state given.
      * @see https://resthooks.io/docs/api/Controller#getResponse
      */
-    getResponse: <E extends Pick<EndpointInterface<FetchFunction<any, any>, Schema | undefined, true | undefined>, "key" | "schema" | "invalidIfStale">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => {
+    getResponse: <E extends Pick<EndpointInterface<FetchFunction<any, any>, Schema | undefined, boolean | undefined>, "schema" | "key" | "invalidIfStale">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => {
         data: DenormalizeNullable<E["schema"]>;
         expiryStatus: ExpiryStatus;
         expiresAt: number;

--- a/website/src/components/Playground/editor-types/@rest-hooks/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/normalizr.d.ts
@@ -74,7 +74,7 @@ interface Path {
     key: string;
     pk: string;
 }
-type AbstractInstanceType<T> = T extends {
+type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
 type DenormalizeObject<S extends Record<string, any>> = {
@@ -222,7 +222,7 @@ interface SnapshotInterface {
 }
 
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): InferReturn<F, S>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -259,7 +259,7 @@ interface MutateEndpoint<F extends FetchFunction = FetchFunction, S extends Sche
     sideEffect: true;
 }
 /** For retrieval requests */
-type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined>;
+type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined | false>;
 
 type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Promise<R>;
 

--- a/website/src/components/Playground/editor-types/@rest-hooks/react.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/react.d.ts
@@ -118,7 +118,7 @@ interface EntityTable {
     } | undefined;
 }
 
-type AbstractInstanceType<T> = T extends {
+type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
 type DenormalizeObject<S extends Record<string, any>> = {
@@ -171,7 +171,7 @@ interface SnapshotInterface {
 }
 
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): InferReturn<F, S>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -208,7 +208,7 @@ type Denormalize<S> = Extract<S, EntityInterface> extends never ? Extract<S, Ent
 type DenormalizeNullable<S> = Extract<S, EntityInterface> extends never ? Extract<S, EntityInterface[]> extends never ? DenormalizeNullable$1<S> : DenormalizeNullable$1<Extract<S, EntityInterface[]>> : DenormalizeNullable$1<Extract<S, EntityInterface>>;
 
 type CondNull$1<P, A, B> = P extends null ? A : B;
-type SuspenseReturn<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]> = CondNull$1<Args[0], E['schema'] extends undefined | null ? undefined : DenormalizeNullable<E['schema']>, E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>>;
+type SuspenseReturn<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]> = CondNull$1<Args[0], E['schema'] extends undefined | null ? undefined : DenormalizeNullable<E['schema']>, E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>>;
 
 /**
  * Ensure an endpoint is available.
@@ -219,7 +219,7 @@ type SuspenseReturn<E extends EndpointInterface<FetchFunction, Schema | undefine
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
+declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
 
 /**
  * Access a response if it is available.
@@ -227,7 +227,7 @@ declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema |
  * `useCache` guarantees referential equality globally.
  * @see https://resthooks.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
 
 type ErrorTypes = NetworkError | UnknownError;
 type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;
@@ -241,13 +241,13 @@ declare function useError<E extends Pick<EndpointInterface, 'key'>, Args extends
  * Request a resource if it is not in cache.
  * @see https://resthooks.io/docs/api/useFetch
  */
-declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): ReturnType<E> | undefined;
+declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): ReturnType<E> | undefined;
 
 /**
  * Keeps a resource fresh by subscribing to updates.
  * @see https://resthooks.io/docs/api/useSubscription
  */
-declare function useSubscription<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): void;
+declare function useSubscription<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): void;
 
 type CondNull<P, A, B> = P extends null ? A : B;
 type StatefulReturn<S extends Schema | undefined, P> = CondNull<P, {
@@ -271,7 +271,7 @@ type StatefulReturn<S extends Schema | undefined, P> = CondNull<P, {
  * Use async date with { data, loading, error } (DLE)
  * @see https://resthooks.io/docs/api/useDLE
  */
-declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? {
+declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? {
     data: E extends (...args: any) => any ? ResolveType<E> | undefined : any;
     loading: boolean;
     error: ErrorTypes$1 | undefined;
@@ -291,7 +291,7 @@ declare function useController(): Controller;
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
+declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
 
 declare const StateContext: Context<State$1<unknown>>;
 /** @deprecated use Controller.dispatch */

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -1,4 +1,4 @@
-type AbstractInstanceType<T> = T extends {
+type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
 type DenormalizeObject<S extends Record<string, any>> = {
@@ -68,6 +68,107 @@ declare class Delete<E extends EntityInterface & {
         date: number;
         fetchedAt: number;
     }, existing: any, incoming: any): boolean;
+}
+
+type Constructor = abstract new (...args: any[]) => {};
+type IDClass = abstract new (...args: any[]) => {
+    id: string | number | undefined;
+};
+type PKClass = abstract new (...args: any[]) => {
+    pk(parent?: any, key?: string): string | undefined;
+};
+type ValidSchemas<TInstance> = {
+    [k in keyof TInstance]?: Schema;
+};
+interface EntityOptions<TInstance> {
+    readonly schema?: ValidSchemas<TInstance>;
+    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly key?: string;
+}
+interface RequiredPKOptions<TInstance> extends EntityOptions<TInstance> {
+    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+}
+interface IEntityClass<TBase extends Constructor = any> {
+    toJSON(): {
+        name: string;
+        schema: {
+            [k: string]: Schema;
+        };
+        key: string;
+    };
+    /** Defines nested entities */
+    schema: {
+        [k: string]: Schema;
+    };
+    /** Returns the globally unique identifier for the static Entity */
+    key: string;
+    /** Defines indexes to enable lookup by */
+    indexes?: readonly string[] | undefined;
+    /**
+     * A unique identifier for each Entity
+     *
+     * @param [value] POJO of the entity or subset used
+     * @param [parent] When normalizing, the object which included the entity
+     * @param [key] When normalizing, the key where this entity was found
+     */
+    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string): string | undefined;
+    /** Return true to merge incoming data; false keeps existing entity */
+    useIncoming(existingMeta: {
+        date: number;
+        fetchedAt: number;
+    }, incomingMeta: {
+        date: number;
+        fetchedAt: number;
+    }, existing: any, incoming: any): boolean;
+    cmpIncoming(existingMeta: {
+        date: number;
+        fetchedAt: number;
+    }, incomingMeta: {
+        date: number;
+        fetchedAt: number;
+    }, existing: any, incoming: any): number;
+    /** Creates new instance copying over defined values of arguments */
+    merge(existing: any, incoming: any): any;
+    /** Run when an existing entity is found in the store */
+    mergeWithStore(existingMeta: {
+        date: number;
+        fetchedAt: number;
+    }, incomingMeta: {
+        date: number;
+        fetchedAt: number;
+    }, existing: any, incoming: any): any;
+    /** Factory method to convert from Plain JS Objects.
+     *
+     * @param [props] Plain Object of properties to assign.
+     */
+    fromJS<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, props?: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T>;
+    /** Factory method to convert from Plain JS Objects.
+     *
+     * @param [props] Plain Object of properties to assign.
+     */
+    createIfValid<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, props: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T> | undefined;
+    /** Do any transformations when first receiving input */
+    process(input: any, parent: any, key: string | undefined): any;
+    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>): any;
+    validate(processedEntity: any): string | undefined;
+    infer(args: readonly any[], indexes: NormalizedIndex, recurse: any): any;
+    expiresAt(meta: {
+        expiresAt: number;
+        date: number;
+        fetchedAt: number;
+    }, input: any): number;
+    denormalize<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
+    /** All instance defaults set */
+    readonly defaults: any;
+}
+interface IEntityInstance {
+    /**
+     * A unique identifier for each Entity
+     *
+     * @param [parent] When normalizing, the object which included the entity
+     * @param [key] When normalizing, the key where this entity was found
+     */
+    pk(parent?: any, key?: string): string | undefined;
 }
 
 /**
@@ -363,6 +464,28 @@ interface SchemaClass$1<T = any, N = T | undefined>
   _denormalizeNullable(): [N, boolean, boolean];
 }
 
+// id is in Instance, so we default to that as pk
+/**
+ * Represents data that should be deduped by specifying a primary key.
+ * @see https://resthooks.io/docs/api/schema.Entity
+ */
+declare function Entity$1<TBase extends PKClass>(
+  Base: TBase,
+  opt?: EntityOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase;
+
+// id is in Instance, so we default to that as pk
+declare function Entity$1<TBase extends IDClass>(
+  Base: TBase,
+  opt?: EntityOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+
+// pk was specified in options, so we don't need to redefine
+declare function Entity$1<TBase extends Constructor>(
+  Base: TBase,
+  opt: RequiredPKOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+
 type schema_d_Delete<E extends EntityInterface & {
     process: any;
 }> = Delete<E>;
@@ -397,6 +520,7 @@ declare namespace schema_d {
     schema_d_SchemaAttributeFunction as SchemaAttributeFunction,
     schema_d_UnionResult as UnionResult,
     SchemaClass$1 as SchemaClass,
+    Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
   };
 }
@@ -717,22 +841,16 @@ type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [
     : never
   : Orig;
 
+declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
+    pk(parent?: any, key?: string | undefined): string | undefined;
+}> & (abstract new (...args: any[]) => {
+    pk(parent?: any, key?: string | undefined): string | undefined;
+});
 /**
  * Represents data that should be deduped by specifying a primary key.
  * @see https://resthooks.io/docs/api/Entity
  */
-declare abstract class Entity {
-    static toJSON(): {
-        name: string;
-        schema: {
-            [k: string]: Schema;
-        };
-        key: string;
-    };
-    /** Defines nested entities */
-    static schema: {
-        [k: string]: Schema;
-    };
+declare abstract class Entity extends Entity_base {
     /**
      * A unique identifier for each Entity
      *
@@ -740,10 +858,6 @@ declare abstract class Entity {
      * @param [key] When normalizing, the key where this entity was found
      */
     abstract pk(parent?: any, key?: string): string | undefined;
-    /** Returns the globally unique identifier for the static Entity */
-    static key: string;
-    /** Defines indexes to enable lookup by */
-    static indexes?: readonly string[];
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -753,14 +867,6 @@ declare abstract class Entity {
      * Note: this only applies to non-nested members.
      */
     protected static automaticValidation?: 'warn' | 'silent';
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [value] POJO of the entity or subset used
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     */
-    static pk<T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string): string | undefined;
     /** Return true to merge incoming data; false keeps existing entity */
     static useIncoming(existingMeta: {
         date: number;
@@ -769,8 +875,6 @@ declare abstract class Entity {
         date: number;
         fetchedAt: number;
     }, existing: any, incoming: any): boolean;
-    /** Creates new instance copying over defined values of arguments */
-    static merge(existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store */
     static mergeWithStore(existingMeta: {
         date: number;
@@ -783,28 +887,21 @@ declare abstract class Entity {
      *
      * @param [props] Plain Object of properties to assign.
      */
-    static fromJS<T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T>;
-    /** Factory method to convert from Plain JS Objects.
+    static fromJS: <T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>) => AbstractInstanceType<T>;
+    /**
+     * A unique identifier for each Entity
      *
-     * @param [props] Plain Object of properties to assign.
+     * @param [value] POJO of the entity or subset used
+     * @param [parent] When normalizing, the object which included the entity
+     * @param [key] When normalizing, the key where this entity was found
      */
-    static createIfValid<T extends typeof Entity>(this: T, props: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T> | undefined;
+    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string) => string | undefined;
     /** Do any transformations when first receiving input */
     static process(input: any, parent: any, key: string | undefined): any;
-    static normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>): any;
-    protected static validate(processedEntity: any): string | undefined;
-    static infer(args: readonly any[], indexes: NormalizedIndex, recurse: any): any;
-    static expiresAt(meta: {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    }, input: any): number;
+    static validate(processedEntity: any): string | undefined;
     static denormalize<T extends typeof Entity>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
-    private static __defaults;
-    /** All instance defaults set */
-    protected static get defaults(): any;
     /** Used by denormalize to set nested members */
-    protected static set(entity: any, key: string, value: any): void;
+    protected static set?(entity: any, key: string, value: any): void;
 }
 
 declare function validateRequired(processedEntity: any, requiredDefaults: Record<string, unknown>): string | undefined;

--- a/website/src/components/Playground/editor-types/rest-hooks.d.ts
+++ b/website/src/components/Playground/editor-types/rest-hooks.d.ts
@@ -4,7 +4,7 @@ export { AbstractInstanceType, ActionTypes, Controller, DefaultConnectionListene
 import React$1, { Context } from 'react';
 import * as packages_core_lib_controller_Controller from 'packages/core/lib/controller/Controller';
 
-type AbstractInstanceType$1<T> = T extends {
+type AbstractInstanceType$1<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
 type DenormalizeObject$1<S extends Record<string, any>> = {
@@ -457,7 +457,7 @@ interface EntityTable {
     } | undefined;
 }
 
-type AbstractInstanceType<T> = T extends {
+type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
 type DenormalizeObject<S extends Record<string, any>> = {
@@ -510,7 +510,7 @@ interface SnapshotInterface {
 }
 
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): InferReturn<F, S>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -547,7 +547,7 @@ type Denormalize<S> = Extract<S, EntityInterface> extends never ? Extract<S, Ent
 type DenormalizeNullable<S> = Extract<S, EntityInterface> extends never ? Extract<S, EntityInterface[]> extends never ? DenormalizeNullable$1<S> : DenormalizeNullable$1<Extract<S, EntityInterface[]>> : DenormalizeNullable$1<Extract<S, EntityInterface>>;
 
 type CondNull$2<P, A, B> = P extends null ? A : B;
-type SuspenseReturn<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]> = CondNull$2<Args[0], E['schema'] extends undefined | null ? undefined : DenormalizeNullable<E['schema']>, E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>>;
+type SuspenseReturn<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]> = CondNull$2<Args[0], E['schema'] extends undefined | null ? undefined : DenormalizeNullable<E['schema']>, E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>>;
 
 /**
  * Ensure an endpoint is available.
@@ -558,13 +558,13 @@ type SuspenseReturn<E extends EndpointInterface<FetchFunction, Schema | undefine
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
+declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
 
 /**
  * Request a resource if it is not in cache.
  * @see https://resthooks.io/docs/api/useFetch
  */
-declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): ReturnType<E> | undefined;
+declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): ReturnType<E> | undefined;
 
 type CondNull$1<P, A, B> = P extends null ? A : B;
 type StatefulReturn<S extends Schema | undefined, P> = CondNull$1<P, {
@@ -588,7 +588,7 @@ type StatefulReturn<S extends Schema | undefined, P> = CondNull$1<P, {
  * Use async date with { data, loading, error } (DLE)
  * @see https://resthooks.io/docs/api/useDLE
  */
-declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? {
+declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? {
     data: E extends (...args: any) => any ? ResolveType<E> | undefined : any;
     loading: boolean;
     error: ErrorTypes$1 | undefined;
@@ -608,7 +608,7 @@ declare function useController(): Controller;
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
+declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, Args extends readonly [...Parameters<E>] | readonly [null]>(endpoint: E, ...args: Args): SuspenseReturn<E, Args>;
 
 declare const StateContext: Context<State$1<unknown>>;
 /** @deprecated use Controller.dispatch */
@@ -743,7 +743,7 @@ denormalizeCache?: any): {
  * `useCache` guarantees referential equality globally.
  * @see https://resthooks.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined>, 'key' | 'schema' | 'invalidIfStale'> | Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>, Args extends (E extends {
+declare function useCache<E extends Pick<EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined | false>, 'key' | 'schema' | 'invalidIfStale'> | Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>, Args extends (E extends {
     key: any;
 } ? readonly [...Parameters<E['key']>] : readonly [ParamsFromShape<E>]) | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends {} ? DenormalizeNullable$3<E['schema']> : E extends (...args: any) => any ? ResolveType$2<E> | undefined : any;
 
@@ -753,7 +753,7 @@ type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;
  * Get any errors for a given request
  * @see https://resthooks.io/docs/api/useError
  */
-declare function useError<E extends Pick<EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined>, 'key' | 'schema' | 'invalidIfStale'> | Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>, Args extends (E extends {
+declare function useError<E extends Pick<EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined | false>, 'key' | 'schema' | 'invalidIfStale'> | Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>, Args extends (E extends {
     key: any;
 } ? readonly [...Parameters<E['key']>] : readonly [ParamsFromShape<E>]) | readonly [null]>(endpoint: E, ...args: Args): UseErrorReturn<typeof args>;
 
@@ -951,6 +951,6 @@ declare function useRetrieve<Shape extends ReadShape<any, any>>(fetchShape: Shap
  * Keeps a resource fresh by subscribing to updates.
  * @see https://resthooks.io/docs/api/useSubscription
  */
-declare function useSubscription<E extends EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined> | ReadShape<any, any>, Args extends (E extends (...args: any) => any ? readonly [...Parameters<E>] : readonly [ParamsFromShape<E>]) | readonly [null]>(endpoint: E, ...args: Args): void;
+declare function useSubscription<E extends EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined | false> | ReadShape<any, any>, Args extends (E extends (...args: any) => any ? readonly [...Parameters<E>] : readonly [ParamsFromShape<E>]) | readonly [null]>(endpoint: E, ...args: Args): void;
 
 export { ArrayElement, _default as AsyncBoundary, _default$1 as BackupBoundary, CacheProvider, ControllerContext, DeleteShape, DenormalizeCacheContext, DispatchContext, Endpoint, EndpointParam, EndpointExtraOptions$1 as FetchOptions, FetchShape, Index, IndexParams, MutateEndpoint, MutateShape, NetworkErrorBoundary, ParamsFromShape, ReadEndpoint, ReadShape, SetShapeParams, StateContext, Store, StoreContext, internal_d as __INTERNAL__, makeCacheProvider, useCache, useController, useDLE, useDenormalized, useError, useFetch, useLive, useMeta, usePromisifiedDispatch, useResource, useRetrieve, useSubscription, useSuspense };

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3036,37 +3036,37 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.2.4
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=d8545d&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=f54144&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^10.0.0
     flux-standard-action: ^2.1.1
-  checksum: 4bbf0f99c89bc3d83d420e3bfbe05a8098350b2eec173d00ccfb51d526e5632a124042a19f747f49de4a2a469db40c50f0405fbfb52cf2db14d2286b84adcd1a
+  checksum: 26d9f60081105dfaac21af30bcb85cb248e1e41aae1c9f621509059d36fb0493d702c28328d800bd2d916ad4e55482b1f919cdef90ccdbcc842d12b2264fa4a6
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.6.0
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=a34f92&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=8aaaec&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 569385c810a6cf37dea52a66a840112ce48087b162a54eed756a7eefe9c7b41d840ba71984bc84ccd1d6748a050b5863f0e3b0094aa7b449cf8fb2639dbd2c06
+  checksum: 4125d5b7c2cdb588ae85c3fe36df62d1234afa9d042d21ccb1657a3b1808e7f57141049d9ac3f19e50070241aaa4706a6ac0684713dc15c7e3b447be1c9b2e4f
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.4.0
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=549380&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=b487a0&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.6.0
-  checksum: b2f5a3d4adcf5d91ad2901284a32b2f78924c693d59b1490a5f9a5e2ced3ede0debe79a4575934ac2e9b8b53e91f6ee37faf8fb126d73643683f4854217b8b40
+  checksum: 4141de2364c73d0a6bf6fd756733eafd30108214262cebc2b710b2b9fa2a739061deeb1c874d9868217ea3f6f97f2e707c5a7ea6cfb89d34d43c362ff76d5b4c
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.1.10
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=3c98de&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=20f702&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^10.0.0
@@ -3076,22 +3076,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 8e714b3a6dc810dc8a125a2fc2a5d5b21aba64473b1b1eeb0e8db10fff3cf496519a18eda478863c9dc1570c6ae4b71f15f110b35a4969cc00ef318fc6d67c55
+  checksum: 0c33b47bda202de39557eb30538725b612219bc3390c998239837d45cc5e485e4d029b3dca5096137ad371ce371069cee276db6a65bef111fef45be33c38f9f6
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.0.0
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=8671eb&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=40a6b6&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 3adb55b8a3bc4ad76c22e63894d768a570ca47b54446c24542e58bcedd1dfa7d68479d824c44b13309762f1866a420be9f2f2cef59d1d5d1f282a9ca2566fc2b
+  checksum: ac39e1d6d1b3a4865757e4537d90baf0fa987b1bc83947628d57dbd7d8d442b1b531af2fd19fa6d41ad5058aa5d5b844e80dd04bc9312fccd8c7003961dd193e
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.2.4
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=aebb7a&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=641dd2&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.2.4
@@ -3105,24 +3105,24 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: ea463bef62efe3ced75b0770723ee3006f4c39a3d4aa59d193e5c07081da4ed12aae58ab0a916d3e8d999f03c5cd2c4616a7b81ba1cf298f042589082e1a7565
+  checksum: 4d5cad81fd6911e6c5116eba13d23f3c2fb6d12633a058d654ad0589be2059877d15c2b3883019f7c79a26e10b57526798cb5d1a03e216c5eeb37bff037c2104
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.3.7
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=54d509&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=aebbd9&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.6.0
     path-to-regexp: ^6.2.1
-  checksum: 31c98fa9c5940bebfc7728e20b194cf2bb96c64c7035f35abebcffb1bbd7c5179466851bd2b0407d6fa1534749ea714c1f5834568456f30d6a48f3ab338cf783
+  checksum: 6538766014b4deaa85a822cb0cef538fe6aae3de97102f8fe01d645a304a8a5756dd4ae13ed88dd43d3f21a0ac34fa2526ff662f6355284050abbf148bcd8d2e
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.2.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=cf89f7&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=5956b0&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^13.4.0
@@ -3148,7 +3148,7 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: 841e88da4d0c2b9e41d64488dba2af9dcd24f5b4acc40cb87a082a13586b1a935e60b2c74747213a5443494dd66cba13de2f2aef5f6d75611899c73c08f4b2a2
+  checksum: 0539e165d17f919e7d807e1d2a19148d976dc8dc8d21caf3406ede15f269078914768196e4b3bcd7c52d815abebc5b4455211c7627f56d9806a709438277c1b9
   languageName: node
   linkType: hard
 
@@ -12731,7 +12731,7 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.12
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=aefe37&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=b7e2b7&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.6.0
@@ -12743,7 +12743,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 8c575a351268d27662eae1d2b17755682d87e661629dd013841af15892a352efd6013b8374a176b1f8614fc400e3e6bf54702b7f77f1c09ee8120c5759593108
+  checksum: 3b8821eed700cfd228cc9452d25c8dc5cea568462338615c5962ea3121143c7949d9d009c27ba5db2399c24a0cfe0754741af721dc9750392fdf68cdf424050a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #416 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Provide more flexible (composition) ways of utilizing the useful Entity code.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

```ts
class User {
  username = '';
  id = '';
  createdAt = new Date(0);
}
```

#### Extending

```ts
class UserSchema extends schema.Entity(User) {
  pk(value) { return value.id }

  static schema = {
    createdAt: Date,
  }
}
```

#### Options

```ts
const UserSchema = schema.Entity(User, {
  pk() {
    return this.id;
  },
  key: 'User',
  schema: { createdAt: Date },
});
```


```ts
const UserSchema = schema.Entity(User, {
  pk: 'id',
  key: 'User',
  schema: { createdAt: Date },
});
```
