### PR TITLE
enhance: Only use mergeWithStore logic when entityMeta exists

### DIFF
--- a/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
+++ b/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
@@ -8,7 +8,7 @@ describe('normalizer() merging', () => {
   describe('with instance.constructor.merge()', () => {
     it('should merge two Resource instances', () => {
       const id = 20;
-      const { entities: first } = normalize(
+      const { entities: first, entityMeta: firstEM } = normalize(
         {
           id,
           title: 'hi',
@@ -21,6 +21,8 @@ describe('normalizer() merging', () => {
         { id, title: 'hello' },
         Article,
         first,
+        {},
+        firstEM,
       );
 
       const [merged] = denormalize(result, Article, entities);
@@ -64,7 +66,7 @@ describe('normalizer() merging', () => {
   describe('basics', function () {
     it('should assign `null` values', () => {
       const id = 20;
-      const { entities: first } = normalize(
+      const { entities: first, entityMeta: firstEM } = normalize(
         {
           id,
           title: 'hi',
@@ -77,6 +79,8 @@ describe('normalizer() merging', () => {
         { id, title: null },
         Article,
         first,
+        {},
+        firstEM,
       );
 
       const [merged] = denormalize(result, Article, entities);

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -78,9 +78,13 @@ const addEntities =
         : meta.expiresAt;
 
       const inStoreEntity = existingEntities[schemaKey][id];
+      let inStoreMeta: {
+        date: number;
+        expiresAt: number;
+        fetchedAt: number;
+      };
       // this case we already have this entity in store
-      if (inStoreEntity) {
-        const inStoreMeta = entityMeta[schemaKey][id];
+      if (inStoreEntity && (inStoreMeta = entityMeta[schemaKey][id])) {
         entities[schemaKey][id] = schema.mergeWithStore
           ? schema.mergeWithStore(
               inStoreMeta,
@@ -96,9 +100,9 @@ const addEntities =
               processedEntity,
             );
         entityMeta[schemaKey][id] = {
-          expiresAt: Math.max(entityExpiresAt, inStoreMeta?.expiresAt),
-          date: Math.max(meta.date, inStoreMeta?.date ?? 0),
-          fetchedAt: Math.max(meta.fetchedAt ?? 0, inStoreMeta?.fetchedAt ?? 0),
+          expiresAt: Math.max(entityExpiresAt, inStoreMeta.expiresAt),
+          date: Math.max(meta.date, inStoreMeta.date),
+          fetchedAt: Math.max(meta.fetchedAt ?? 0, inStoreMeta.fetchedAt),
         };
       } else {
         entities[schemaKey][id] = processedEntity;
@@ -153,13 +157,11 @@ Entity: ${JSON.stringify(entity, undefined, 2)}`);
 /** @deprecated use Entity.mergeStore() instead */
 function mergeWithStore(
   schema: EntityInterface<any>,
-  existingMeta:
-    | {
-        date: number;
-        expiresAt: number;
-        fetchedAt: number;
-      }
-    | undefined,
+  existingMeta: {
+    date: number;
+    expiresAt: number;
+    fetchedAt: number;
+  },
   incomingMeta: {
     expiresAt: number;
     date: number;
@@ -169,12 +171,10 @@ function mergeWithStore(
   incoming: any,
 ) {
   const useIncoming =
-    // we may have in store but not in meta; so this existance check is still important
-    !existingMeta ||
     // useIncoming should not be used with legacy optimistic
-    (schema.useIncoming && incomingMeta.fetchedAt
+    schema.useIncoming && incomingMeta.fetchedAt
       ? schema.useIncoming(existingMeta, incomingMeta, existing, incoming)
-      : existingMeta.date <= incomingMeta.date);
+      : existingMeta.date <= incomingMeta.date;
   if (useIncoming) {
     if (typeof incoming !== typeof existing) {
       return incoming;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simplify a lot of complex conditional logic

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
When operating on a full store like @rest-hooks/core does; entityMeta will always exist if an entity does. However, we still want to never crash even if weird things happen. By extracting this case to one condition we can 'hoist' the complexity to only one split point.

If entityMeta doesn't exist, then we don't need reasoning around how to merge with entity - simply replace. For those possibly using normalizr without such an enforcement; they will get the behavior that would exerted without a persistent store anyway - as there is no expectations of existing entity tracking.

### Future work

Remove `mergeWithStore` undefined possibility in Endpoint implementation. This complexity will not be needed when using updated versions of rest-hooks