### PR TITLE
feat: Add FetchInterceptor - a lower-level interceptor

### DIFF
--- a/docs/core/api/types.md
+++ b/docs/core/api/types.md
@@ -2,21 +2,25 @@
 title: TypeScript Types
 ---
 
-## @rest-hooks/core
-
-### Manager
+## Manager
 
 ```typescript
-interface Manager {
-  getMiddleware(): Middleware;
+interface Manager<Actions = ActionTypes> {
+  getMiddleware(): Middleware<Actions>;
   cleanup(): void;
   init?: (state: State<any>) => void;
 }
 ```
 
-[More](./Manager)
+```typescript
+type Middleware<Actions = any> = <C extends Controller<Actions>>(
+  controller: C,
+) => (next: C['dispatch']) => C['dispatch'];
+```
 
-### NetworkError
+[More](./Manager) about manager.
+
+## NetworkError
 
 ```typescript
 interface NetworkError extends Error {
@@ -25,7 +29,7 @@ interface NetworkError extends Error {
 }
 ```
 
-### UnknownError
+## UnknownError
 
 This is a catch-all for errors thrown in fetch functions. It is recommended
 to try to conform to the `NetworkError` interface above
@@ -34,127 +38,38 @@ to try to conform to the `NetworkError` interface above
 type UnknownError = Error & { status?: unknown; response?: unknown };
 ```
 
-## @rest-hooks/endpoint
-
-### EndpointInterface
-
-The bare requirements for an endpoint-type. This is useful
-for typing function parameters (like hooks), as it is accepting of any correct
-implementation.
+## State
 
 ```typescript
