### PR TITLE
enhance: Simplified null args path for ctrl.getResponse()

### DIFF
--- a/.changeset/nine-cups-admire.md
+++ b/.changeset/nine-cups-admire.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/core': patch
+'@rest-hooks/react': patch
+---
+
+Simplified null args path for ctrl.getResponse()

--- a/examples/benchmark/core.js
+++ b/examples/benchmark/core.js
@@ -87,6 +87,9 @@ export default function addReducerSuite(suite) {
       .add('getResponse', () => {
         return controller.getResponse(getProject, cachedState);
       })
+      .add('getResponse (null)', () => {
+        return controller.getResponse(getProject, null, cachedState);
+      })
       .add('getResponse (clear cache)', () => {
         controller.globalCache = {
           entities: {},

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -91,7 +91,7 @@ describe('Controller.getResponse()', () => {
       },
     };
     const { data, expiryStatus } = controller.getResponse(ep, null, state);
-    expect(expiryStatus).toBe(ExpiryStatus.InvalidIfStale);
+    expect(expiryStatus).toBe(ExpiryStatus.Valid);
     // null args means don't fill anything in
     expect(data.data).toBeUndefined();
     expect(data).toMatchInlineSnapshot(`


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Simplified code. Better performance.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

When we pass in null as the first arg, we are indicating we want to 'do nothing'.

For getResponse() this means

- Our results won't be found organically so they will be inferred
  - Thererfore, the results cannot be cached
  - Therefore, no entities will be found and thus no entity cache
- So essentially our data is just filling the shape with inferred results, which means we can just return those immediately.
- Since we never want to fetch we will return expiryStatus as Valid, and expiresAt Infinity - there is no case where we can do anything here

This results in a 5x speedup of the already very fast path:

Before:
getResponse (null) x 1,709,543 ops/sec ±0.17% (98 runs sampled)

After
getResponse (null) x 6,400,458 ops/sec ±0.20% (98 runs sampled)