### PR TITLE
enhance: Allow 'false' as Endpoint.sideEffect

### DIFF
--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -252,7 +252,11 @@ export default class Controller<
    * @see https://resthooks.io/docs/api/Controller#subscribe
    */
   subscribe = <
-    E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+    E extends EndpointInterface<
+      FetchFunction,
+      Schema | undefined,
+      undefined | false
+    >,
   >(
     endpoint: E,
     ...args: readonly [...Parameters<E>] | readonly [null]
@@ -270,7 +274,11 @@ export default class Controller<
    * @see https://resthooks.io/docs/api/Controller#unsubscribe
    */
   unsubscribe = <
-    E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+    E extends EndpointInterface<
+      FetchFunction,
+      Schema | undefined,
+      undefined | false
+    >,
   >(
     endpoint: E,
     ...args: readonly [...Parameters<E>] | readonly [null]

--- a/packages/experimental/src/hooks/useSubscription.tsx
+++ b/packages/experimental/src/hooks/useSubscription.tsx
@@ -11,7 +11,11 @@ import { useEffect } from 'react';
  * @see https://resthooks.io/docs/api/useSubscription
  */
 export default function useSubscription<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args) {
   const controller = useController();

--- a/packages/normalizr/src/endpoint/EndpointInterface.ts
+++ b/packages/normalizr/src/endpoint/EndpointInterface.ts
@@ -9,7 +9,7 @@ import { Normalize } from '../types.js';
 export interface EndpointInterface<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointExtraOptions<F> {
   (...args: Parameters<F>): InferReturn<F, S>;
   key(...args: Parameters<F>): string;
@@ -70,4 +70,4 @@ export interface MutateEndpoint<
 export type ReadEndpoint<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-> = EndpointInterface<F, S, undefined>;
+> = EndpointInterface<F, S, undefined | false>;

--- a/packages/react/src/hooks/types.ts
+++ b/packages/react/src/hooks/types.ts
@@ -11,7 +11,11 @@ import {
 export type CondNull<P, A, B> = P extends null ? A : B;
 
 export type SuspenseReturn<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 > = CondNull<
   Args[0],

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -20,7 +20,7 @@ import useController from '../hooks/useController.js';
  */
 export default function useCache<
   E extends Pick<
-    EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+    EndpointInterface<FetchFunction, Schema | undefined, undefined | false>,
     'key' | 'schema' | 'invalidIfStale'
   >,
   Args extends readonly [...Parameters<E['key']>] | readonly [null],

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -37,7 +37,11 @@ type StatefulReturn<S extends Schema | undefined, P> = CondNull<
  * @see https://resthooks.io/docs/api/useDLE
  */
 export default function useDLE<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(
   endpoint: E,

--- a/packages/react/src/hooks/useFetch.native.ts
+++ b/packages/react/src/hooks/useFetch.native.ts
@@ -18,7 +18,11 @@ import useFocusEffect from './useFocusEffect.native.js';
  * @see https://resthooks.io/docs/api/useFetch
  */
 export default function useFetch<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args) {
   const state = useCacheState();

--- a/packages/react/src/hooks/useFetch.ts
+++ b/packages/react/src/hooks/useFetch.ts
@@ -16,7 +16,11 @@ import useController from '../hooks/useController.js';
  * @see https://resthooks.io/docs/api/useFetch
  */
 export default function useFetch<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args) {
   const state = useCacheState();

--- a/packages/react/src/hooks/useLive.ts
+++ b/packages/react/src/hooks/useLive.ts
@@ -20,7 +20,11 @@ import useSuspense from './useSuspense.js';
  * @throws {NetworkError} If fetch fails.
  */
 export default function useLive<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
   useSubscription(endpoint, ...args);

--- a/packages/react/src/hooks/useSubscription.native.tsx
+++ b/packages/react/src/hooks/useSubscription.native.tsx
@@ -12,7 +12,11 @@ import useFocusEffect from './useFocusEffect.native.js';
  * @see https://resthooks.io/docs/api/useSubscription
  */
 export default function useSubscription<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args) {
   const controller = useController();

--- a/packages/react/src/hooks/useSubscription.tsx
+++ b/packages/react/src/hooks/useSubscription.tsx
@@ -12,7 +12,11 @@ import useController from './useController.js';
  * @see https://resthooks.io/docs/api/useSubscription
  */
 export default function useSubscription<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args) {
   const controller = useController();

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -28,7 +28,11 @@ import useFocusEffect from './useFocusEffect.native.js';
  * @throws {NetworkError} If fetch fails.
  */
 export default function useSuspense<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
   const state = useCacheState();

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -22,7 +22,11 @@ import useController from '../hooks/useController.js';
  * @throws {NetworkError} If fetch fails.
  */
 export default function useSuspense<
-  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
   Args extends readonly [...Parameters<E>] | readonly [null],
 >(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
   const state = useCacheState();

--- a/packages/rest-hooks/src/hooks/useCache.ts
+++ b/packages/rest-hooks/src/hooks/useCache.ts
@@ -21,7 +21,7 @@ import { ReadShape, ParamsFromShape } from '../endpoint/index.js';
 export default function useCache<
   E extends
     | Pick<
-        EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+        EndpointInterface<FetchFunction, Schema | undefined, undefined | false>,
         'key' | 'schema' | 'invalidIfStale'
       >
     | Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>,

--- a/packages/rest-hooks/src/hooks/useError.ts
+++ b/packages/rest-hooks/src/hooks/useError.ts
@@ -22,7 +22,7 @@ type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;
 export default function useError<
   E extends
     | Pick<
-        EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+        EndpointInterface<FetchFunction, Schema | undefined, undefined | false>,
         'key' | 'schema' | 'invalidIfStale'
       >
     | Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>,

--- a/packages/rest-hooks/src/hooks/useSubscription.ts
+++ b/packages/rest-hooks/src/hooks/useSubscription.ts
@@ -15,7 +15,7 @@ import { ReadShape, ParamsFromShape } from '../endpoint/index.js';
  */
 export default function useSubscription<
   E extends
-    | EndpointInterface<FetchFunction, Schema | undefined, undefined>
+    | EndpointInterface<FetchFunction, Schema | undefined, undefined | false>
     | ReadShape<any, any>,
   Args extends
     | (E extends (...args: any) => any


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Besides being kind of weird to have `undefined` as a specific type - `undefined` can behave quite weirdly in typescript. For instance, in non-strict mode it won't even be a type.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We first allow `undefined` in all consumers. Eventually we'll migrate to using booleans for definitions.