### PR TITLE
enhance: Remove the need for 'found' in denormalize

### DIFF
--- a/.changeset/fifty-months-turn.md
+++ b/.changeset/fifty-months-turn.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/normalizr': minor
+---
+
+Add validateInference()

--- a/.changeset/moody-forks-itch.md
+++ b/.changeset/moody-forks-itch.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/core': minor
+'@rest-hooks/legacy': minor
+---
+
+Rework Controller to use simplified denoramlize

--- a/.changeset/rotten-dots-learn.md
+++ b/.changeset/rotten-dots-learn.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/endpoint': minor
+---
+
+Entity.infer() supports new usage

--- a/.changeset/seven-countries-march.md
+++ b/.changeset/seven-countries-march.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/react': patch
+---
+
+Improved small response cpu performance

--- a/.changeset/slow-pumas-rush.md
+++ b/.changeset/slow-pumas-rush.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/normalizr': major
+---
+
+denormalize is now non-cached version.
+Use denormalizeCached for previous functionality.

--- a/examples/benchmark/entity.js
+++ b/examples/benchmark/entity.js
@@ -1,16 +1,7 @@
 import data from './data.json' assert { type: 'json' };
-import {
-  Entity,
-  normalize,
-  denormalize,
-  inferResults,
-  WeakEntityMap,
-} from './dist/index.js';
+import { Entity } from './dist/index.js';
 import { printStatus } from './printStatus.js';
 import {
-  ProjectSchema,
-  ProjectQuery,
-  ProjectQuerySorted,
   BuildTypeDescription,
   BuildTypeDescriptionEntity,
   BuildTypeDescriptionEmpty,

--- a/examples/benchmark/normalizr.js
+++ b/examples/benchmark/normalizr.js
@@ -5,7 +5,7 @@ import {
   denormalize,
   inferResults,
   WeakEntityMap,
-  denormalizeSimple,
+  denormalizeCached,
 } from './dist/index.js';
 import { printStatus } from './printStatus.js';
 import {
@@ -45,21 +45,21 @@ export default function addNormlizrSuite(suite) {
     },
   };
   // prime the cache
-  denormalize(
+  denormalizeCached(
     result,
     ProjectSchema,
     entities,
     denormCache.entities,
     denormCache.results['/fake'],
   );
-  denormalize(
+  denormalizeCached(
     queryState.result,
     ProjectQuery,
     queryState.entities,
     denormCache.entities,
     denormCache.results['/fakeQuery'],
   );
-  %OptimizeFunctionOnNextCall(denormalize);
+  %OptimizeFunctionOnNextCall(denormalizeCached);
   %OptimizeFunctionOnNextCall(normalize);
 
   return suite
@@ -75,26 +75,26 @@ export default function addNormlizrSuite(suite) {
       );
     })
     .add('denormalizeLong', () => {
-      return denormalize(result, ProjectSchema, entities);
+      return denormalizeCached(result, ProjectSchema, entities);
     })
     .add('denormalizeLong donotcache', () => {
-      return denormalizeSimple(result, ProjectSchema, entities);
+      return denormalize(result, ProjectSchema, entities);
     })
     .add('denormalizeShort donotcache 500x', () => {
-      for (let i = 0; i < 500; ++i) {
-        denormalizeSimple('gnoff', User, githubState.entities);
-      }
-    })
-    .add('denormalizeShort 500x', () => {
       for (let i = 0; i < 500; ++i) {
         denormalize('gnoff', User, githubState.entities);
       }
     })
+    .add('denormalizeShort 500x', () => {
+      for (let i = 0; i < 500; ++i) {
+        denormalizeCached('gnoff', User, githubState.entities);
+      }
+    })
     .add('denormalizeLong with mixin Entity', () => {
-      return denormalize(result, ProjectSchemaMixin, entities);
+      return denormalizeCached(result, ProjectSchemaMixin, entities);
     })
     .add('denormalizeLong withCache', () => {
-      return denormalize(
+      return denormalizeCached(
         result,
         ProjectSchema,
         entities,
@@ -103,7 +103,7 @@ export default function addNormlizrSuite(suite) {
       );
     })
     .add('denormalizeLong All withCache', () => {
-      return denormalize(
+      return denormalizeCached(
         queryState.result,
         ProjectQuery,
         queryState.entities,
@@ -112,7 +112,7 @@ export default function addNormlizrSuite(suite) {
       );
     })
     .add('denormalizeLong Query-sorted withCache', () => {
-      return denormalize(
+      return denormalizeCached(
         queryInfer,
         ProjectQuerySorted.schema,
         queryState.entities,
@@ -122,7 +122,7 @@ export default function addNormlizrSuite(suite) {
     })
     .on('complete', function () {
       if (process.env.SHOW_OPTIMIZATION) {
-        printStatus(denormalize);
+        printStatus(denormalizeCached);
         printStatus(Entity.normalize);
         printStatus(Entity.denormalize);
         printStatus(ProjectWithBuildTypesDescription.prototype.pk);

--- a/examples/benchmark/src/index.ts
+++ b/examples/benchmark/src/index.ts
@@ -3,7 +3,7 @@ export {
   denormalize,
   WeakEntityMap,
   inferResults,
-  denormalizeSimple,
+  denormalizeCached,
 } from '@rest-hooks/normalizr';
 export * from '@rest-hooks/core';
 export { Endpoint, Entity, schema, Query } from '@rest-hooks/endpoint';

--- a/packages/core/src/controller/__tests__/__snapshots__/getResponse.ts.snap
+++ b/packages/core/src/controller/__tests__/__snapshots__/getResponse.ts.snap
@@ -28,7 +28,7 @@ exports[`Controller.getResponse() infers schema with extra members but not set 1
       "next": false,
     },
     "first": null,
-    "second": undefined,
+    "second": "",
     "third": 0,
   },
 }

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -142,7 +142,7 @@ describe('Controller.getResponse()', () => {
         extra: '',
         page: {
           first: null,
-          second: undefined,
+          second: '',
           third: 0,
           complex: { complex: true, next: false },
         },

--- a/packages/core/src/next/Controller.ts
+++ b/packages/core/src/next/Controller.ts
@@ -1,5 +1,5 @@
 import type { EndpointInterface, Denormalize } from '@rest-hooks/normalizr';
-import { denormalizeSimple } from '@rest-hooks/normalizr';
+import { denormalize } from '@rest-hooks/normalizr';
 
 import BaseController, {
   CompatibleDispatch,
@@ -29,8 +29,8 @@ export default class Controller<
     this.dispatch(action);
 
     if (endpoint.schema) {
-      return action.meta.promise.then(
-        input => denormalizeSimple(input, endpoint.schema, {})[0],
+      return action.meta.promise.then(input =>
+        denormalize(input, endpoint.schema, {}),
       ) as any;
     }
     return action.meta.promise as any;

--- a/packages/endpoint/src/schemas/__tests__/denormalize.ts
+++ b/packages/endpoint/src/schemas/__tests__/denormalize.ts
@@ -1,5 +1,5 @@
 import {
-  denormalize as denormalizeCore,
+  denormalizeCached as denormalizeCore,
   Schema,
   DenormalizeCache,
   WeakEntityMap,

--- a/packages/endpoint/typescript-tests/array_schema.ts
+++ b/packages/endpoint/typescript-tests/array_schema.ts
@@ -24,7 +24,7 @@ const myArray = new schema.Array(
 
 const normalizedData = normalize(data, myArray);
 
-const [denormalizedData, found, deleted] = denormalize(
+const denormalizedData = denormalize(
   normalizedData.result,
   myArray,
   normalizedData.entities,

--- a/packages/endpoint/typescript-tests/denormalize.ts
+++ b/packages/endpoint/typescript-tests/denormalize.ts
@@ -1,4 +1,7 @@
-import { normalize, denormalize } from '@rest-hooks/normalizr';
+import {
+  normalize,
+  denormalizeCached as denormalize,
+} from '@rest-hooks/normalizr';
 import { IDEntity } from '__tests__/new';
 
 import { schema, DenormalizeNullable, Normalize, Denormalize } from '../src';
@@ -43,7 +46,7 @@ const r = normalize({}, scheme);
 type A = DenormalizeNullable<typeof scheme>;
 type B = A['thing']['members'];
 type C = DenormalizeNullable<typeof schemeEntity>;
-type D = ReturnType<typeof unionSchema['_denormalizeNullable']>;
+type D = ReturnType<(typeof unionSchema)['_denormalizeNullable']>;
 type F = Denormalize<typeof unionSchema>;
 type E = Normalize<typeof scheme>['thing']['data'];
 

--- a/packages/legacy/src/SimpleRecord.ts
+++ b/packages/legacy/src/SimpleRecord.ts
@@ -124,8 +124,15 @@ export default abstract class SimpleRecord {
     args: readonly any[],
     indexes: any,
     recurse: any,
+    entities?: any,
   ): NormalizedEntity<T> {
-    return schema.Object.prototype.infer.call(this, args, indexes, recurse);
+    return (schema.Object.prototype.infer as any).call(
+      this,
+      args,
+      indexes,
+      recurse,
+      entities,
+    );
   }
 
   static denormalize<T extends typeof SimpleRecord>(

--- a/packages/legacy/src/useStatefulResource.ts
+++ b/packages/legacy/src/useStatefulResource.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { ErrorTypes } from '@rest-hooks/core';
-import { denormalize } from '@rest-hooks/normalizr';
+import { denormalizeCached } from '@rest-hooks/normalizr';
 import type {
   Schema,
   Denormalize,
@@ -101,7 +101,7 @@ export default function useStatefulResource<
   const loading = expiryStatus !== ExpiryStatus.Valid && !!maybePromise;
 
   if (loading && adaptedEndpoint.schema)
-    data = denormalize(
+    data = denormalizeCached(
       inferResults(
         adaptedEndpoint.schema,
         args as any,

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -477,7 +477,7 @@ exports[`denormalize [fast] denormalizes schema with extra members but not set 1
       },
     ],
   },
-  false,
+  true,
   false,
 ]
 `;
@@ -521,7 +521,7 @@ exports[`denormalize [fast] denormalizes without entities fills undefined 1`] = 
   {
     "data": undefined,
   },
-  false,
+  true,
   false,
 ]
 `;
@@ -531,7 +531,7 @@ exports[`denormalize [fast] denormalizes without entities fills undefined 2`] = 
   Immutable.Map {
     "data": undefined,
   },
-  false,
+  true,
   false,
 ]
 `;

--- a/packages/normalizr/src/__tests__/denormalizeCached.js
+++ b/packages/normalizr/src/__tests__/denormalizeCached.js
@@ -27,6 +27,18 @@ afterAll(() => {
 });
 
 describe('denormalize with global cache', () => {
+  test('denormalizes suspends when symbol contains DELETED string', () => {
+    const entities = {
+      Tacos: {
+        1: Symbol('ENTITY WAS DELETED'),
+      },
+    };
+    expect(denormalize('1', Tacos, entities).slice(0, 3)).toEqual([
+      undefined,
+      true,
+      true,
+    ]);
+  });
   test('maintains referential equality with same results', () => {
     const entityCache = {};
     const resultCache = new WeakEntityMap();

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -3,8 +3,8 @@ import { Entity, schema } from '@rest-hooks/endpoint';
 import { fromJS } from 'immutable';
 
 import { normalize } from '../';
-import { denormalize } from '../denormalize/denormalize';
 import { denormalize as denormalizeCached } from '../denormalize/denormalizeCached';
+import { denormalizeSimple } from '../denormalize/denormalizeSimple';
 import { DELETED } from '../special';
 
 class IDEntity extends Entity {
@@ -387,7 +387,7 @@ describe('normalize', () => {
 });
 
 describe.each([
-  ['fast', denormalize],
+  ['fast', denormalizeSimple],
   ['cached', denormalizeCached],
 ])(`denormalize [%s]`, (_, denormalize) => {
   test('passthrough with undefined schema', () => {
@@ -398,7 +398,7 @@ describe.each([
   test('returns the input if undefined', () => {
     expect(denormalize(undefined, {}, {}).slice(0, 3)).toEqual([
       undefined,
-      false,
+      expect.any(Boolean),
       false,
     ]);
   });
@@ -428,7 +428,7 @@ describe.each([
     ).toMatchSnapshot();
     expect(denormalize('1', Tacos, {}).slice(0, 3)).toEqual([
       undefined,
-      false,
+      expect.any(Boolean),
       false,
     ]);
   });
@@ -453,8 +453,8 @@ describe.each([
     };
     expect(denormalize('1', Tacos, entities).slice(0, 3)).toEqual([
       undefined,
-      true,
-      true,
+      expect.any(Boolean),
+      expect.any(Boolean),
     ]);
   });
 

--- a/packages/normalizr/src/__tests__/inferResults.ts
+++ b/packages/normalizr/src/__tests__/inferResults.ts
@@ -1,8 +1,14 @@
 import { schema as schemas } from '@rest-hooks/endpoint';
 import { SimpleRecord } from '@rest-hooks/legacy';
-import { UnionResource, CoolerArticle, IndexedUser } from '__tests__/new';
+import {
+  UnionResource,
+  CoolerArticle,
+  IndexedUser,
+  FirstUnion,
+} from '__tests__/new';
 
 import buildInferredResults from '../inferResults';
+import { NormalizedIndex } from '../interface';
 
 describe('inferResults()', () => {
   it('should work with Object', () => {
@@ -11,7 +17,14 @@ describe('inferResults()', () => {
         article: CoolerArticle,
       }),
     });
-    expect(buildInferredResults(schema, [{ id: 5 }], {})).toEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [{ id: 5 }],
+        {},
+        { [CoolerArticle.key]: { '5': {} } },
+      ),
+    ).toEqual({
       data: { article: '5' },
     });
   });
@@ -22,7 +35,14 @@ describe('inferResults()', () => {
         article: CoolerArticle,
       }),
     });
-    expect(buildInferredResults(schema, [5], {})).toEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [5],
+        {},
+        { [CoolerArticle.key]: { '5': {} } },
+      ),
+    ).toEqual({
       data: { article: '5' },
     });
   });
@@ -33,7 +53,14 @@ describe('inferResults()', () => {
         article: CoolerArticle,
       }),
     });
-    expect(buildInferredResults(schema, ['5'], {})).toEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        ['5'],
+        {},
+        { [CoolerArticle.key]: { '5': {} } },
+      ),
+    ).toEqual({
       data: { article: '5' },
     });
   });
@@ -53,7 +80,12 @@ describe('inferResults()', () => {
       };
     }
     const schema = Message;
-    const results = buildInferredResults(schema, [{ id: 5 }], {});
+    const results = buildInferredResults(
+      schema,
+      [{ id: 5 }],
+      {},
+      { [CoolerArticle.key]: { '5': {} } },
+    );
     expect(results).toEqual({
       data: { article: '5' },
     });
@@ -63,14 +95,28 @@ describe('inferResults()', () => {
     const schema = {
       data: new schemas.Array(CoolerArticle),
     };
-    expect(buildInferredResults(schema, [{ id: 5 }], {})).toStrictEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [{ id: 5 }],
+        {},
+        { [CoolerArticle.key]: { '5': {} } },
+      ),
+    ).toStrictEqual({
       data: undefined,
     });
 
     const schema2 = {
       data: [CoolerArticle],
     };
-    expect(buildInferredResults(schema2, [{ id: 5 }], {})).toStrictEqual({
+    expect(
+      buildInferredResults(
+        schema2,
+        [{ id: 5 }],
+        {},
+        { [CoolerArticle.key]: { '5': {} } },
+      ),
+    ).toStrictEqual({
       data: undefined,
     });
   });
@@ -79,20 +125,48 @@ describe('inferResults()', () => {
     const schema = {
       data: new schemas.Values(CoolerArticle),
     };
-    expect(buildInferredResults(schema, [{ id: 5 }], {})).toStrictEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [{ id: 5 }],
+        {},
+        { [CoolerArticle.key]: { '5': {} } },
+      ),
+    ).toStrictEqual({
       data: undefined,
     });
   });
 
   it('should be undefined with Union and type', () => {
     const schema = UnionResource.get.schema;
-    expect(buildInferredResults(schema, [{ id: 5 }], {})).toBe(undefined);
+    expect(
+      buildInferredResults(
+        schema,
+        [{ id: 5 }],
+        {},
+        {
+          [CoolerArticle.key]: {
+            '5': {},
+          },
+        },
+      ),
+    ).toBe(undefined);
   });
 
   it('should work with Union', () => {
     const schema = UnionResource.get.schema;
-    expect(buildInferredResults(schema, [{ id: 5, type: 'first' }], {}))
-      .toMatchInlineSnapshot(`
+    expect(
+      buildInferredResults(
+        schema,
+        [{ id: 5, type: 'first' }],
+        {},
+        {
+          [FirstUnion.key]: {
+            '5': {},
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       {
         "id": 5,
         "schema": "first",
@@ -105,7 +179,18 @@ describe('inferResults()', () => {
       pagination: { next: '', previous: '' },
       data: CoolerArticle,
     };
-    expect(buildInferredResults(schema, [{ id: 5 }], {})).toEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [{ id: 5 }],
+        {},
+        {
+          [CoolerArticle.key]: {
+            '5': {},
+          },
+        },
+      ),
+    ).toEqual({
       pagination: { next: '', previous: '' },
       data: '5',
     });
@@ -117,25 +202,43 @@ describe('inferResults()', () => {
       data: IndexedUser,
     };
     expect(
-      buildInferredResults(schema, [{ username: 'bob' }], {
-        [IndexedUser.key]: {
-          username: {
-            bob: '5',
+      buildInferredResults(
+        schema,
+        [{ username: 'bob' }],
+        {
+          [IndexedUser.key]: {
+            username: {
+              bob: '5',
+            },
           },
         },
-      }),
+        {
+          [IndexedUser.key]: {
+            '5': {},
+          },
+        },
+      ),
     ).toEqual({
       pagination: { next: '', previous: '' },
       data: '5',
     });
     expect(
-      buildInferredResults(schema, [{ username: 'bob', mary: 'five' }], {
-        [IndexedUser.key]: {
-          username: {
-            bob: '5',
+      buildInferredResults(
+        schema,
+        [{ username: 'bob', mary: 'five' }],
+        {
+          [IndexedUser.key]: {
+            username: {
+              bob: '5',
+            },
           },
         },
-      }),
+        {
+          [IndexedUser.key]: {
+            '5': {},
+          },
+        },
+      ),
     ).toEqual({
       pagination: { next: '', previous: '' },
       data: '5',
@@ -148,25 +251,43 @@ describe('inferResults()', () => {
       data: IndexedUser,
     };
     expect(
-      buildInferredResults(schema, [{ username: 'bob' }], {
-        [IndexedUser.key]: {
-          username: {
-            charles: '5',
+      buildInferredResults(
+        schema,
+        [{ username: 'bob' }],
+        {
+          [IndexedUser.key]: {
+            username: {
+              charles: '5',
+            },
           },
         },
-      }),
+        {
+          [IndexedUser.key]: {
+            '5': {},
+          },
+        },
+      ),
     ).toEqual({
       pagination: { next: '', previous: '' },
       data: undefined,
     });
     expect(
-      buildInferredResults(schema, [{ hover: 'bob' }], {
-        [IndexedUser.key]: {
-          username: {
-            charles: '5',
+      buildInferredResults(
+        schema,
+        [{ hover: 'bob' }],
+        {
+          [IndexedUser.key]: {
+            username: {
+              charles: '5',
+            },
           },
         },
-      }),
+        {
+          [IndexedUser.key]: {
+            '5': {},
+          },
+        },
+      ),
     ).toEqual({
       pagination: { next: '', previous: '' },
       data: undefined,
@@ -178,13 +299,74 @@ describe('inferResults()', () => {
       pagination: { next: '', previous: '' },
       data: IndexedUser,
     };
-    expect(buildInferredResults(schema, [{ username: 'bob' }], {})).toEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [{ username: 'bob' }],
+        {},
+        { [IndexedUser.key]: { '5': {} } },
+      ),
+    ).toEqual({
       pagination: { next: '', previous: '' },
       data: undefined,
     });
-    expect(buildInferredResults(schema, [{ hover: 'bob' }], {})).toEqual({
+    expect(
+      buildInferredResults(
+        schema,
+        [{ hover: 'bob' }],
+        {},
+        { [IndexedUser.key]: { '5': {} } },
+      ),
+    ).toEqual({
       pagination: { next: '', previous: '' },
       data: undefined,
+    });
+  });
+
+  describe('legacy schema', () => {
+    class MyEntity extends CoolerArticle {
+      static infer(
+        args: readonly any[],
+        indexes: NormalizedIndex,
+        recurse: any,
+      ) {
+        if (!args[0]) return undefined;
+        if (['string', 'number'].includes(typeof args[0])) {
+          return `${args[0]}`;
+        }
+        const id = this.pk(args[0], undefined, '');
+        // Was able to infer the entity's primary key from params
+        if (id !== undefined && id !== '') return id;
+      }
+    }
+
+    it('should work with string argument', () => {
+      const schema = new schemas.Object({
+        data: new schemas.Object({
+          article: MyEntity,
+        }),
+      });
+      expect(
+        buildInferredResults(
+          schema,
+          ['5'],
+          {},
+          { [MyEntity.key]: { '5': {} } },
+        ),
+      ).toEqual({
+        data: { article: '5' },
+      });
+    });
+
+    it('should be undefined even when Entity.infer gives id', () => {
+      const schema = new schemas.Object({
+        data: new schemas.Object({
+          article: MyEntity,
+        }),
+      });
+      expect(buildInferredResults(schema, ['5'], {}, {})).toEqual({
+        data: { article: undefined },
+      });
     });
   });
 });

--- a/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
+++ b/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
@@ -25,7 +25,7 @@ describe('normalizer() merging', () => {
         firstEM,
       );
 
-      const [merged] = denormalize(result, Article, entities);
+      const merged = denormalize(result, Article, entities);
       expect(merged).toBeInstanceOf(Article);
       expect(merged).toEqual(
         Article.fromJS({
@@ -83,7 +83,7 @@ describe('normalizer() merging', () => {
         firstEM,
       );
 
-      const [merged] = denormalize(result, Article, entities);
+      const merged = denormalize(result, Article, entities);
       expect(merged).toBeInstanceOf(Article);
       expect(merged).toEqual(
         Article.fromJS({
@@ -107,7 +107,7 @@ describe('normalizer() merging', () => {
 
       normalize({ id, title: 'hello' }, Article, first);
 
-      const [merged] = denormalize(id, Article, first);
+      const merged = denormalize(id, Article, first);
       expect(merged).toBeInstanceOf(Article);
       expect(merged).toEqual(
         Article.fromJS({

--- a/packages/normalizr/src/denormalize/denormalize.ts
+++ b/packages/normalizr/src/denormalize/denormalize.ts
@@ -8,19 +8,11 @@ export const denormalize = <S extends Schema>(
   input: any,
   schema: S | undefined,
   entities: any,
-):
-  | [denormalized: Denormalize<S>, found: true, deleted: false]
-  | [denormalized: DenormalizeNullable<S>, found: boolean, deleted: true]
-  | [denormalized: DenormalizeNullable<S>, found: false, deleted: boolean] => {
+): Denormalize<S> | DenormalizeNullable<S> => {
   // undefined means don't do anything
-  if (schema === undefined) {
-    return [input, true, false] as [any, boolean, boolean];
+  if (schema === undefined || input === undefined) {
+    return input as any;
   }
-  if (input === undefined) {
-    return [undefined, false, false] as [any, boolean, boolean];
-  }
-  const getEntity = getEntities(entities);
 
-  const ret = getUnvisit(getEntity, new LocalCache())(input, schema);
-  return [ret[0], ret[1], ret[2]];
+  return getUnvisit(getEntities(entities), new LocalCache())(input, schema)[0];
 };

--- a/packages/normalizr/src/denormalize/denormalizeSimple.ts
+++ b/packages/normalizr/src/denormalize/denormalizeSimple.ts
@@ -1,0 +1,14 @@
+import { denormalize } from './denormalize.js';
+import type { Schema } from '../interface.js';
+import type { Denormalize, DenormalizeNullable } from '../types.js';
+
+export const denormalizeSimple = <S extends Schema>(
+  input: any,
+  schema: S | undefined,
+  entities: any,
+):
+  | [denormalized: Denormalize<S>, found: true, deleted: false]
+  | [denormalized: DenormalizeNullable<S>, found: boolean, deleted: true]
+  | [denormalized: DenormalizeNullable<S>, found: false, deleted: boolean] => {
+  return [denormalize(input, schema, entities), true, false] as any;
+};

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -3,12 +3,12 @@ Object.hasOwn =
   /* istanbul ignore next */ function hasOwn(it, key) {
     return Object.prototype.hasOwnProperty.call(it, key);
   };
-import { denormalize as denormalizeSimple } from './denormalize/denormalize.js';
-import { denormalize } from './denormalize/denormalizeCached.js';
+import { denormalize } from './denormalize/denormalize.js';
+import { denormalize as denormalizeCached } from './denormalize/denormalizeCached.js';
 import { isEntity } from './isEntity.js';
 import { normalize } from './normalize.js';
 import WeakEntityMap from './WeakEntityMap.js';
-export { default as inferResults } from './inferResults.js';
+export { default as inferResults, validateInference } from './inferResults.js';
 export { DELETED } from './special.js';
 
 export type {
@@ -24,5 +24,4 @@ export * from './interface.js';
 export * from './Expiry.js';
 export * from './normal.js';
 
-export const denormalizeCached = denormalize;
-export { denormalize, denormalizeSimple, normalize, isEntity, WeakEntityMap };
+export { denormalize, denormalizeCached, normalize, isEntity, WeakEntityMap };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simplify denormalize to have one return value

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Found is only used in conjunction with inferred results
- Found only has relevance for entity inference
- If not found when inferring, then we don't actually use the data from that inference

Therefore:

We use the entities to lookup in infer. If we cannot find the entity, we don't even return the ID.
This means we need to change Entity.infer. To keep back compat as endpoint consumer (normalizr), we will detect entity case in the infer function and run fallback code.

Once we have `undefined` when entities don't exist, we can simply check for any `undefined` to determine the validity of inferred results. Previously any non-entity case would simply infer `undefined` anyway, and when denormalize found `undefined` it would return found of `false`. Therefore, our new `validateInference()` function will provide the same result.

Now we call this boolean invalidResults. suspend is now known as invalidDenormalize.