### PR TITLE
internal: Centralize common scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,15 @@
     "test:coverage": "yarn test --coverage --testPathIgnorePatterns=\"packages/(experimental)\"",
     "prepare": "yarn build:copy:ambient && tsc --build",
     "prepack": "yarn prepare",
-    "prepublishOnly": "yarn workspaces foreach -pti --no-private run build:legacy-types"
+    "prepublishOnly": "yarn workspaces foreach -pti --no-private run build:legacy-types",
+    "g:babel": "cd $INIT_CWD && babel --root-mode upward src --source-maps inline --extensions '.ts,.tsx,.cts,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "g:babel-lite": "cd $INIT_CWD && babel --root-mode upward src --source-maps inline --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "g:rollup": "cd $INIT_CWD && rollup -c",
+    "g:clean": "cd $INIT_CWD && rimraf lib ts3.4 legacy dist *.tsbuildinfo",
+    "g:downtypes": "cd $INIT_CWD && downlevel-dts",
+    "g:tsc": "cd $INIT_CWD && tsc",
+    "g:runs": "cd $INIT_CWD && run-s",
+    "g:copy": "cd $INIT_CWD && copyfiles"
   },
   "engines": {
     "node": "^12.17 || ^13.7 || >=14"
@@ -68,6 +76,7 @@
     "coveralls": "^3.1.0",
     "cpy-cli": "4.2.0",
     "cross-fetch": "^3.0.6",
+    "downlevel-dts": "^0.10.0",
     "eslint": "8.36.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "2.27.5",
@@ -80,6 +89,7 @@
     "mkdirp": "^2.0.0",
     "nock": "13.3.0",
     "node-fetch": "^3.3.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "2.8.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -90,6 +100,15 @@
     "redux": "4.2.1",
     "rest-hooks": "workspace:^",
     "rimraf": "^4.0.0",
+    "rollup": "2.79.1",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-dts": "^5.0.0",
+    "rollup-plugin-filesize": "^9.1.2",
+    "rollup-plugin-json": "^4.0.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-replace": "^2.2.0",
+    "rollup-plugin-terser": "^7.0.2",
     "ts-node": "10.9.1",
     "typescript": "5.0.2",
     "whatwg-fetch": "3.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,18 +52,18 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo ./index.d.ts",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean ./index.d.ts",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "data",
@@ -109,21 +109,5 @@
     "@babel/runtime": "^7.17.0",
     "@rest-hooks/normalizr": "^10.0.3",
     "flux-standard-action": "^2.1.1"
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-dts": "^5.0.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -68,20 +68,20 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\*",
-    "build:clean": "rimraf lib dist legacy ts3.4 ts4.0 ts4.2 *.tsbuildinfo",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4 && yarn run downlevel-dts lib ts4.0 --to=4.0 && yarn run downlevel-dts lib ts4.2 --to=4.2 && copyfiles --up 1 ./src-4.2-types/**/*.d.ts ./ts4.0/ && copyfiles --up 1 ./src-4.2-types/**/*.d.ts ./ts4.2 && copyfiles --up 1 ./src-4.0-types/**/*.d.ts ./ts3.4/ && copyfiles --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0 && copyfiles --up 1 ./src-legacy-types/**/*.d.ts ./ts3.4/",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib",
-    "tsc:ci": "tsc --project tsconfig.test.json",
-    "typecheck": "yarn run tsc:ci"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\*",
+    "build:clean": "yarn g:clean ts4.0 ts4.2",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4 && yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:downtypes lib ts4.2 --to=4.2 && yarn g:copy --up 1 ./src-4.2-types/**/*.d.ts ./ts4.0/ && yarn g:copy --up 1 ./src-4.2-types/**/*.d.ts ./ts4.2 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts3.4/ && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0 && yarn g:copy --up 1 ./src-legacy-types/**/*.d.ts ./ts3.4/",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib",
+    "tsc:ci": "yarn g:tsc --project tsconfig.test.json",
+    "typecheck": "run tsc:ci"
   },
   "keywords": [
     "data",
@@ -118,21 +118,5 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0"
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2",
-    "typescript": "5.0.2"
   }
 }

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -20,14 +20,14 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
-    "build": "yarn run build:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 yarn g:babel --out-dir lib",
+    "build:bundle": "yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build": "run build:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle"
   },
   "keywords": [
     "rest",
@@ -75,18 +75,6 @@
     }
   },
   "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@rest-hooks/test": "workspace:^",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "@rest-hooks/test": "workspace:*"
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -50,18 +50,18 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo index.d.ts",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean index.d.ts",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "GraphQL",
@@ -104,20 +104,5 @@
   "dependencies": {
     "@babel/runtime": "^7.17.0",
     "@rest-hooks/endpoint": "^3.7.4"
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -36,15 +36,15 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/hooks' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
-    "build": "yarn run build:lib && yarn run build:bundle",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/hooks' yarn g:babel --out-dir lib",
+    "build:bundle": "yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build": "run build:lib && run build:bundle",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle"
   },
   "keywords": [
     "hooks",
@@ -84,19 +84,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -36,15 +36,15 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 yarn g:babel --out-dir lib",
+    "build:bundle": "yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle"
   },
   "keywords": [
     "react",
@@ -81,19 +81,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -50,18 +50,18 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "rest",
@@ -99,20 +99,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -75,20 +75,16 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "build:js:development": "BROWSERSLIST_ENV=legacy NODE_ENV=development rollup -c",
-    "build:js:production": "BROWSERSLIST_ENV=legacy NODE_ENV=production rollup -c",
-    "build:js:node": "BROWSERSLIST_ENV=node12 NODE_ENV=development rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "run-s build:js:\\*",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "lint": "yarn lint:cmd --fix",
-    "lint:ci": "yarn lint:cmd",
-    "lint:cmd": "eslint . --ext '.js,.json,.snap' --cache",
-    "precommit": "flow check && lint-staged",
-    "prepublishOnly": "npm run build"
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "build:js:development": "BROWSERSLIST_ENV=legacy NODE_ENV=development yarn g:rollup",
+    "build:js:production": "BROWSERSLIST_ENV=legacy NODE_ENV=production yarn g:rollup",
+    "build:js:node": "BROWSERSLIST_ENV=node12 NODE_ENV=development yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:bundle": "yarn g:runs build:js:\\*",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "prepublishOnly": "run build"
   },
   "author": "Nathaniel Tucker",
   "contributors": [
@@ -97,20 +93,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "immutable": "4.2.2",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "immutable": "4.2.2"
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,18 +67,18 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo ./index.d.ts",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean ./index.d.ts",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "react",
@@ -139,21 +139,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-dts": "^5.0.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -66,18 +66,18 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo ./index.d.ts",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean ./index.d.ts",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "react",
@@ -134,22 +134,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "redux": "^4.2.0",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-dts": "^5.0.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -52,18 +52,18 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo ./index.d.ts",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4 && copyfiles --up 1 ./src-legacy-types/**/*.d.ts ./ts3.4/",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean ./index.d.ts",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4 && yarn g:copy --up 1 ./src-legacy-types/**/*.d.ts ./ts3.4/",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "react",
@@ -121,20 +121,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -50,18 +50,18 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts4.0 legacy dist *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts4.0 --to=4.0 && copyfiles --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "REST",
@@ -104,21 +104,6 @@
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "@types/copyfiles": "^2",
-    "@types/path-to-regexp": "^1.7.0",
-    "copyfiles": "^2.4.1",
-    "downlevel-dts": "^0.10.0",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "@types/path-to-regexp": "^1.7.0"
   }
 }

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -60,18 +60,18 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:js:node": "BROWSERSLIST_ENV=node12 rollup -c",
-    "build:js:browser": "BROWSERSLIST_ENV=legacy rollup -c",
-    "build:bundle": "run-s build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib ts3.4 legacy dist *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
+    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
+    "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
+    "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "ssr",
@@ -129,19 +129,6 @@
     }
   },
   "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "next": "^13.0.4",
