### PR TITLE
internal(test): React test matrix - only target react tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
                 ./codecov < ./lcov.info || true;
               fi
             else
-              yarn test:ci --maxWorkers=3
+              yarn test:ci --maxWorkers=3 packages/react packages/redux packages/ssr packages/use-enhanced-reducer packages/img packages/legacy/src/__tests__/useStatefulResource.tsx packages/rest packages/hooks packages/rest-hooks
             fi
 
   node_matrix:


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Faster CI. If a test doesn't use react, it doesn't need to be run more than once for each version of react.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Only run all tests for the codecoverage as this must do them all to get accurate coverage.

Note we still include `packages/rest` because it does have some (limited) react references in its tests.