### PR TITLE
feat: Add Entity lifecycle overrides to mixin options

### DIFF
--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
@@ -511,8 +511,20 @@ EntityMixin {
 }
 `;
 
-exports[`EntitySchema normalization process is run before and passed to the schema denormalization 1`] = `
+exports[`EntitySchema normalization process schema denormalization is run before and passed to the schema denormalization EntriesEntity 1`] = `
 EntriesEntity {
+  "data": {
+    "attachment": AttachmentsEntity {
+      "id": "456",
+    },
+  },
+  "id": "123",
+  "type": "message",
+}
+`;
+
+exports[`EntitySchema normalization process schema denormalization is run before and passed to the schema denormalization EntriesEntity2 1`] = `
+EntriesEntity2 {
   "data": {
     "attachment": AttachmentsEntity {
       "id": "456",

--- a/packages/rest/src/__tests__/__snapshots__/RestEndpoint.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/RestEndpoint.ts.snap
@@ -1,19 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RestEndpoint.fetch() should reject if content-type does not exist with schema 1`] = `
-[NetworkError: Unexpected text response for schema class CoolerArticle extends Article {
-  get things() {
-    return \`\${this.title} five\`;
-  }
-}]
-`;
+exports[`RestEndpoint.fetch() should reject if content-type does not exist with schema 1`] = `[NetworkError: Unexpected text response for schema CoolerArticle]`;
 
 exports[`RestEndpoint.fetch() should reject if content-type is not json with schema 1`] = `
-[NetworkError: Unexpected html response for schema class CoolerArticle extends Article {
-  get things() {
-    return \`\${this.title} five\`;
-  }
-}
+[NetworkError: Unexpected html response for schema CoolerArticle
 This likely means no API endpoint was configured for this request, resulting in an HTML fallback.
 
 Response (first 300 characters): <body>this is html</body>]


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Eliminate need for extends if people don't want to use it.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Supported options:

```ts
| 'process'
| 'merge'
| 'expiresAt'
| 'createIfValid'
| 'mergeWithStore'
| 'validate'
| 'shouldReorder'
| 'useIncoming'
```

#### Example

```ts
class EntriesEntity extends schema.Entity(Entries, {
  schema: {
    data: { attachment: AttachmentsEntity },
  },
  process(input, parent, key) {
    return {
      ...values(input)[0],
      type: Object.keys(input)[0],
    };
  },
}) {}
```