### PR TITLE
fix: StrictMode compatibility

### DIFF
--- a/packages/hooks/src/useLoading.ts
+++ b/packages/hooks/src/useLoading.ts
@@ -25,12 +25,12 @@ export default function useLoading<F extends (...args: any) => Promise<any>>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<undefined | Error>(undefined);
   const isMountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
       isMountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
   const depsList = deps || [func];
   const wrappedFunc = useCallback(async (...args: any) => {
     setLoading(true);

--- a/packages/redux/src/ExternalCacheProvider.tsx
+++ b/packages/redux/src/ExternalCacheProvider.tsx
@@ -53,12 +53,12 @@ export default function ExternalCacheProvider<S>({
   const [state, setState] = useState(selectState);
 
   const isMounted = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMounted.current = true;
+    () => {
       isMounted.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   useEffect(() => {
     const unsubscribe = store.subscribe(() => {


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2484 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state

React 18 StrictMode calls useEffect callback twice; making it look like the component unmounted before it did.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We did this properly for CacheProvider in #2361

This add compat to

- hooks package (useLoading)
- ExternalCacheProvider (in redux pkg)

Reset refs to initial conditions in the first useeffect block

Thanks to @d7sd6u for not only a great bug report but the solution