### PR TITLE
enhance: Denormalize even when pk cannot be computed

### DIFF
--- a/.changeset/fast-melons-raise.md
+++ b/.changeset/fast-melons-raise.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/endpoint': patch
+'@rest-hooks/graphql': patch
+'@rest-hooks/rest': patch
+---
+
+Values members are skipped if they are falsy

--- a/.changeset/nine-shoes-sell.md
+++ b/.changeset/nine-shoes-sell.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/normalizr': patch
+'@rest-hooks/react': patch
+'@rest-hooks/core': patch
+---
+
+Fully denormalize even when pk cannot be computed

--- a/packages/core/src/controller/BaseController.ts
+++ b/packages/core/src/controller/BaseController.ts
@@ -393,7 +393,7 @@ export default class Controller<
       // expiresAt existance is equivalent to cacheResults
       if (found) {
         const entityMeta = state.entityMeta;
-        // oldest entity dictates age
+        // earliest expiry dictates age
         expiresAt = entityPaths.reduce(
           (expiresAt: number, { pk, key }) =>
             Math.min(expiresAt, entityMeta[key]?.[pk]?.expiresAt ?? Infinity),

--- a/packages/endpoint/src/schemas/Values.ts
+++ b/packages/endpoint/src/schemas/Values.ts
@@ -48,7 +48,7 @@ export default class ValuesSchema extends PolymorphicSchema {
         if (deletedItem) {
           deleted = true;
         }
-        if (!foundItem || deletedItem) return output;
+        if (!value || deletedItem) return output;
         return {
           ...output,
           [key]: value,

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -221,6 +221,19 @@ exports[`denormalize [cached] denormalizes schema with extra members but not set
 ]
 `;
 
+exports[`denormalize [cached] denormalizes where id is only in key 1`] = `
+{
+  "1": Tacos {
+    "id": "",
+    "type": "foo",
+  },
+  "2": Tacos {
+    "id": "",
+    "type": "bar",
+  },
+}
+`;
+
 exports[`denormalize [cached] denormalizes with function as pk() 1`] = `
 [
   [
@@ -467,6 +480,19 @@ exports[`denormalize [fast] denormalizes schema with extra members but not set 1
   false,
   false,
 ]
+`;
+
+exports[`denormalize [fast] denormalizes where id is only in key 1`] = `
+{
+  "1": Tacos {
+    "id": "",
+    "type": "foo",
+  },
+  "2": Tacos {
+    "id": "",
+    "type": "bar",
+  },
+}
 `;
 
 exports[`denormalize [fast] denormalizes with function as pk() 1`] = `

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -9,8 +9,8 @@ import { DELETED } from '../special';
 
 class IDEntity extends Entity {
   id = '';
-  pk() {
-    return this.id;
+  pk(parent, key) {
+    return this.id || key;
   }
 }
 
@@ -725,6 +725,19 @@ describe.each([
 
     expect(
       denormalize(normalizedData.result, [Patron], normalizedData.entities),
+    ).toMatchSnapshot();
+  });
+
+  test('denormalizes where id is only in key', () => {
+    expect(
+      denormalize(
+        {
+          1: { type: 'foo' },
+          2: { type: 'bar' },
+        },
+        new schema.Values(Tacos),
+        {},
+      )[0],
     ).toMatchSnapshot();
   });
 });

--- a/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
@@ -628,13 +628,13 @@ describe.each([
           mynock
             .persist()
             .post('/toggle/5')
-            .delay(2000)
+            .delay(500)
             .reply(200, () => {
               visible = visible ? false : true;
               return { id: 5, visible };
             });
 
-          const { result, waitForNextUpdate } = renderRestHook(
+          const { result } = renderRestHook(
             () => {
               const { fetch } = useController();
               const tog = useCache(getbool, 5);
@@ -662,7 +662,7 @@ describe.each([
           // nothing should change since this failed
           expect(result.current.tog).toEqual({ id: 5, visible: false });
           expect(result.current.err).toEqual(toThrow);
-          await act(() => promise);
+          renderRestHook.cleanup();
         },
       );
 
@@ -677,7 +677,7 @@ describe.each([
         mynock
           .persist()
           .post('/toggle/5')
-          .delay(2000)
+          .delay(700)
           .reply(200, () => {
             visible = visible ? false : true;
             return { id: 5, visible };
@@ -710,16 +710,19 @@ describe.each([
         act(() => {
           promises.push(result.current.fetch(toggle, 5));
         });
+        jest.runOnlyPendingTimers();
         expect(result.current.tog).toEqual({ id: 5, visible: true });
 
         act(() => {
           promises.push(result.current.fetch(toggle, 5));
         });
+        jest.runOnlyPendingTimers();
         expect(result.current.tog).toEqual({ id: 5, visible: false });
 
         act(() => {
           promises.push(result.current.fetch(toggle, 5));
         });
+        jest.runOnlyPendingTimers();
         expect(result.current.tog).toEqual({ id: 5, visible: true });
 
         jest.advanceTimersByTime(300);
@@ -727,9 +730,11 @@ describe.each([
         act(() => {
           promises2.push(result.current.fetch(toggle, 5));
         });
+        jest.runOnlyPendingTimers();
         expect(result.current.tog).toEqual({ id: 5, visible: false });
 
-        jest.advanceTimersByTime(2001);
+        jest.advanceTimersByTime(701);
+        jest.runOnlyPendingTimers();
         await act(async () => {
           await Promise.all(promises);
         });
@@ -744,6 +749,8 @@ describe.each([
         });
 
         expect(result.current.tog).toEqual({ id: 5, visible: false });
+
+        renderRestHook.cleanup();
       });
 
       it('toggle should handle when response is missing', async () => {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Since we're now dealing with denormalizing non-cached items; we can be presented with objects that may rely on their context (parent, key) to properly compute pk. If they were normalized first they would still find a pk (by it simply being passed as input).

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Fully denormalize even when pk cannot be computed