-export interface EndpointInterface<
-  F extends FetchFunction = FetchFunction,
-  S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined
-> extends EndpointExtraOptions {
-  (...args: Parameters<F>): InferReturn<F, S>;
-  key(...args: Parameters<F>): string;
-  readonly sideEffect?: M;
-  readonly schema?: S;
+interface State<T> {
+  readonly entities: {
+    readonly [entityKey: string]: { readonly [pk: string]: T } | undefined;
+  };
+  readonly indexes: NormalizedIndex;
+  readonly results: { readonly [key: string]: unknown | PK[] | PK | undefined };
+  readonly meta: {
+    readonly [key: string]: {
+      readonly date: number;
+      readonly error?: ErrorTypes;
+      readonly expiresAt: number;
+      readonly prevExpiresAt?: number;
+      readonly invalidated?: boolean;
+      readonly errorPolicy?: 'hard' | 'soft' | undefined;
+    };
+  };
+  readonly entityMeta: {
+    readonly [entityKey: string]: {
+      readonly [pk: string]: {
+        readonly date: number;
+        readonly expiresAt: number;
+        readonly fetchedAt: number;
+      };
+    };
+  };
+  readonly optimistic: (
+    | previousActions.ReceiveAction
+    | previousActions.OptimisticAction
+  )[];
+  readonly lastReset: Date | number;
 }
 ```
-
-e.g.,
-
-```typescript
-function useCache<E extends EndpointInterface>(
-  endpoint: E,
-  params: Parameters<E>[0],
-);
-```
-
-### EndpointInstance
-
-An instance of the [Endpoint](/rest/api/Endpoint) class.
-
-```typescript
-interface EndpointInstance<
-  F extends FetchFunction = FetchFunction,
-  S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined
->;
-```
-
-This is useful to specify types explicitly, instead of implicitly in construction.
-Being explicit reduces TypeScript computational overhead when inferring types, which
-is sometimes necessary to avoid tripping the recursion depth limit. This is one of the reasons why
-there is an [eslint rule to explicitly specify return types of methods/functions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md).
-
-```typescript
-const userDetail: EndpointInstance<FetchFunction<{
-  id: string;
-}>> = new Endpoint(({ id }) => fetch(`/users/${id}`));
-
-class User extends Entity {
-  static detail<T extends User>(
-    this: T,
-  ): EndpointInstance<
-    FetchFunction<{
-      id: string;
-    }>,
-    T,
-    undefined
-  > {
-    return new Endpoint(({ id }) => fetch(`/users/${id}`), { schema: this });
-  }
-
-  /** Expected Body payload is a subset of the properties of User
-  *  Expected Response is all the properties of User
-  */
-  static update<T extends User>(
-    this: T,
-  ): EndpointInstance<
-    FetchFunction<
-      {
-        id: string;
-      },
-      Partial<T>,
-      // return value is plain object - this is an easy way to extract public members from this class' interface
-      Omit<T, never>
-    >,
-    T,
-    true
-  > {
-    return new Endpoint(({ id }) => fetch(`/users/${id}`, { method: 'PUT' }), {
-      schema: this,
-    });
-  }
-}
-```
-
-### FetchFunction
-
-Represents a function that does actual fetch. Convenient type to specify
-only part of the function's type.
-
-```typescript
-export type FetchFunction<A extends readonly any[] = any, R = any> = (
-  ...args: A
-) => Promise<R>;
-```
-
-Providing a function type that returns a Promise also works.
-
-## @rest-hooks/rest
-
-```typescript
-export interface RestGenerics {
-  readonly path: string;
-  readonly schema?: Schema | undefined;
-  readonly method?: string;
-  readonly body?: any;
-}
-
-export type GetEndpoint<
-  UrlParams = any,
-  S extends Schema | undefined = Schema | undefined,
-> = RestTypeNoBody<UrlParams, S, undefined>;
-
-export type MutateEndpoint<
-  UrlParams = any,
-  Body extends BodyInit | Record<string, any> = any,
-  S extends Schema | undefined = Schema | undefined,
-> = RestTypeWithBody<UrlParams, S, true, Body>;
-```
-

--- a/docs/core/api/useController.md
+++ b/docs/core/api/useController.md
@@ -11,7 +11,7 @@ title: useController()
 function useController(): Controller;
 ```
 
-Provides access to [Controller](./Controller.md) which can be used for imperative control
+Provides access to [Controller](./Controller.md) from React, which can be used for imperative control
 over the cache. For instance [fetch](./Controller.md#fetch), [invalidate](./Controller.md#invalidate),
 and [setResponse](./Controller.md#setResponse)
 

--- a/docs/rest/guides/optimistic-updates.md
+++ b/docs/rest/guides/optimistic-updates.md
@@ -360,6 +360,20 @@ endpoint: new RestEndpoint({path: '/api/count'}),
 args: [],
 response: { count: 0, updatedAt: Date.now() }
 },
+{
+  endpoint: new RestEndpoint({
+    path: '/api/count/increment',
+    method: 'POST',
+    body: undefined,
+  }),
+  fetchResponse(input, init) {
+    return ({
+      "count": (this.count = this.count + 1),
+      "updatedAt": JSON.parse(init.body).updatedAt,
+    });
+  },
+  delay: () => 500 + Math.random() * 4500,
+}
 ]}
 getInitialInterceptorData={() => ({ count: 0 })}
 >
