### PR TITLE
internal: Skip website, docs dirs for checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,14 @@ jobs:
       - image: cimg/node:18.15
     resource_class: large
     steps:
-      - checkout
+      - run:
+          name: checkout
+          command: |
+            echo 'Cloning git repository'
+            existing_repo='false'
+            mkdir -p '/home/circleci/project'
+            cd '/home/circleci/project'
+            git clone -b "$CIRCLE_BRANCH" --depth 1 --no-checkout "$CIRCLE_REPOSITORY_URL" .
       - restore_cache:
           keys:
             - v7-dependencies-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Checkout is a bottleneck in circleci and currently takes 30s

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
website and docs dir are not needed. They also have lots of files and some assets (larger size) in them.