### PR TITLE
fix: Improve subscription edge case handling

### DIFF
--- a/.changeset/calm-taxis-beam.md
+++ b/.changeset/calm-taxis-beam.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/core': patch
+---
+
+Polling intervals double check cancellation before dispatching fetch

--- a/.changeset/rude-pets-kick.md
+++ b/.changeset/rude-pets-kick.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/core': patch
+'@rest-hooks/test': patch
+---
+
+allSettled() always returns an allsettled promise

--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -126,7 +126,7 @@ export default class NetworkManager implements Manager {
 
   allSettled() {
     const fetches = Object.values(this.fetched);
-    if (fetches.length) return Promise.allSettled(fetches);
+    return Promise.allSettled(fetches);
   }
 
   /** Clear all promise state */

--- a/packages/core/src/manager/PollingSubscription.ts
+++ b/packages/core/src/manager/PollingSubscription.ts
@@ -147,9 +147,15 @@ export default class PollingSubscription implements Subscription {
     this.connectionListener.removeOnlineListener(this.onlineListener);
     const now = Date.now();
     this.startId = setTimeout(() => {
-      delete this.startId;
-      this.update();
-      this.run();
+      if (this.startId) {
+        delete this.startId;
+        this.update();
+        this.run();
+      } else if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `Poll setTimeout for ${this.key} still running, but timeoutId deleted`,
+        );
+      }
     }, Math.max(0, this.lastFetchTime() - now + this.frequency));
     this.connectionListener.addOfflineListener(this.offlineListener);
   };
@@ -168,7 +174,12 @@ export default class PollingSubscription implements Subscription {
         clearInterval(this.lastIntervalId);
         delete this.lastIntervalId;
       }
-      this.update();
+      if (this.intervalId) this.update();
+      else if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `Poll intervalId for ${this.key} still running, but intervalId deleted`,
+        );
+      }
     }, this.frequency);
   }
 