@@ -390,7 +404,7 @@ export const increment = new RestEndpoint({
   schema: CountEntity,
   getRequestInit() {
     // this is a substitute for super.getRequestInit() since we aren't in a class context
-    return this.constructor.prototype.getRequestInit.call(this, {
+    return RestEndpoint.prototype.getRequestInit.call(this, {
       updatedAt: Date.now(),
     });
   },

--- a/docs/rest/guides/relational-data.md
+++ b/docs/rest/guides/relational-data.md
@@ -324,7 +324,7 @@ Comment.schema = {
 export const PostResource = createResource({
   path: '/posts/:id',
   schema: Post,
-  dataExpiryLength: 3600000,
+  dataExpiryLength: Infinity,
 });
 export const UserResource = createResource({
   path: '/users/:id',

--- a/packages/core/src/middlewareTypes.ts
+++ b/packages/core/src/middlewareTypes.ts
@@ -19,10 +19,10 @@ export interface MiddlewareController<Actions = LegacyActionTypes>
 }
 
 export type Middleware<Actions = any> = <
-  A extends MiddlewareController<Actions>,
+  C extends MiddlewareController<Actions>,
 >(
-  controller: A,
-) => (next: A['dispatch']) => A['dispatch'];
+  controller: C,
+) => (next: C['dispatch']) => C['dispatch'];
 
 export type RestHooksReducer = React.Reducer<State<unknown>, ActionTypes>;
 

--- a/packages/core/src/newActions.ts
+++ b/packages/core/src/newActions.ts
@@ -5,7 +5,7 @@ import type {
 } from '@rest-hooks/normalizr';
 
 import type {
-  RECEIVE_TYPE,
+  SET_TYPE,
   RESET_TYPE,
   FETCH_TYPE,
   SUBSCRIBE_TYPE,
@@ -27,7 +27,7 @@ export interface ReceiveMeta {
 export interface ReceiveActionSuccess<
   E extends EndpointInterface = EndpointInterface,
 > {
-  type: typeof RECEIVE_TYPE;
+  type: typeof SET_TYPE;
   endpoint: E;
   meta: ReceiveMeta;
   payload: ResolveType<E>;
@@ -36,7 +36,7 @@ export interface ReceiveActionSuccess<
 export interface ReceiveActionError<
   E extends EndpointInterface = EndpointInterface,
 > {
-  type: typeof RECEIVE_TYPE;
+  type: typeof SET_TYPE;
   endpoint: E;
   meta: ReceiveMeta;
   payload: UnknownError;

--- a/packages/react/src/components/CacheProvider.tsx
+++ b/packages/react/src/components/CacheProvider.tsx
@@ -68,6 +68,9 @@ Try using https://resthooks.io/docs/api/ExternalCacheProvider for server entry p
     </ControllerContext.Provider>
   );
 }
+/** Default props for CacheProvider
+ * @see https://resthooks.io/docs/api/CacheProvider#defaultprops
+ */
 CacheProvider.defaultProps = {
   managers: [
     new NetworkManager(),

--- a/packages/test/src/collapseFixture.ts
+++ b/packages/test/src/collapseFixture.ts
@@ -1,7 +1,7 @@
-import type { Fixture, Interceptor } from './fixtureTypes.js';
+import type { Fixture, ResponseInterceptor } from './fixtureTypes.js';
 
-export function collapseFixture(
-  fixture: Fixture | Interceptor,
+export async function collapseFixture(
+  fixture: Fixture | ResponseInterceptor,
   args: any[],
   interceptorData: any,
 ) {
@@ -9,7 +9,7 @@ export function collapseFixture(
   let response = fixture.response;
   if (typeof fixture.response === 'function') {
     try {
-      response = fixture.response.apply(interceptorData, args);
+      response = await fixture.response.apply(interceptorData, args);
       // dispatch goes through user-code that can sometimes fail.
       // let's ensure we always handle errors
     } catch (e: any) {

--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -6,8 +6,7 @@ import {
   __INTERNAL__,
 } from '@rest-hooks/react';
 
-import { collapseFixture } from './collapseFixture.js';
-import type { Fixture, Interceptor } from './fixtureTypes.js';
+import type { Fixture } from './fixtureTypes.js';
 
 const { initialState, createReducer } = __INTERNAL__;
 
@@ -39,7 +38,7 @@ function dispatchFixture(
 ) {
   // eslint-disable-next-line prefer-const
   let { endpoint } = fixture;
-  const { response, error } = collapseFixture(fixture, args, {});
+  const { response, error } = fixture;
   if (controller.resolve) {
     controller.resolve(endpoint, {
       args,

--- a/website/src/components/Playground/FixturePreview.tsx
+++ b/website/src/components/Playground/FixturePreview.tsx
@@ -20,7 +20,11 @@ function FixtureResponse({
 }: {
   fixture: Fixture | Interceptor;
 }): ReactElement {
-  return typeof fixture.response === 'function' ? (
+  return 'fetchResponse' in fixture ? (
+    <CodeBlock language="javascript" className={styles.fixtureJson}>
+      {`${fixture.fetchResponse}`}
+    </CodeBlock>
+  ) : typeof fixture.response === 'function' ? (
     <CodeBlock language="javascript" className={styles.fixtureJson}>
       {`${fixture.response}`}
     </CodeBlock>

--- a/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
@@ -255,14 +255,14 @@ interface ReceiveMeta$2 {
     expiresAt: number;
 }
 interface ReceiveActionSuccess<E extends EndpointInterface = EndpointInterface> {
-    type: typeof RECEIVE_TYPE;
+    type: typeof SET_TYPE;
     endpoint: E;
     meta: ReceiveMeta$2;
     payload: ResolveType<E>;
     error?: false;
 }
 interface ReceiveActionError<E extends EndpointInterface = EndpointInterface> {
-    type: typeof RECEIVE_TYPE;
+    type: typeof SET_TYPE;
     endpoint: E;
     meta: ReceiveMeta$2;
     payload: UnknownError;
@@ -543,7 +543,7 @@ interface MiddlewareAPI$1<R extends RestHooksReducer = RestHooksReducer> extends
 interface MiddlewareController<Actions = ActionTypes> extends Controller<RHDispatch<Actions>> {
     controller: Controller<RHDispatch<Actions>>;
 }
-type Middleware$2<Actions = any> = <A extends MiddlewareController<Actions>>(controller: A) => (next: A['dispatch']) => A['dispatch'];
+type Middleware$2<Actions = any> = <C extends MiddlewareController<Actions>>(controller: C) => (next: C['dispatch']) => C['dispatch'];
 type RestHooksReducer = React.Reducer<State<unknown>, ActionTypes$2>;
 type Dispatch$1<R extends Reducer<any, any>> = (action: ReducerAction<R>) => Promise<void>;
 type Reducer<S, A> = (prevState: S, action: A) => S;
@@ -895,6 +895,11 @@ declare class NetworkManager implements Manager {
      * Will resolve the promise associated with receive key.
      */
     protected handleReceive(action: ReceiveAction): void;
+    /** Called when middleware intercepts a set action.
+     *
+     * Will resolve the promise associated with set key.
+     */
+    protected handleSet(action: SetAction): void;
     /** Attaches NetworkManager to store
      *
      * Intercepts 'rest-hooks/fetch' actions to start requests.

--- a/website/src/mocks/handlers.js
+++ b/website/src/mocks/handlers.js
@@ -1,4 +1,4 @@
-import { rest, graphql } from 'msw';
+import { graphql } from 'msw';
 
 const pageInitAt = Date.now();
 
@@ -35,56 +35,7 @@ export let TODOS = [
   },
 ].map(todo => ({ ...todo, updatedAt: pageInitAt }));
 
-let MAX_ID = TODOS.reduce((todo, prev) => Math.max(todo.id, prev), 0);
-
-let simulatedServerStateCount = 0;
-
 export const handlers = [
-  // todos
-  rest.get('/api/todos', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.delay(150), ctx.json(TODOS));
-  }),
-  rest.get('/api/todos/:id', (req, res, ctx) => {
-    const { id } = req.params;
-    const todo = TODOS.find(todo => todo.id == id);
-    if (!todo) return res(ctx.status(404), ctx.delay(150));
-    return res(ctx.status(200), ctx.delay(150), ctx.json(todo));
-  }),
-  rest.patch('/api/todos/:id', (req, res, ctx) => {
-    const { id } = req.params;
-    const i = TODOS.findIndex(todo => todo.id == id);
-    if (i < 0) return res(ctx.status(404), ctx.delay(150));
-    TODOS[i] = { ...TODOS[i], updatedAt: Date.now(), ...req.body };
-    return res(ctx.status(200), ctx.delay(150), ctx.json(TODOS[i]));
-  }),
-  rest.post('/api/todos', (req, res, ctx) => {
-    TODOS.push({ id: MAX_ID++, updatedAt: Date.now(), ...req.body });
-    return res(
-      ctx.status(201),
-      ctx.delay(150),
-      ctx.json(TODOS[TODOS.length - 1]),
-    );
-  }),
-  rest.delete('/api/todos/:id', (req, res, ctx) => {
-    const { id } = req.params;
-    const i = TODOS.findIndex(todo => todo.id == id);
-    if (i < 0) return res(ctx.status(204), ctx.delay(150));
-    TODOS = TODOS.slice(0, i).concat(TODOS.slice(i + 1));
-    return res(ctx.status(200), ctx.delay(150), ctx.json(''));
-  }),
-
-  rest.get('/api/currentTime/:id', (req, res, ctx) => {
-    const { id } = req.params;
-    return res(
-      ctx.status(200),
-      ctx.delay(150),
-      ctx.json({
-        id,
-        updatedAt: new Date().toISOString(),
-      }),
-    );
-  }),
-
   graphql.query('GetTodos', (req, res, ctx) => {
     return res(ctx.delay(150), ctx.data({ todos: TODOS }));
   }),
@@ -106,26 +57,5 @@ export const handlers = [
       ...todo,
     };
     return res(ctx.data({ updateTodo: newTodo }));
-  }),
-
-  // optimistic updates
-  rest.get('/api/count', (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.delay(150),
-      ctx.json({ count: simulatedServerStateCount, updatedAt: pageInitAt }),
-    );
-  }),
-  rest.post('/api/count/increment', (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      // resolve from 500ms -> 5 seconds. Represents network variance.
-      // making state computed before hand allows demonstrating out of order race conditions
-      ctx.delay(500 + Math.random() * 4500),
-      ctx.json({
-        count: ++simulatedServerStateCount,
-        updatedAt: req.body.updatedAt,
-      }),
-    );
   }),
 ];

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3174,37 +3174,37 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.2.5
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=7a1664&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=5d3393&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^10.0.1
     flux-standard-action: ^2.1.1
-  checksum: e292d66d77e51f3e73523c2a361ea18d9d3baa3fc639516c3d90d8249bd81159b3d87156955d4bbff9dc7d124589cac643d69da135b4c1111de6318a0252df2a
+  checksum: 68077c0d956b0527bd2ffeb6fb900c9f757006499b8181ac132bd3ac99e537e6a8491f170b1b6b4c868cfdf1aa472fddaef5e7594e1b2b3af0276a3228c57857
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.7.0
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=80efac&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=58dbc6&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 65e528467c69d441ac2b6ccb5da8cc2b73b87e496f519e308db8931343cb2cbb8d3ff32fb55fbbbb2858b37e1dff607cbb260c7cc9f48e59c7bdc191c168b2cb
+  checksum: b4e47f5c80b73268c9d3cf6daddcb0b331adec048ebf0a2a94973df7fb29ac75c0edd97b008d9fcdd7ea6cfe354d6ed8af3ce948ddf69f2c8dfd58ed7d3770b3
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.4.1
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=61bcc4&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=26f9f3&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.0
-  checksum: afcf5986a0e47eabff5578816a8444ebe10d7deeec0fe1472feaca536b60aa1b33d2aa1387151a41cf534b325b892fe2e99b41e01f13c64ef8469c0701a72bd4
+  checksum: 1dd26bbc93f1d0a5eb2d857a9ff2434f45d9fe7e490af8a45b0e5a9c1c22ae9540e537c3673ee04211b1cec07d6034ebd80e568d138f772b566a9ed0717d422e
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.1.11
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=c38987&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=a60987&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^10.0.1
@@ -3214,22 +3214,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: ddff8d4460c2ed347f8591fa97720c95e4e341f91cded2058c1a66fe73a665cf1601a505719e5d168019b2dd5d751a0abedb4bbcb330f83400d903f39f005504
+  checksum: 9850e037f42721e1afa011d159b79bb5723955514bacc233c4096e8800372579574c041cffc42def29d94fb983c100cb55c868c6746b32940983d8a21864cb0f
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.0.1
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=a1dcfa&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=70d501&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 563b8bc02b7c1c30eaea8a31b514d2e06e77fe32b3189eded72dbd2b4d049478ba496ff0bd5e568981aa170542042e7c8bdfaf955f5367d3745cbbc5d4b7dd4f
+  checksum: fd0fc747a24d97223874cd26de0a9f36a9978daab14011c68b0406f17976bbea11d21985f5c029d112318e0b6b3bbbcd65bc1313fc6c58b0ff3369325693e950
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.2.5
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=242101&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=595e21&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.2.5
@@ -3243,24 +3243,24 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: ce6913e3f82bbc2ce8d45d7e5fc469bfc797317cb625f5878a63ee8de2483cf6c97ceb2b2d915c25028907cfc8fabdfd911cb3792653b678e88225468678bb15
+  checksum: 341fcf02480e4328cd045327ff8cc5ff4b84e97cc7f1f5a495c0e50c6e87b257137149fc39c0543189734aeb86bd6e81ca32d8eb9d674f7ec884c43fb745affb
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.3.8
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=7ccc82&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=1545eb&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.0
     path-to-regexp: ^6.2.1
-  checksum: 91fcd48b02fa3dcb54ed96ceba128057105cc429b622e74d2a7573f9f0ddb89ce676fad84569d30de71d6629ef9ad906d4b688a76cfa7508faa65268043a5511
+  checksum: 1690ff1e7b62a6142665f12ccc454eea8e21bba6d9ee1151b5f304863e8b15945525645664638887642435f6cb0ec1e64761019de06cc8a6c0742820a6702e63
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.2.1
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=62157d&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=f4c6d9&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^14.0.0
@@ -3286,20 +3286,20 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: e13249714492ded04ee783b0f2662976e11b2bc2a08434f8c2ef70d3049a3e27b9f207755cd958caef3d7bfc432da96f56a945bdbac718f7d9879903361f4248
+  checksum: 9e49aab1ea74af634d81e31fffa96f678d6a211f528ac7ca1248cacc2059df74ac6363d4c055b623bf726563765c2add25af1b94165bd5d34a344393d1cb5a56
   languageName: node
   linkType: hard
 
 "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer::locator=root-workspace-0b6124%40workspace%3A.":
   version: 1.2.7
-  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=f4b2d5&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=1f9edc&locator=root-workspace-0b6124%40workspace%3A."
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 99ce9703966b4a4eaaf319720e8a3014670930fe4c3975cb8b7b044ee89a6e4967d9b7936e29ab017ce0dfb4a3711950032fd2274b2aaedcc4ea13f77541e774
+  checksum: 215509befdcc030bf8f273271ab80cbdb9ded412b34d9fa759f790bb77f32f953d881f77c7b35a6966d821a9784a362a3daaf2f0d3856db18c52bee8884e74c2
   languageName: node
   linkType: hard
 
@@ -12938,7 +12938,7 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.13
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=3746a7&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=33a0c4&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.0
@@ -12950,7 +12950,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 607b7a6d5a3a4686c9bf09f8f1c5c7ef19b77c165e261def932040a29ab620cc5efc84e911ec7db825fa76df9fa31014522799d1eeb599ee5f19a14abaa92418
+  checksum: 5373fca048e246e69be86e67bebba3abc509e892c8744c05fb5620278dd9e4c1fa5eef54aefebc54170bf83a38e1eccc64d8fc920a6c366c528e06589dab16e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Follow up to #2380

When you want to still run other parts of an endpoint's fetch preparation like [getRequestInit()](https://resthooks.io/rest/api/RestEndpoint#getRequestInit)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add new Interceptor type, and make Interceptor a union of this and old type.

```ts
interface FetchInterceptor<
  T = any,
  E extends EndpointInterface & {
    update?: Updater;
    testKey(key: string): boolean;
    fetchResponse(input: RequestInfo, init: RequestInit): Promise<Response>;
    extend(options: any): any;
  } = EndpointInterface & {
    testKey(key: string): boolean;
    fetchResponse(input: RequestInfo, init: RequestInit): Promise<Response>;
    extend(options: any): any;
  },
> {
  readonly endpoint: E;
  fetchResponse(this: T, input: RequestInfo, init: RequestInit): ResolveType<E>;
  /** Number of miliseconds (or function that returns) to wait before resolving */
  readonly delay?: number | ((...args: Parameters<E>) => number);
  /** Waits to run `response()` after `delay` time */
  readonly delayCollapse?: boolean;
}
```

.e.g,


```ts
const incrementInterceptor = {
  endpoint: new RestEndpoint({
    path: '/api/count/increment',
    method: 'POST',
    body: undefined,
  }),
  fetchResponse(input, init) {
    return ({
      "count": (this.count = this.count + 1),
      "updatedAt": JSON.parse(init.body).updatedAt,
    });
  },
}
```

This only allows Endpoints that implement both extend and fetchResponse (both REST and Graphql provide these).

When this interceptor is found, it is translated to the previous `ResponseInterceptor` type, by creating a new `response()` method that calls an endpoint overriding [fetchResponse](https://resthooks.io/rest/api/RestEndpoint#fetchResponse) with the `FetchInterceptor` provided value.