### PR TITLE
internal: Fix publish scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,8 +62,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "data",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -78,8 +78,7 @@
     "build:legacy-types": "yarn g:downtypes lib ts3.4 && yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:downtypes lib ts4.2 --to=4.2 && yarn g:copy --up 1 ./src-4.2-types/**/*.d.ts ./ts4.0/ && yarn g:copy --up 1 ./src-4.2-types/**/*.d.ts ./ts4.2 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts3.4/ && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0 && yarn g:copy --up 1 ./src-legacy-types/**/*.d.ts ./ts3.4/",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib",
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib",
     "tsc:ci": "yarn g:tsc --project tsconfig.test.json",
     "typecheck": "run tsc:ci"
   },

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -26,8 +26,7 @@
     "build": "run build:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle"
+    "prepack": "run prepare && run build:bundle"
   },
   "keywords": [
     "rest",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -60,8 +60,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "GraphQL",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -43,8 +43,7 @@
     "build:legacy-types": "yarn g:downtypes lib ts3.4",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle"
+    "prepack": "run prepare && run build:bundle"
   },
   "keywords": [
     "hooks",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -43,8 +43,7 @@
     "build": "run build:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle"
+    "prepack": "run prepare && run build:bundle"
   },
   "keywords": [
     "react",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -60,8 +60,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "rest",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,8 +77,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "react",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -76,8 +76,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "react",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -62,8 +62,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "react",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -60,8 +60,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "REST",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -70,8 +70,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "ssr",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -75,8 +75,7 @@
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib:esm -w & run build:lib:cjs -w && fg",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle && run build:legacy:lib"
+    "prepack": "echo 'run prepack' && run prepare && run build:bundle && run build:legacy:lib"
   },
   "keywords": [
     "test",

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -43,8 +43,7 @@
     "build": "run build:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
-    "prepack": "run prepare",
-    "prepublishOnly": "run build:bundle"
+    "prepack": "run prepare && run build:bundle"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
prepublishOnly is run *before* prepack, so we need to change the order.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
put everything in prepack. this will make bundle builds run on git installs as well which is probably desirable