--- a/packages/core/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
+++ b/packages/core/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PollingSubscription fresh data cleanup() should not run even if interval not cancelled 1`] = `
+[
+  "Poll intervalId for test.com2 still running, but intervalId deleted",
+]
+`;
+
 exports[`PollingSubscription fresh data should call after period 1`] = `
 [
   {

--- a/packages/experimental/src/hooks/__tests__/subscriptions.tsx
+++ b/packages/experimental/src/hooks/__tests__/subscriptions.tsx
@@ -110,7 +110,9 @@ describe.each([
   });
 
   it('useSubscription() + useCache()', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
 
@@ -169,7 +171,9 @@ describe.each([
   });
 
   it('useSubscription() without active arg', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
     expect(PollingArticleResource.anotherGet.pollFrequency).toBeDefined();

--- a/packages/hooks/src/__tests__/useCancelling.ts
+++ b/packages/hooks/src/__tests__/useCancelling.ts
@@ -14,8 +14,9 @@ describe('useCancelling()', () => {
     title: 'second one',
   };
   beforeAll(() => {
-    jest.useFakeTimers();
-
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const mynock = nock(/.*/)
       .persist()
       .defaultReplyHeaders({

--- a/packages/react/src/__tests__/subscriptions-endpoint.tsx
+++ b/packages/react/src/__tests__/subscriptions-endpoint.tsx
@@ -108,7 +108,9 @@ describe.each([
   });
 
   it('useSubscription() + useCache()', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
 
@@ -166,7 +168,9 @@ describe.each([
   });
 
   it('useSubscription() without active arg', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
     expect(PollingArticleResource.get.pollFrequency).toBeDefined();

--- a/packages/react/src/hooks/__tests__/subscriptions.native.tsx
+++ b/packages/react/src/hooks/__tests__/subscriptions.native.tsx
@@ -107,9 +107,10 @@ describe.each([
     jest.useRealTimers();
   });
 
-  /* TODO: this uses non-native testing so it doesn't work
   it('useSubscription() + useCache()', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
 
@@ -124,12 +125,7 @@ describe.each([
       { initialProps: { active: true } },
     );
 
-    await validateSubscription(
-      result,
-      frequency,
-      articlePayload,
-      waitFor,
-    );
+    await validateSubscription(result, frequency, articlePayload, waitFor);
 
     // should not update if active is false
     rerender({ active: false });
@@ -141,14 +137,16 @@ describe.each([
 
     // errors should not fail when data already exists
     nock.cleanAll();
-    jsonNock().get(`/article/${articlePayload.id}`).reply(403, () => {
-      return { message: 'you fail' };
-    });
+    jsonNock()
+      .get(`/article/${articlePayload.id}`)
+      .reply(403, () => {
+        return { message: 'you fail' };
+      });
     rerender({ active: true });
     jest.advanceTimersByTime(frequency);
     expect((result.current as any).title).toBe('fiver');
     jest.useRealTimers();
-  });*/
+  });
 
   it('should console.error() with no frequency specified', async () => {
     const oldError = console.error;
@@ -164,21 +162,22 @@ describe.each([
     await renderRestHook.allSettled();
   });
 
-  /*it.only('useSubscription() without active arg', async () => {
-    jest.useFakeTimers();
+  it('useSubscription() without active arg', async () => {
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
     expect(PollingArticleResource.anotherGet.pollFrequency).toBeDefined();
 
-    const { result } = renderRestHook(() => {
+    const { result, waitFor } = renderRestHook(() => {
       useSubscription(PollingArticleResource.get, { id: articlePayload.id });
       return useCache(PollingArticleResource.get, { id: articlePayload.id });
     });
 
-    await validateSubscription(result, frequency, articlePayload);
+    await validateSubscription(result, frequency, articlePayload, waitFor);
     await renderRestHook.allSettled();
-
-  });*/
+  });
 
   it('useSubscription() should dispatch rest-hooks/subscribe only once even with rerender', async () => {
     const fakeDispatch = jest.fn();

--- a/packages/react/src/hooks/__tests__/subscriptions.tsx
+++ b/packages/react/src/hooks/__tests__/subscriptions.tsx
@@ -107,7 +107,9 @@ describe.each([
   });
 
   it('useSubscription() + useCache()', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
 
@@ -166,7 +168,9 @@ describe.each([
   });
 
   it('useSubscription() without active arg', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
     expect(PollingArticleResource.anotherGet.pollFrequency).toBeDefined();

--- a/packages/react/src/hooks/__tests__/useLive.tsx
+++ b/packages/react/src/hooks/__tests__/useLive.tsx
@@ -99,7 +99,9 @@ describe.each([
   });
 
   it('useLive()', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
 
@@ -150,7 +152,9 @@ describe.each([
   });
 
   it('useSubscription() without active arg', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
     const frequency = PollingArticleResource.get.pollFrequency as number;
     expect(frequency).toBeDefined();
     expect(PollingArticleResource.anotherGet.pollFrequency).toBeDefined();

--- a/packages/test/src/makeRenderRestHook/index.tsx
+++ b/packages/test/src/makeRenderRestHook/index.tsx
@@ -65,6 +65,7 @@ export default function makeRenderRestHook(
         rej();
       });
       (managers[0] as any).clearAll();
+      managers.forEach(manager => manager.cleanup());
     };
     renderRestHook.allSettled = async () => {
       return (managers[0] as NetworkManager).allSettled();
@@ -145,7 +146,7 @@ export default function makeRenderRestHook(
     return ret;
   }) as any;
   renderRestHook.cleanup = () => {};
-  renderRestHook.allSettled = () => Promise.resolve();
+  renderRestHook.allSettled = () => Promise.allSettled([]);
   return renderRestHook;
 }
 interface ProviderProps {
@@ -165,4 +166,7 @@ type RenderRestHook = (<P, R>(
   },
 ) => RenderHookResult<R, P> & {
   controller: Controller;
-}) & { cleanup: () => void; allSettled: () => Promise<unknown> };
+}) & {
+  cleanup: () => void;
+  allSettled: () => Promise<PromiseSettledResult<unknown>[]>;
+};


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Mostly because clear interval is flaky when mocking timers. However, we can at least detect weird edge cases more easily.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
In case the intervalId is undefined, we warn instead of doing an update fetch