### PR TITLE
fix: Remove empty entity path from denormalize

### DIFF
--- a/.changeset/thin-peaches-wait.md
+++ b/.changeset/thin-peaches-wait.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/normalizr': patch
+---
+
+fix: Remove empty entity path from denormalize

--- a/packages/normalizr/src/WeakEntityMap.ts
+++ b/packages/normalizr/src/WeakEntityMap.ts
@@ -54,7 +54,10 @@ export function getEntities<K extends object>(state: State<K>): GetEntity<K> {
 }
 
 export function depToPaths(dependencies: Dep[]) {
-  return dependencies.map(dep => dep.path);
+  const paths = dependencies.map(dep => dep.path);
+  // the first item is the result input not an actual entity
+  if (paths[0]?.pk === '') paths.shift();
+  return paths;
 }
 
 export type GetEntity<K = object | symbol> = (lookup: Path) => K;


### PR DESCRIPTION
The first dependency is always the input, which has a path of {key:'', pk: ''}. While this is an important part of dependencies, it should not be part of the path list as it is not a valid entity.