-    "npm-run-all": "^4.1.5",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "next": "^13.0.4"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -64,17 +64,19 @@
   ],
   "scripts": {
     "build:lib": "run build:lib:esm && run build:lib:cjs",
-    "build:lib:esm": "NODE_ENV=production BROWSERSLIST_ENV=2020 babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:lib:cjs": "BROWSERSLIST_ENV=node12 BABEL_MODULES=cjs babel --root-mode upward src --out-dir lib --extensions '.cts' --ignore '**/__tests__/**' --ignore '**/*.d.ts' && mv ./lib/makeRenderRestHook/renderHook.js ./lib/makeRenderRestHook/renderHook.cjs && mv ./lib/makeRenderRestHook/use18.js ./lib/makeRenderRestHook/use18.cjs",
-    "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV=2018 babel --root-mode upward src --out-dir legacy --extensions '.ts,.tsx,.cts,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "BROWSERSLIST_ENV=node12 rollup -c && COMPILE_TARGET=native BROWSERSLIST_ENV=node12 rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib dist ts3.4 legacy *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib:esm -w & yarn run build:lib:cjs -w && fg",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle && yarn run build:legacy:lib"
+    "build:lib:esm": "NODE_ENV=production BROWSERSLIST_ENV=2020 yarn g:babel-lite --out-dir lib --extensions '.ts,.tsx,.js'",
+    "build:lib:cjs": "BROWSERSLIST_ENV=node12 BABEL_MODULES=cjs yarn g:babel-lite --out-dir lib --extensions '.cts' && mv ./lib/makeRenderRestHook/renderHook.js ./lib/makeRenderRestHook/renderHook.cjs && mv ./lib/makeRenderRestHook/use18.js ./lib/makeRenderRestHook/use18.cjs && mv ./lib/makeRenderRestHook/use18.native.js ./lib/makeRenderRestHook/use18.native.cjs",
+    "build:legacy:lib": "run build:legacy:lib:esm && run build:legacy:lib:cjs",
+    "build:legacy:lib:esm": "NODE_ENV=production BROWSERSLIST_ENV=2018 yarn g:babel-lite --out-dir legacy --extensions '.ts,.tsx,.js'",
+    "build:legacy:lib:cjs": "BABEL_MODULES=cjs BROWSERSLIST_ENV=2018 yarn g:babel-lite --out-dir legacy --extensions '.cts' && mv ./legacy/makeRenderRestHook/renderHook.js ./legacy/makeRenderRestHook/renderHook.cjs && mv ./legacy/makeRenderRestHook/use18.js ./legacy/makeRenderRestHook/use18.cjs && mv ./legacy/makeRenderRestHook/use18.native.js ./legacy/makeRenderRestHook/use18.native.cjs",
+    "build:bundle": "BROWSERSLIST_ENV=node12 yarn g:rollup && COMPILE_TARGET=native BROWSERSLIST_ENV=node12 yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "dev": "run build:lib:esm -w & run build:lib:cjs -w && fg",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "test",
@@ -142,18 +144,6 @@
     }
   },
   "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "@types/react-test-renderer": "^18",
