### PR TITLE
feat: Add Entity.mergeMeta()

### DIFF
--- a/.changeset/fuzzy-clouds-occur.md
+++ b/.changeset/fuzzy-clouds-occur.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/normalizr': minor
+'@rest-hooks/endpoint': minor
+'@rest-hooks/core': minor
+---
+
+Add Entity.mergeMeta()

--- a/.changeset/sour-radios-drop.md
+++ b/.changeset/sour-radios-drop.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/normalizr': major
+---
+
+Require fetchedAt in meta

--- a/packages/core/src/state/reducer/setReducer.ts
+++ b/packages/core/src/state/reducer/setReducer.ts
@@ -43,7 +43,7 @@ export function setReducer(
       state.entities,
       state.indexes,
       state.entityMeta,
-      action.meta,
+      { fetchedAt: action.meta.date, ...action.meta },
     );
     let results = {
       ...state.results,

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -60,6 +60,12 @@ export interface EntityInterface<T = any> extends SchemaSimple {
     existing: any,
     incoming: any,
   ): any;
+  mergeMeta?(
+    existingMeta: any,
+    incomingMeta: any,
+    existing: any,
+    incoming: any,
+  ): any;
   // TODO(breaking): deprecate this
   useIncoming?(
     existingMeta: any,

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -74,6 +74,26 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
     }
   }
 
+  static mergeMeta(
+    existingMeta: {
+      expiresAt: number;
+      date: number;
+      fetchedAt: number;
+    },
+    incomingMeta: { expiresAt: number; date: number; fetchedAt: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return {
+      expiresAt: Math.max(
+        (this as any).expiresAt(incomingMeta, incoming),
+        existingMeta.expiresAt,
+      ),
+      date: Math.max(incomingMeta.date, existingMeta.date),
+      fetchedAt: Math.max(incomingMeta.fetchedAt, existingMeta.fetchedAt),
+    };
+  }
+
   /** Factory method to convert from Plain JS Objects.
    *
    * @param [props] Plain Object of properties to assign.
@@ -284,3 +304,11 @@ if (process.env.NODE_ENV !== 'production') {
     return superFrom.call(this, props) as any;
   };
 }
+
+// we're avoiding this on the type
+(Entity as any).expiresAt = function (
+  meta: { expiresAt: number; date: number; fetchedAt: number },
+  input: any,
+): number {
+  return meta.expiresAt;
+};

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -166,6 +166,21 @@ export default function EntitySchema<TBase extends Constructor>(
       }
     }
 
+    static mergeMeta(
+      existingMeta: {
+        expiresAt: number;
+        date: number;
+        fetchedAt: number;
+      },
+      incomingMeta: { expiresAt: number; date: number; fetchedAt: number },
+      existing: any,
+      incoming: any,
+    ) {
+      return this.shouldReorder(existingMeta, incomingMeta, existing, incoming)
+        ? existingMeta
+        : incomingMeta;
+    }
+
     /** Factory method to convert from Plain JS Objects.
      *
      * @param [props] Plain Object of properties to assign.
@@ -303,13 +318,6 @@ export default function EntitySchema<TBase extends Constructor>(
       // no entity arg is back-compatibility
       if (!entities || entities[this.key]?.[id]) return id;
       return undefined;
-    }
-
-    static expiresAt(
-      meta: { expiresAt: number; date: number; fetchedAt: number },
-      input: any,
-    ): number {
-      return meta.expiresAt;
     }
 
     static denormalize<T extends typeof EntityMixin>(
@@ -556,6 +564,20 @@ export interface IEntityClass<TBase extends Constructor = any> {
     existing: any,
     incoming: any,
   ): any;
+  mergeMeta(
+    existingMeta: {
+      expiresAt: number;
+      date: number;
+      fetchedAt: number;
+    },
+    incomingMeta: { expiresAt: number; date: number; fetchedAt: number },
+    existing: any,
+    incoming: any,
+  ): {
+    expiresAt: number;
+    date: number;
+    fetchedAt: number;
+  };
   /** Factory method to convert from Plain JS Objects.
    *
    * @param [props] Plain Object of properties to assign.
@@ -594,14 +616,6 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): any;
   validate(processedEntity: any): string | undefined;
   infer(args: readonly any[], indexes: NormalizedIndex, recurse: any): any;
-  expiresAt(
-    meta: {
-      expiresAt: number;
-      date: number;
-      fetchedAt: number;
-    },
-    input: any,
-  ): number;
   denormalize<
     T extends (abstract new (...args: any[]) => IEntityInstance &
       InstanceType<TBase>) &

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -55,6 +55,12 @@ export interface EntityInterface<T = any> extends SchemaSimple {
     existing: any,
     incoming: any,
   ): any;
+  mergeMeta?(
+    existingMeta: any,
+    incomingMeta: any,
+    existing: any,
+    incoming: any,
+  ): any;
   // TODO(breaking): deprecate this
   useIncoming?(
     existingMeta: any,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Allowing for more flexible schemas, including customizing expiry controls

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Hoist no `fetchAt` handling to earlier to simplify control flow, and reduce bundle size.
- Entity.mergeMeta() normalize lifecycle pushing metadata handling to the schema