### PR TITLE
fix: SSR will complete suspense

### DIFF
--- a/.changeset/breezy-coins-think.md
+++ b/.changeset/breezy-coins-think.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/test': patch
+---
+
+renderRestHook.allSettled() sometimes returns undefined

--- a/.changeset/proud-dingos-fold.md
+++ b/.changeset/proud-dingos-fold.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/core': patch
+'@rest-hooks/react': patch
+---
+
+Fix: SSR previously would never unsuspend cache provider
+(NetworkManager.allSettled() must return undefined if nothing in flight)

--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -126,7 +126,7 @@ export default class NetworkManager implements Manager {
 
   allSettled() {
     const fetches = Object.values(this.fetched);
-    return Promise.allSettled(fetches);
+    if (fetches.length) return Promise.allSettled(fetches);
   }
 
   /** Clear all promise state */

--- a/packages/test/src/makeRenderRestHook/index.tsx
+++ b/packages/test/src/makeRenderRestHook/index.tsx
@@ -67,7 +67,7 @@ export default function makeRenderRestHook(
       (managers[0] as any).clearAll();
       managers.forEach(manager => manager.cleanup());
     };
-    renderRestHook.allSettled = async () => {
+    renderRestHook.allSettled = () => {
       return (managers[0] as NetworkManager).allSettled();
     };
 
@@ -168,5 +168,5 @@ type RenderRestHook = (<P, R>(
   controller: Controller;
 }) & {
   cleanup: () => void;
-  allSettled: () => Promise<PromiseSettledResult<unknown>[]>;
+  allSettled: () => Promise<PromiseSettledResult<unknown>[]> | undefined;
 };


### PR DESCRIPTION
We used nm.allSettled() being falsy (undefined) to indicate we can complete suspense. Therefore, we must return undefined rather than a promise when there are no fetches in flight.

This reverts part of #2540