### PR TITLE
fix: Do not export a type in js file (pnp compat)

### DIFF
--- a/.changeset/tame-humans-dress.md
+++ b/.changeset/tame-humans-dress.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/test': patch
+---
+
+Fix pnp compatibility by not exporting a type in a js file

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -16,5 +16,6 @@ export type {
   Interceptor,
 } from './fixtureTypes.js';
 export { act } from './makeRenderRestHook/renderHook.cjs';
+export type { RenderHookOptions } from './makeRenderRestHook/renderHook.cjs';
 
 export { makeRenderRestHook, mockInitialState };

--- a/packages/test/src/makeRenderRestHook/index.tsx
+++ b/packages/test/src/makeRenderRestHook/index.tsx
@@ -15,6 +15,8 @@ import { Interceptor, Fixture, FixtureEndpoint } from '../fixtureTypes.js';
 import MockResolver from '../MockResolver.js';
 import mockInitialState from '../mockState.js';
 
+export type { RenderHookOptions } from './renderHook.cjs';
+
 export default function makeRenderRestHook(
   Provider: React.ComponentType<ProviderProps>,
 ) {

--- a/packages/test/src/makeRenderRestHook/render18Hook.native.ts
+++ b/packages/test/src/makeRenderRestHook/render18Hook.native.ts
@@ -1,6 +1,2 @@
-export {
-  act,
-  waitFor,
-  renderHook,
-  RenderHookOptions,
-} from '@testing-library/react-native';
+export { act, waitFor, renderHook } from '@testing-library/react-native';
+export type { RenderHookOptions } from '@testing-library/react';

--- a/packages/test/src/makeRenderRestHook/render18Hook.ts
+++ b/packages/test/src/makeRenderRestHook/render18Hook.ts
@@ -1,6 +1,2 @@
-export {
-  act,
-  waitFor,
-  renderHook,
-  RenderHookOptions,
-} from '@testing-library/react';
+export { act, waitFor, renderHook } from '@testing-library/react';
+export type { RenderHookOptions } from '@testing-library/react';

--- a/packages/test/src/makeRenderRestHook/renderHook.cts
+++ b/packages/test/src/makeRenderRestHook/renderHook.cts
@@ -26,6 +26,8 @@ export const act: typeof reactAct extends undefined
   ? (require('./render18HookWrapped.js').act as any)
   : (act17 as any);
 
+export type { RenderHookOptions } from '@testing-library/react';
+
 type RenderHook = <
   Result,
   Props,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
PNP strictly disallows import/exports of non-existant members. Previously the compiler was retaining a type export in the js file

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Mark the export as 'type' explicitly so it's clear to babel it should be removed in js file