### PR TITLE
enhance: Optimize index check in normalize

### DIFF
--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -115,7 +115,7 @@ const addEntities =
     }
 
     // update index
-    if (Array.isArray(schema.indexes)) {
+    if (schema.indexes) {
       const entity = entities[schemaKey][id];
       if (!(schemaKey in indexes)) {
         indexes[schemaKey] = {};


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://www.measurethat.net/Benchmarks/Show/23731/0/arrayisarray-vs-truthy

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
index can only be undefined or an array - therefore this check is equivalent, but much faster and less code