-    "downlevel-dts": "^0.10.0",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "@types/react-test-renderer": "^18"
   }
 }

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -36,15 +36,15 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
-    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
-    "build": "yarn run build:lib && yarn run build:bundle",
-    "dev": "yarn run build:lib -w",
-    "prepare": "yarn run build:lib",
-    "prepack": "yarn prepare",
-    "prepublishOnly": "yarn run build:bundle"
+    "build:lib": "NODE_ENV=production BROWSERSLIST_ENV=2019 yarn g:babel --out-dir lib",
+    "build:bundle": "yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean",
+    "build:legacy-types": "yarn g:downtypes lib ts3.4",
+    "build": "run build:lib && run build:bundle",
+    "dev": "run build:lib -w",
+    "prepare": "run build:lib",
+    "prepack": "run prepare",
+    "prepublishOnly": "run build:bundle"
   },
   "keywords": [
     "react",
@@ -81,19 +81,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@babel/cli": "7.21.0",
-    "@babel/core": "7.21.3",
-    "@types/babel__core": "^7",
-    "downlevel-dts": "^0.10.0",
-    "rollup": "2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-filesize": "^9.1.2",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4553,23 +4553,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^10.0.3
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-dts: ^5.0.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   languageName: unknown
   linkType: soft
 
@@ -4577,21 +4563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
-    typescript: 5.0.2
   languageName: unknown
   linkType: soft
 
@@ -4599,22 +4571,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/experimental@workspace:packages/experimental"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/test": "workspace:^"
-    "@types/babel__core": ^7
+    "@rest-hooks/test": "workspace:*"
     "@types/path-to-regexp": ^1.7.0
-    downlevel-dts: ^0.10.0
     path-to-regexp: ^6.2.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/endpoint": ^2.2.0-beta.2 || ^3.3.0
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
@@ -4641,21 +4601,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/graphql@workspace:packages/graphql"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.4
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   languageName: unknown
   linkType: soft
 
@@ -4663,20 +4610,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/hooks@workspace:packages/hooks"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^10.0.3
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -4690,20 +4625,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/img@workspace:packages/img"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.4
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -4717,20 +4640,6 @@ __metadata:
 "@rest-hooks/legacy@workspace:packages/legacy":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/legacy@workspace:packages/legacy"
-  dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -4745,21 +4654,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
     immutable: 4.2.2
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   languageName: unknown
   linkType: soft
 
@@ -4776,23 +4672,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/react@workspace:packages/react"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.2.9
     "@rest-hooks/use-enhanced-reducer": ^1.2.8
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-dts: ^5.0.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@react-navigation/native": ^6.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
@@ -4809,23 +4691,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/redux@workspace:packages/redux"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.2.9
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
-    redux: ^4.2.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-dts: ^5.0.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
@@ -4841,25 +4708,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/rest@workspace:packages/rest"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.4
-    "@types/babel__core": ^7
-    "@types/copyfiles": ^2
     "@types/path-to-regexp": ^1.7.0
-    copyfiles: ^2.4.1
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
     path-to-regexp: ^6.2.1
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   languageName: unknown
   linkType: soft
 
@@ -4867,21 +4719,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rest-hooks/ssr@workspace:packages/ssr"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
     next: ^13.0.4
-    npm-run-all: ^4.1.5
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/react": ^6.0.0 || ^7.0.0
     "@rest-hooks/redux": ^6.3.0 || ^7.0.0
@@ -4897,28 +4736,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/test@^10.0.0, @rest-hooks/test@workspace:^, @rest-hooks/test@workspace:packages/test":
+"@rest-hooks/test@^10.0.0, @rest-hooks/test@workspace:*, @rest-hooks/test@workspace:^, @rest-hooks/test@workspace:packages/test":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/test@workspace:packages/test"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^14.0.0
     "@testing-library/react-hooks": ~8.0.0
     "@testing-library/react-native": ^12.0.1
-    "@types/babel__core": ^7
     "@types/react-test-renderer": ^18
-    downlevel-dts: ^0.10.0
     react-error-boundary: ^4.0.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/react": ^0.2.0 || ^0.3.0 || ^1.0.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
@@ -4944,19 +4771,6 @@ __metadata:
 "@rest-hooks/use-enhanced-reducer@^1.2.8, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
-  dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -5407,13 +5221,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: fe81351470f2d3165e8b12ce33542eef89ea893e36dd62e8f7d72566dfb7e448376ae962f9f3ea888547ce8b55a40020ca0e01d637fab5d99567673084542641
-  languageName: node
-  linkType: hard
-
-"@types/copyfiles@npm:^2":
-  version: 2.4.1
-  resolution: "@types/copyfiles@npm:2.4.1"
-  checksum: e586284f736c5e1336c7760972db44c26cb4aa02a7fea0d31694306b5569a499546f35990aec9c007df7506a9c0ab62ddb019d96d054560d39d423ebd5ecb917
   languageName: node
   linkType: hard
 
@@ -20886,22 +20693,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rest-hooks@workspace:packages/rest-hooks"
   dependencies:
-    "@babel/cli": 7.21.0
-    "@babel/core": 7.21.3
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.7.4
-    "@types/babel__core": ^7
-    downlevel-dts: ^0.10.0
-    npm-run-all: ^4.1.5
     redux: ^4.0.0
-    rollup: 2.79.1
-    rollup-plugin-babel: ^4.4.0
-    rollup-plugin-commonjs: ^10.1.0
-    rollup-plugin-filesize: ^9.1.2
-    rollup-plugin-json: ^4.0.0
-    rollup-plugin-node-resolve: ^5.2.0
-    rollup-plugin-replace: ^2.2.0
-    rollup-plugin-terser: ^7.0.2
   peerDependencies:
     "@rest-hooks/react": ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -21180,6 +20974,7 @@ __metadata:
     coveralls: ^3.1.0
     cpy-cli: 4.2.0
     cross-fetch: ^3.0.6
+    downlevel-dts: ^0.10.0
     eslint: 8.36.0
     eslint-plugin-babel: ^5.3.1
     eslint-plugin-import: 2.27.5
@@ -21192,6 +20987,7 @@ __metadata:
     mkdirp: ^2.0.0
     nock: 13.3.0
     node-fetch: ^3.3.0
+    npm-run-all: ^4.1.5
     prettier: 2.8.7
     react: 18.2.0
     react-dom: 18.2.0
@@ -21202,6 +20998,15 @@ __metadata:
     redux: 4.2.1
     rest-hooks: "workspace:^"
     rimraf: ^4.0.0
+    rollup: 2.79.1
+    rollup-plugin-babel: ^4.4.0
+    rollup-plugin-commonjs: ^10.1.0
+    rollup-plugin-dts: ^5.0.0
+    rollup-plugin-filesize: ^9.1.2
+    rollup-plugin-json: ^4.0.0
+    rollup-plugin-node-resolve: ^5.2.0
+    rollup-plugin-replace: ^2.2.0
+    rollup-plugin-terser: ^7.0.2
     ts-node: 10.9.1
     typescript: 5.0.2
     whatwg-fetch: 3.0.0


### PR DESCRIPTION
Found out about https://yarnpkg.com/getting-started/qa#how-to-share-scripts-between-workspaces

This allows us to centralize all dev deps used in scripts to the root, as well as shared options.

### Root

```json
{
  "dependencies": {
    "typescript": "^3.8.0"
  },
  "scripts": {
    "g:tsc": "cd $INIT_CWD && tsc"
  }
}
```

### Workspace

```json
{
  "scripts": {
    "build": "yarn g:tsc"
  }
}
```