### PR TITLE
feat: Add schema.Collection

### DIFF
--- a/.changeset/big-horses-begin.md
+++ b/.changeset/big-horses-begin.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/rest': minor
+---
+
+Added RestEndpoint.paginated('cursor').
+Place the name of the pagination field instead of writing a function

--- a/.changeset/cuddly-horses-peel.md
+++ b/.changeset/cuddly-horses-peel.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/normalizr': major
+---
+
+normalize/denormalize both take args array

--- a/.changeset/fluffy-students-raise.md
+++ b/.changeset/fluffy-students-raise.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/normalizr': minor
+'@rest-hooks/react': minor
+'@rest-hooks/core': minor
+---
+
+Support Collections

--- a/.changeset/giant-teachers-buy.md
+++ b/.changeset/giant-teachers-buy.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': minor
+---
+
+Add RestEndpoint collections extenders: push/unshift/assign/insert

--- a/.changeset/grumpy-walls-compare.md
+++ b/.changeset/grumpy-walls-compare.md
@@ -1,0 +1,10 @@
+---
+'@rest-hooks/normalizr': minor
+'@rest-hooks/core': minor
+'@rest-hooks/react': minor
+'@rest-hooks/endpoint': minor
+'@rest-hooks/rest': minor
+'rest-hooks/legacy': minor
+---
+
+Support using args[] during normalization/denormalization

--- a/.changeset/khaki-keys-wait.md
+++ b/.changeset/khaki-keys-wait.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/normalizr': minor
+'@rest-hooks/endpoint': minor
+'@rest-hooks/rest': minor
+---
+
+Entity.pk() has a fourth argument: args[]

--- a/.changeset/khaki-toys-worry.md
+++ b/.changeset/khaki-toys-worry.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': minor
+---
+
+Add next/createResource: Uses Collections and has more options from RestEndpoint

--- a/.changeset/tender-cooks-occur.md
+++ b/.changeset/tender-cooks-occur.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/test': patch
+---
+
+enhance: Updated warning example with modern syntax

--- a/.changeset/unlucky-rockets-remain.md
+++ b/.changeset/unlucky-rockets-remain.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/endpoint': minor
+'@rest-hooks/rest': minor
+---
+
+Add Collections - entities but for Arrays or Values

--- a/.changeset/violet-wombats-camp.md
+++ b/.changeset/violet-wombats-camp.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/test': patch
+---
+
+enhance: renderRestHook interceptors must be defined to warn about unmatched fetch

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,6 +46,14 @@
 					"endsPattern": "compiled successfully"
 				}
 			}
+		},
+		{
+			"type": "npm",
+			"script": "build",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: build",
+			"detail": "yarn build:types && yarn workspaces foreach -ptiv --no-private run build"
 		}
 	]
 }

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -1,5 +1,3 @@
-import React, { createContext, useContext } from 'react';
-
 import { SimpleRecord } from '@rest-hooks/legacy';
 import {
   AbstractInstanceType,
@@ -17,6 +15,7 @@ import {
   RestType,
   MutateEndpoint,
 } from '@rest-hooks/rest';
+import React, { createContext, useContext } from 'react';
 
 /** Represents data with primary key being from 'id' field. */
 export class IDEntity extends Entity {
@@ -604,7 +603,7 @@ export class SecondUnion extends UnionBase {
   readonly secondeOnlyField: number = 10;
 }
 
-const UnionSchema = new schema.Union(
+export const UnionSchema = new schema.Union(
   {
     first: FirstUnion,
     second: SecondUnion,

--- a/docs/rest/guides/summary-list.md
+++ b/docs/rest/guides/summary-list.md
@@ -45,7 +45,9 @@ delay: 150,
 },
 ]}>
 
-```typescript title="api/Article.ts" {9}
+```typescript title="api/Article.ts" {11,24}
+import { validateRequired } from '@rest-hooks/rest';
+
 class ArticleSummary extends Entity {
   readonly id: string = '';
   readonly title: string = '';
@@ -170,6 +172,7 @@ class Article extends ArticleSummary {
 
   static validate(processedEntity) {
     return (
+      // highlight-next-line
       validateRequired(processedEntity, this.defaults) ||
       super.validate(processedEntity)
     );

--- a/examples/benchmark/normalizr.js
+++ b/examples/benchmark/normalizr.js
@@ -57,6 +57,7 @@ export default function addNormlizrSuite(suite) {
     entities,
     denormCache.entities,
     denormCache.results['/fake'],
+    [],
   );
   denormalizeCached(
     queryState.result,
@@ -64,6 +65,7 @@ export default function addNormlizrSuite(suite) {
     queryState.entities,
     denormCache.entities,
     denormCache.results['/fakeQuery'],
+    [],
   );
   %OptimizeFunctionOnNextCall(denormalizeCached);
   %OptimizeFunctionOnNextCall(normalize);
@@ -73,6 +75,7 @@ export default function addNormlizrSuite(suite) {
       return normalize(
         data,
         ProjectSchema,
+        [],
         initialState.entities,
         initialState.indexes,
         initialState.entityMeta,
@@ -113,6 +116,7 @@ export default function addNormlizrSuite(suite) {
         entities,
         denormCache.entities,
         denormCache.results['/fake'],
+        [],
       );
     })
     .add('denormalizeLong All withCache', () => {
@@ -122,6 +126,7 @@ export default function addNormlizrSuite(suite) {
         queryState.entities,
         denormCache.entities,
         denormCache.results['/fakeQuery'],
+        [],
       );
     })
     .add('denormalizeLong Query-sorted withCache', () => {
@@ -131,6 +136,7 @@ export default function addNormlizrSuite(suite) {
         queryState.entities,
         denormCache.entities,
         denormCache.results['/fakeQuery'],
+        [],
       );
     })
     .on('complete', function () {

--- a/packages/core/src/controller/BaseController.ts
+++ b/packages/core/src/controller/BaseController.ts
@@ -401,6 +401,7 @@ export default class Controller<
       state.entities,
       this.globalCache.entities,
       this.globalCache.results[key],
+      args,
     ) as { data: DenormalizeNullable<E['schema']>; paths: Path[] };
     const invalidDenormalize = typeof data === 'symbol';
 

--- a/packages/core/src/next/Controller.ts
+++ b/packages/core/src/next/Controller.ts
@@ -30,7 +30,7 @@ export default class Controller<
 
     if (endpoint.schema) {
       return action.meta.promise.then(input =>
-        denormalize(input, endpoint.schema, {}),
+        denormalize(input, endpoint.schema, {}, args),
       ) as any;
     }
     return action.meta.promise as any;

--- a/packages/core/src/state/reducer/setReducer.ts
+++ b/packages/core/src/state/reducer/setReducer.ts
@@ -40,6 +40,7 @@ export function setReducer(
     const { result, entities, indexes, entityMeta } = normalize(
       payload,
       action.meta.schema,
+      action.meta.args as any,
       state.entities,
       state.indexes,
       state.entityMeta,

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -25,13 +25,19 @@ export interface SchemaSimple<T = any> {
     visit: (...args: any) => any,
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
+    storeEntities: any,
+    args: any[],
   ): any;
   denormalize(
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {},
     unvisit: UnvisitFunction,
   ): [denormalized: T, found: boolean, suspend: boolean];
-  denormalizeOnly?(input: {}, unvisit: (input: any, schema: any) => any): T;
+  denormalizeOnly?(
+    input: {},
+    args: any,
+    unvisit: (input: any, schema: any) => any,
+  ): T;
   infer(
     args: readonly any[],
     indexes: NormalizedIndex,
@@ -50,7 +56,7 @@ export interface SchemaClass<T = any, N = T | undefined>
 
 export interface EntityInterface<T = any> extends SchemaSimple {
   createIfValid?(props: any): any;
-  pk(params: any, parent?: any, key?: string): string | undefined;
+  pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
   readonly key: string;
   merge(existing: any, incoming: any): any;
   expiresAt?(meta: any, input: any): number;

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -70,7 +70,7 @@ export type Denormalize<S> = S extends EntityInterface<infer U>
   ? AbstractInstanceType<S>
   : S extends { denormalizeOnly: (...args: any) => any }
   ? ReturnType<S['denormalizeOnly']>
-  : S extends SchemaClass
+  : S extends { denormalize: (...args: any) => any }
   ? DenormalizeReturnType<S['denormalize']>
   : S extends Serializable<infer T>
   ? T
@@ -84,7 +84,7 @@ export type DenormalizeNullable<S> = S extends EntityInterface<any>
   ? DenormalizeNullableNestedSchema<S> | undefined
   : S extends RecordClass
   ? DenormalizeNullableNestedSchema<S>
-  : S extends SchemaClass
+  : S extends { _denormalizeNullable: (...args: any) => any }
   ? DenormalizeReturnType<S['_denormalizeNullable']>
   : S extends Serializable<infer T>
   ? T
@@ -98,7 +98,7 @@ export type Normalize<S> = S extends EntityInterface
   ? string
   : S extends RecordClass
   ? NormalizeObject<S['schema']>
-  : S extends SchemaClass
+  : S extends { normalize: (...args: any) => any }
   ? NormalizeReturnType<S['normalize']>
   : S extends Serializable<infer T>
   ? T
@@ -112,7 +112,7 @@ export type NormalizeNullable<S> = S extends EntityInterface
   ? string | undefined
   : S extends RecordClass
   ? NormalizedNullableObject<S['schema']>
-  : S extends SchemaClass
+  : S extends { _normalizeNullable: (...args: any) => any }
   ? NormalizeReturnType<S['_normalizeNullable']>
   : S extends Serializable<infer T>
   ? T

--- a/packages/endpoint/src/queryEndpoint.ts
+++ b/packages/endpoint/src/queryEndpoint.ts
@@ -46,10 +46,11 @@ export class Query<
     if (schema.denormalizeOnly)
       query.denormalizeOnly = (
         { args, input }: { args: P; input: any },
+        _: P,
         unvisit: any,
       ) => {
         if (input === undefined) return undefined;
-        const value = (schema as any).denormalizeOnly(input, unvisit);
+        const value = (schema as any).denormalizeOnly(input, args, unvisit);
         return typeof value === 'symbol'
           ? undefined
           : this.process(value, ...args);
@@ -83,5 +84,9 @@ type QuerySchema<Schema, R> = Exclude<
     input: {},
     unvisit: UnvisitFunction,
   ): [denormalized: R | undefined, found: boolean, suspend: boolean];
-  denormalizeOnly(input: {}, unvisit: (input: any, schema: any) => any): R;
+  denormalizeOnly(
+    input: {},
+    args: readonly any[],
+    unvisit: (input: any, schema: any) => any,
+  ): R;
 };

--- a/packages/endpoint/src/schema.js
+++ b/packages/endpoint/src/schema.js
@@ -6,4 +6,5 @@ export { default as All } from './schemas/All.js';
 export { default as Object } from './schemas/Object.js';
 export { default as Delete } from './schemas/Delete.js';
 export { default as Invalidate } from './schemas/Invalidate.js';
+export { default as Collection } from './schemas/Collection.js';
 export { default as Entity } from './schemas/EntitySchema.js';

--- a/packages/endpoint/src/schemas-3.7/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas-3.7/__tests__/Entity.test.ts
@@ -113,6 +113,7 @@ describe(`${Entity.name} normalization`, () => {
     const secondEntities = normalize(
       { id: '1', title: 'second' },
       MyEntity,
+      [],
       entities,
       {},
       entityMeta,

--- a/packages/endpoint/src/schemas-3.7/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas-3.7/__tests__/EntitySchema.test.ts
@@ -345,6 +345,7 @@ describe(`${schema.Entity.name} normalization`, () => {
     const secondEntities = normalize(
       { id: '1', title: 'second' },
       MyEntity,
+      [],
       entities,
       {},
       entityMeta,

--- a/packages/endpoint/src/schemas/All.ts
+++ b/packages/endpoint/src/schemas/All.ts
@@ -26,9 +26,20 @@ export default class AllSchema<
     visit: any,
     addEntity: any,
     visitedEntities: any,
+    storeEntities: any,
+    args?: any[],
   ): any {
     // we return undefined
-    super.normalize(input, parent, key, visit, addEntity, visitedEntities);
+    super.normalize(
+      input,
+      parent,
+      key,
+      visit,
+      addEntity,
+      visitedEntities,
+      storeEntities,
+      args,
+    );
   }
 
   infer(args: any, indexes: any, recurse: any, entities: EntityTable): any {

--- a/packages/endpoint/src/schemas/Array.ts
+++ b/packages/endpoint/src/schemas/Array.ts
@@ -13,6 +13,8 @@ export default class ArraySchema extends PolymorphicSchema {
     visit: any,
     addEntity: any,
     visitedEntities: any,
+    storeEntities: any,
+    args?: any[],
   ): any {
     const values = getValues(input);
 
@@ -25,6 +27,8 @@ export default class ArraySchema extends PolymorphicSchema {
           visit,
           addEntity,
           visitedEntities,
+          storeEntities,
+          args,
         ),
       )
       .filter(value => value !== undefined && value !== null);
@@ -34,10 +38,14 @@ export default class ArraySchema extends PolymorphicSchema {
     input: any,
     unvisit: any,
   ): [denormalized: any, found: boolean, deleted: boolean] {
-    return [this.denormalizeOnly(input, unvisit), true, false];
+    return [this.denormalizeOnly(input, [], unvisit), true, false];
   }
 
-  denormalizeOnly(input: any, unvisit: (input: any, schema: any) => any) {
+  denormalizeOnly(
+    input: any,
+    args: any[],
+    unvisit: (input: any, schema: any) => any,
+  ) {
     return input.map
       ? input
           .map((entityOrId: any) => this.denormalizeValue(entityOrId, unvisit))

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -6,7 +6,7 @@ import { AbstractInstanceType } from '../normal.js';
 import { Entity as EntitySchema } from '../schema.js';
 
 const EmptyBase = class {} as any as abstract new (...args: any[]) => {
-  pk(parent?: any, key?: string): string | undefined;
+  pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
 };
 
 /**
@@ -20,7 +20,11 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
    * @param [parent] When normalizing, the object which included the entity
    * @param [key] When normalizing, the key where this entity was found
    */
-  abstract pk(parent?: any, key?: string): string | undefined;
+  abstract pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | undefined;
 
   /** Control how automatic schema validation is handled
    *
@@ -116,6 +120,7 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
     value: Partial<AbstractInstanceType<T>>,
     parent?: any,
     key?: string,
+    args?: any[],
   ) => string | undefined;
 
   /** Do any transformations when first receiving input */

--- a/packages/endpoint/src/schemas/Invalidate.ts
+++ b/packages/endpoint/src/schemas/Invalidate.ts
@@ -39,10 +39,12 @@ export default class Invalidate<
     visit: (...args: any) => any,
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
+    storeEntities: Record<string, any>,
+    args?: any[],
   ): string | undefined {
     // TODO: what's store needs to be a differing type from fromJS
     const processedEntity = this._entity.process(input, parent, key);
-    const id = this._entity.pk(processedEntity, parent, key);
+    const id = this._entity.pk(processedEntity, parent, key, args);
 
     if (
       process.env.NODE_ENV !== 'production' &&
@@ -103,6 +105,7 @@ export default class Invalidate<
 
   denormalizeOnly(
     id: string,
+    args: readonly any[],
     unvisit: (input: any, schema: any) => any,
   ): AbstractInstanceType<E> {
     return unvisit(id, this._entity) as any;

--- a/packages/endpoint/src/schemas/Object.ts
+++ b/packages/endpoint/src/schemas/Object.ts
@@ -12,6 +12,8 @@ export const normalize = (
   visit: any,
   addEntity: any,
   visitedEntities: any,
+  storeEntities: any,
+  args: any[],
 ) => {
   const object = { ...input };
   Object.keys(schema).forEach(key => {
@@ -23,6 +25,8 @@ export const normalize = (
       localSchema,
       addEntity,
       visitedEntities,
+      storeEntities,
+      args,
     );
     if (value === undefined || value === null) {
       delete object[key];
@@ -64,6 +68,7 @@ export const denormalize = (
 export function denormalizeOnly(
   schema: any,
   input: {},
+  args: readonly any[],
   unvisit: (input: any, schema: any) => any,
 ): any {
   if (isImmutable(input)) {
@@ -97,7 +102,6 @@ export function infer(
   });
   return resultObject;
 }
-
 /**
  * Represents objects with statically known members
  * @see https://resthooks.io/rest/api/Object
@@ -124,6 +128,8 @@ export default class ObjectSchema {
       visit: any,
       addEntity: any,
       visitedEntities: any,
+      storeEntities: any,
+      args: any[],
     ]
   ) {
     return normalize(this.schema, ...args);
@@ -134,8 +140,12 @@ export default class ObjectSchema {
     return denormalize(this.schema, ...args);
   }
 
-  denormalizeOnly(input: {}, unvisit: (input: any, schema: any) => any): any {
-    return denormalizeOnly(this.schema, input, unvisit);
+  denormalizeOnly(
+    input: {},
+    args: readonly any[],
+    unvisit: (input: any, schema: any) => any,
+  ): any {
+    return denormalizeOnly(this.schema, input, args, unvisit);
   }
 
   infer(args: any, indexes: any, recurse: any, entities: any) {

--- a/packages/endpoint/src/schemas/Polymorphic.ts
+++ b/packages/endpoint/src/schemas/Polymorphic.ts
@@ -23,7 +23,13 @@ export default class PolymorphicSchema {
   }
 
   define(definition: any) {
-    this.schema = definition;
+    // sending Union into another Polymorphic gets hoisted
+    if ('_schemaAttribute' in definition && !this._schemaAttribute) {
+      this.schema = definition.schema;
+      this._schemaAttribute = definition._schemaAttribute;
+    } else {
+      this.schema = definition;
+    }
   }
 
   getSchemaAttribute(input: any, parent: any, key: any) {
@@ -46,7 +52,10 @@ export default class PolymorphicSchema {
     visit: any,
     addEntity: any,
     visitedEntities: any,
+    storeEntities: any,
+    args?: any[],
   ) {
+    if (!value) return value;
     const schema = this.inferSchema(value, parent, key);
     if (!schema) {
       /* istanbul ignore else */
@@ -74,6 +83,8 @@ Value: ${JSON.stringify(value, undefined, 2)}`,
       schema,
       addEntity,
       visitedEntities,
+      storeEntities,
+      args,
     );
     return this.isSingleSchema ||
       normalizedValue === undefined ||

--- a/packages/endpoint/src/schemas/Union.ts
+++ b/packages/endpoint/src/schemas/Union.ts
@@ -21,6 +21,8 @@ export default class UnionSchema extends PolymorphicSchema {
     visit: any,
     addEntity: any,
     visitedEntities: any,
+    storeEntities: any,
+    args: any[],
   ) {
     return this.normalizeValue(
       input,
@@ -29,6 +31,8 @@ export default class UnionSchema extends PolymorphicSchema {
       visit,
       addEntity,
       visitedEntities,
+      storeEntities,
+      args,
     );
   }
 
@@ -38,7 +42,11 @@ export default class UnionSchema extends PolymorphicSchema {
     return [value, value !== undefined, typeof value === 'symbol'];
   }
 
-  denormalizeOnly(input: {}, unvisit: (input: any, schema: any) => any) {
+  denormalizeOnly(
+    input: {},
+    args: readonly any[],
+    unvisit: (input: any, schema: any) => any,
+  ) {
     return this.denormalizeValue(input, unvisit);
   }
 

--- a/packages/endpoint/src/schemas/Values.ts
+++ b/packages/endpoint/src/schemas/Values.ts
@@ -12,6 +12,8 @@ export default class ValuesSchema extends PolymorphicSchema {
     visit: any,
     addEntity: any,
     visitedEntities: any,
+    storeEntities: any,
+    args: any[],
   ) {
     return Object.keys(input).reduce((output, key, index) => {
       const value = input[key];
@@ -25,6 +27,8 @@ export default class ValuesSchema extends PolymorphicSchema {
               visit,
               addEntity,
               visitedEntities,
+              storeEntities,
+              args,
             ),
           }
         : output;
@@ -48,7 +52,11 @@ export default class ValuesSchema extends PolymorphicSchema {
     ];
   }
 
-  denormalizeOnly(input: {}, unvisit: (input: any, schema: any) => any): any {
+  denormalizeOnly(
+    input: {},
+    args: readonly any[],
+    unvisit: (input: any, schema: any) => any,
+  ): any {
     return Object.keys(input).reduce((output, key) => {
       const entityOrId = (input as any)[key];
       const value = this.denormalizeValue(entityOrId, unvisit);

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -1,0 +1,394 @@
+// eslint-env jest
+import { inferResults, normalize, WeakEntityMap } from '@rest-hooks/normalizr';
+import { IDEntity } from '__tests__/new';
+import { fromJS, Record } from 'immutable';
+
+import { denormalizeSimple as denormalize } from './denormalize';
+import WeakListMap from './legacy-compat/WeakListMap';
+import { AbstractInstanceType } from '../..';
+import { schema } from '../..';
+import Entity from '../Entity';
+
+let dateSpy: jest.SpyInstance;
+beforeAll(() => {
+  dateSpy = jest
+    // eslint-disable-next-line no-undef
+    .spyOn(global.Date, 'now')
+    .mockImplementation(() => new Date('2019-05-14T11:01:58.135Z').valueOf());
+});
+afterAll(() => {
+  dateSpy.mockRestore();
+});
+
+const values = <T extends { [k: string]: any }>(obj: T) =>
+  Object.keys(obj).map(key => obj[key]);
+
+class Tacos extends IDEntity {
+  readonly name: string = '';
+  readonly alias: string | undefined = undefined;
+}
+
+class Todo extends IDEntity {
+  userId = 0;
+  title = '';
+  completed = false;
+
+  static key = 'Todo';
+}
+
+class User extends IDEntity {
+  name = '';
+  username = '';
+  email = '';
+  todos: Todo[] = [];
+
+  static key = 'User';
+  static schema = {
+    todos: new schema.Collection(new schema.Array(Todo), {
+      nestKey: (parent, key) => ({
+        userId: parent.id,
+      }),
+    }),
+  };
+}
+
+const userTodos = new schema.Collection(new schema.Array(Todo), {
+  argsKey: ({ userId }: { userId: string }) => ({
+    userId,
+  }),
+});
+
+describe(`${schema.Collection.name} normalization`, () => {
+  let warnSpy: jest.SpyInstance;
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+  beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
+
+  test('throws without a key option', () => {
+    // @ts-expect-error
+    expect(() => new schema.Collection(new schema.Array(Todo), {})).toThrow();
+  });
+
+  test('should throw a custom error if data loads with string unexpected value', () => {
+    function normalizeBad() {
+      normalize('abc', userTodos);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw a custom error if data loads with string unexpected value', () => {
+    function normalizeBad() {
+      normalize(null, userTodos.push);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw a custom error if data loads with string unexpected value', () => {
+    function normalizeBad() {
+      // @ts-expect-error
+      userTodos.normalize(
+        [],
+        undefined,
+        '',
+        () => undefined,
+        () => undefined,
+        {},
+      );
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  test('normalizes nested collections', () => {
+    const state = normalize(
+      {
+        id: '1',
+        username: 'bob',
+        todos: [{ id: '5', title: 'finish collections' }],
+      },
+      User,
+    );
+    expect(state).toMatchSnapshot();
+    //const a: string | undefined = state.result;
+    // @ts-expect-error
+    const b: Record<any, any> | undefined = state.result;
+  });
+
+  test('normalizes top level collections', () => {
+    const state = normalize(
+      [{ id: '5', title: 'finish collections' }],
+      userTodos,
+      [{ userId: '1' }],
+    );
+    expect(state).toMatchSnapshot();
+    //const a: string[] | undefined = state.result;
+    // @ts-expect-error
+    const b: Record<any, any> | undefined = state.result;
+  });
+
+  test('normalizes already processed entities', () => {
+    const state = normalize(
+      {
+        id: '1',
+        username: 'bob',
+        todos: ['5', '6'],
+      },
+      User,
+    );
+    expect(state).toMatchSnapshot();
+  });
+
+  test('normalizes push onto the end', () => {
+    const init = {
+      entities: {
+        'COLLECT:ArraySchema(Todo)': {
+          '{"userId":"1"}': ['5'],
+        },
+        Todo: {
+          '5': {
+            id: '5',
+            title: 'finish collections',
+          },
+        },
+        User: {
+          '1': {
+            id: '1',
+            todos: '{"userId":"1"}',
+            username: 'bob',
+          },
+        },
+      },
+      entityMeta: {
+        'COLLECT:ArraySchema(Todo)': {
+          '{"userId":"1"}': {
+            date: 1557831718135,
+            expiresAt: Infinity,
+            fetchedAt: 0,
+          },
+        },
+        Todo: {
+          '5': {
+            date: 1557831718135,
+            expiresAt: Infinity,
+            fetchedAt: 0,
+          },
+        },
+        User: {
+          '1': {
+            date: 1557831718135,
+            expiresAt: Infinity,
+            fetchedAt: 0,
+          },
+        },
+      },
+      indexes: {},
+      result: '1',
+    };
+    const state = normalize(
+      [{ id: '10', title: 'create new items' }],
+      User.schema.todos.push,
+      [{ userId: '1' }],
+      init.entities,
+      init.indexes,
+      init.entityMeta,
+    );
+    expect(state).toMatchSnapshot();
+  });
+});
+
+describe(`${schema.Collection.name} denormalization`, () => {
+  const normalizeNested = {
+    entities: {
+      'COLLECT:ArraySchema(Todo)': {
+        '{"userId":"1"}': ['5'],
+      },
+      Todo: {
+        '5': {
+          id: '5',
+          title: 'finish collections',
+        },
+      },
+      User: {
+        '1': {
+          id: '1',
+          todos: '{"userId":"1"}',
+          username: 'bob',
+        },
+      },
+    },
+    entityMeta: {
+      'COLLECT:ArraySchema(Todo)': {
+        '{"userId":"1"}': {
+          date: 1557831718135,
+          expiresAt: Infinity,
+          fetchedAt: 0,
+        },
+      },
+      Todo: {
+        '5': {
+          date: 1557831718135,
+          expiresAt: Infinity,
+          fetchedAt: 0,
+        },
+      },
+      User: {
+        '1': {
+          date: 1557831718135,
+          expiresAt: Infinity,
+          fetchedAt: 0,
+        },
+      },
+    },
+    indexes: {},
+    result: '1',
+  };
+
+  test('denormalizes nested collections', () => {
+    expect(
+      denormalize(normalizeNested.result, User, normalizeNested.entities),
+    ).toMatchSnapshot();
+  });
+
+  test('denormalizes top level collections', () => {
+    expect(
+      denormalize('{"userId":"1"}', userTodos, normalizeNested.entities),
+    ).toMatchSnapshot();
+  });
+
+  describe('caching', () => {
+    const entityCache = {};
+    const resultCache = new WeakEntityMap();
+    test('denormalizes nested and top level share referential equality', () => {
+      const todos = denormalize(
+        '{"userId":"1"}',
+        userTodos,
+        normalizeNested.entities,
+        entityCache,
+        resultCache,
+        [{ userId: '1' }],
+      );
+      const user = denormalize(
+        normalizeNested.result,
+        User,
+        normalizeNested.entities,
+        entityCache,
+        resultCache,
+      );
+      expect(user).toBeDefined();
+      expect(user).not.toEqual(expect.any(Symbol));
+      if (typeof user === 'symbol' || !user) return;
+      expect(todos).toBe(user.todos);
+    });
+
+    test('push updates cache', () => {
+      const pushedState = normalize(
+        [{ id: '10', title: 'create new items' }],
+        User.schema.todos.push,
+        [{ userId: '1' }],
+        normalizeNested.entities,
+        normalizeNested.indexes,
+        normalizeNested.entityMeta,
+      );
+      const todos = denormalize(
+        '{"userId":"1"}',
+        userTodos,
+        pushedState.entities,
+        entityCache,
+        resultCache,
+        [{ userId: '1' }],
+      );
+      const user = denormalize(
+        normalizeNested.result,
+        User,
+        pushedState.entities,
+        entityCache,
+        resultCache,
+        [{ id: '1' }],
+      );
+      expect(user).toBeDefined();
+      expect(user).not.toEqual(expect.any(Symbol));
+      if (typeof user === 'symbol' || !user) return;
+      expect(user.todos.length).toBe(2);
+      expect(todos).toBe(user.todos);
+    });
+
+    test('unshift places at start', () => {
+      const unshiftState = normalize(
+        [{ id: '2', title: 'from the start' }],
+        User.schema.todos.unshift,
+        [{ userId: '1' }],
+        normalizeNested.entities,
+        normalizeNested.indexes,
+        normalizeNested.entityMeta,
+      );
+      const todos = denormalize(
+        '{"userId":"1"}',
+        userTodos,
+        unshiftState.entities,
+        entityCache,
+        resultCache,
+        [{ userId: '1' }],
+      );
+      const user = denormalize(
+        normalizeNested.result,
+        User,
+        unshiftState.entities,
+        entityCache,
+        resultCache,
+        [{ id: '1' }],
+      );
+      expect(user).toBeDefined();
+      expect(user).not.toEqual(expect.any(Symbol));
+      if (typeof user === 'symbol' || !user) return;
+      expect(user.todos.length).toBe(2);
+      expect(todos).toBe(user.todos);
+      expect(user.todos[0].title).toBe('from the start');
+    });
+
+    test('denormalizes unshift', () => {
+      const todos = denormalize(
+        [{ id: '2', title: 'from the start' }],
+        userTodos.unshift,
+        {},
+        entityCache,
+        resultCache,
+        [{ id: '1' }],
+      );
+      expect(todos).toBeDefined();
+      expect(todos).not.toEqual(expect.any(Symbol));
+      if (typeof todos === 'symbol' || !todos) return;
+      expect(todos[0].title).toBe('from the start');
+      expect(todos).toMatchInlineSnapshot(`
+        [
+          Todo {
+            "completed": false,
+            "id": "2",
+            "title": "from the start",
+            "userId": 0,
+          },
+        ]
+      `);
+    });
+
+    test('denormalizes unshift (single item)', () => {
+      const todos = denormalize(
+        { id: '2', title: 'from the start' },
+        userTodos.unshift,
+        {},
+        entityCache,
+        resultCache,
+        [{ id: '1' }],
+      );
+      expect(todos).toBeDefined();
+      expect(todos).not.toEqual(expect.any(Symbol));
+      if (typeof todos === 'symbol' || !todos) return;
+      //expect(todos.title).toBe('from the start');
+      expect(todos).toMatchInlineSnapshot(`
+        {
+          "id": "2",
+          "title": "from the start",
+        }
+      `);
+    });
+  });
+});

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -101,6 +101,7 @@ describe(`${Entity.name} normalization`, () => {
     const secondEntities = normalize(
       { id: '1', title: 'second' },
       MyEntity,
+      [],
       entities,
       {},
       entityMeta,

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -346,6 +346,7 @@ describe(`${schema.Entity.name} normalization`, () => {
     const secondEntities = normalize(
       { id: '1', title: 'second' },
       MyEntity,
+      [],
       entities,
       {},
       entityMeta,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
@@ -1,0 +1,247 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CollectionSchema denormalization denormalizes nested collections 1`] = `
+User {
+  "email": "",
+  "id": "1",
+  "name": "",
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "finish collections",
+      "userId": 0,
+    },
+  ],
+  "username": "bob",
+}
+`;
+
+exports[`CollectionSchema denormalization denormalizes top level collections 1`] = `
+[
+  Todo {
+    "completed": false,
+    "id": "5",
+    "title": "finish collections",
+    "userId": 0,
+  },
+]
+`;
+
+exports[`CollectionSchema normalization normalizes already processed entities 1`] = `
+{
+  "entities": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": [
+        "5",
+        "6",
+      ],
+    },
+    "User": {
+      "1": {
+        "id": "1",
+        "todos": "{"userId":"1"}",
+        "username": "bob",
+      },
+    },
+  },
+  "entityMeta": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "User": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "1",
+}
+`;
+
+exports[`CollectionSchema normalization normalizes nested collections 1`] = `
+{
+  "entities": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
+    "Todo": {
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+    },
+    "User": {
+      "1": {
+        "id": "1",
+        "todos": "{"userId":"1"}",
+        "username": "bob",
+      },
+    },
+  },
+  "entityMeta": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Todo": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "User": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "1",
+}
+`;
+
+exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
+{
+  "entities": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": [
+        "5",
+        "10",
+      ],
+    },
+    "Todo": {
+      "10": {
+        "id": "10",
+        "title": "create new items",
+      },
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+    },
+    "User": {
+      "1": {
+        "id": "1",
+        "todos": "{"userId":"1"}",
+        "username": "bob",
+      },
+    },
+  },
+  "entityMeta": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Todo": {
+      "10": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "User": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    "10",
+  ],
+}
+`;
+
+exports[`CollectionSchema normalization normalizes top level collections 1`] = `
+{
+  "entities": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
+    "Todo": {
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+    },
+  },
+  "entityMeta": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Todo": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "{"userId":"1"}",
+}
+`;
+
+exports[`CollectionSchema normalization should throw a custom error if data loads with string unexpected value 1`] = `
+"Unexpected input given to normalize. Expected type to be "object", found "string".
+
+          Schema: {
+  "name": "Collection(Todo)",
+  "schema": {
+    "name": "Todo",
+    "schema": {},
+    "key": "Todo"
+  },
+  "key": "COLLECT:ArraySchema(Todo)"
+}
+          Input: "abc""
+`;
+
+exports[`CollectionSchema normalization should throw a custom error if data loads with string unexpected value 2`] = `
+"Unexpected input given to normalize. Expected type to be "object", found "null".
+
+          Schema: {
+  "name": "Collection(Todo)",
+  "schema": {
+    "name": "Todo",
+    "schema": {},
+    "key": "Todo"
+  },
+  "key": "COLLECT:ArraySchema(Todo)"
+}
+          Input: "null""
+`;
+
+exports[`CollectionSchema normalization should throw a custom error if data loads with string unexpected value 3`] = `"Collections only work with @rest-hooks/react>=7.4"`;

--- a/packages/endpoint/src/schemas/__tests__/denormalize.ts
+++ b/packages/endpoint/src/schemas/__tests__/denormalize.ts
@@ -18,8 +18,9 @@ export const denormalizeSimple = <S extends Schema>(
   entities: any,
   entityCache: DenormalizeCache['entities'] = {},
   resultCache: DenormalizeCache['results'][string] = new WeakEntityMap(),
+  args: any[] = [],
 ): Denormalize<S> | DenormalizeNullable<S> | symbol =>
-  denormalizeCore(input, schema, entities, entityCache, resultCache)
+  denormalizeCore(input, schema, entities, entityCache, resultCache, args)
     .data as any;
 
 export default denormalizeSimple;

--- a/packages/legacy/src/SimpleRecord.ts
+++ b/packages/legacy/src/SimpleRecord.ts
@@ -114,6 +114,8 @@ export default abstract class SimpleRecord {
       visit: (...args: any) => any,
       addEntity: (...args: any) => any,
       visitedEntities: Record<string, any>,
+      storeEntities: Record<string, any>,
+      args?: any[],
     ]
   ): NormalizedEntity<T> {
     return schema.Object.prototype.normalize.call(this, ...args) as any;

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -344,7 +344,7 @@ describe('normalize', () => {
     }
 
     expect(
-      normalize({ user: { id: '456' } }, Recommendations),
+      normalize({ user: { id: '456' } }, Recommendations, [{ id: '456' }]),
     ).toMatchSnapshot();
     expect(calls).toMatchSnapshot();
   });

--- a/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
+++ b/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
@@ -20,6 +20,7 @@ describe('normalizer() merging', () => {
       const { result, entities } = normalize(
         { id, title: 'hello' },
         Article,
+        [],
         first,
         {},
         firstEM,
@@ -56,6 +57,7 @@ describe('normalizer() merging', () => {
       const { entities } = normalize(
         { id, title: 'hi', content: 'this is the content' },
         Article,
+        [],
         entitiesA,
       );
 
@@ -78,6 +80,7 @@ describe('normalizer() merging', () => {
       const { result, entities } = normalize(
         { id, title: null },
         Article,
+        [],
         first,
         {},
         firstEM,
@@ -105,7 +108,7 @@ describe('normalizer() merging', () => {
         Article,
       );
 
-      normalize({ id, title: 'hello' }, Article, first);
+      normalize({ id, title: 'hello' }, Article, [], first);
 
       const merged = denormalize(id, Article, first);
       expect(merged).toBeInstanceOf(Article);
@@ -123,7 +126,7 @@ describe('normalizer() merging', () => {
       const { entities: first } = normalize({ id }, new schema.Delete(Article));
 
       const nested = { id, title: 'hello' };
-      const { entities } = normalize(nested, Article, first);
+      const { entities } = normalize(nested, Article, [], first);
 
       expect(entities).toMatchInlineSnapshot(`
         {
@@ -166,6 +169,7 @@ describe('normalizer() merging', () => {
       const { entities } = normalize(
         { id, title: 'hi', content: 'this is the content' },
         User,
+        [],
         entitiesA,
       );
 
@@ -222,6 +226,7 @@ describe('normalizer() merging', () => {
       const { entities } = normalize(
         { id, title: 'hi', content: 'this is the content' },
         User,
+        [],
         entitiesA,
         {},
         meta,

--- a/packages/normalizr/src/denormalize/denormalize.ts
+++ b/packages/normalizr/src/denormalize/denormalize.ts
@@ -8,12 +8,16 @@ export const denormalize = <S extends Schema>(
   input: any,
   schema: S | undefined,
   entities: any,
+  args: readonly any[] = [],
 ): DenormalizeNullable<S> | symbol => {
   // undefined means don't do anything
   if (schema === undefined || input === undefined) {
     return input as any;
   }
 
-  return getUnvisit(getEntities(entities), new LocalCache())(input, schema)
-    .data;
+  return getUnvisit(
+    getEntities(entities),
+    new LocalCache(),
+    args,
+  )(input, schema).data;
 };

--- a/packages/normalizr/src/denormalize/denormalizeCached.ts
+++ b/packages/normalizr/src/denormalize/denormalizeCached.ts
@@ -16,6 +16,7 @@ export const denormalize = <S extends Schema>(
   entities: any,
   entityCache: DenormalizeCache['entities'] = {},
   resultCache: DenormalizeCache['results'][string] = new WeakEntityMap(),
+  args: readonly any[] = [],
 ): {
   data: DenormalizeNullable<S> | symbol;
   paths: Path[];
@@ -32,5 +33,6 @@ export const denormalize = <S extends Schema>(
   return getUnvisit(
     getEntity,
     new GlobalCache(getEntity, entityCache, resultCache),
+    args,
   )(input, schema);
 };

--- a/packages/normalizr/src/denormalize/globalCache.ts
+++ b/packages/normalizr/src/denormalize/globalCache.ts
@@ -138,6 +138,10 @@ interface EntityCacheValue {
 const getEntityCaches = (entityCache: DenormalizeCache['entities']) => {
   return (pk: string, schema: EntityInterface) => {
     const key = schema.key;
+    // collections should use the entities they collect over
+    // TODO: this should be based on a public interface
+    const entityInstance: EntityInterface =
+      (schema.schema?.schema as any) ?? schema;
 
     if (!(key in entityCache)) {
       entityCache[key] = Object.create(null);
@@ -149,10 +153,12 @@ const getEntityCaches = (entityCache: DenormalizeCache['entities']) => {
         WeakEntityMap<object, any>
       >();
 
-    let wem: WeakEntityMap<object, any> = entityCacheKey[pk].get(schema) as any;
+    let wem: WeakEntityMap<object, any> = entityCacheKey[pk].get(
+      entityInstance,
+    ) as any;
     if (!wem) {
       wem = new WeakEntityMap<object, any>();
-      entityCacheKey[pk].set(schema, wem);
+      entityCacheKey[pk].set(entityInstance, wem);
     }
 
     return wem;

--- a/packages/normalizr/src/endpoint/EndpointInterface.ts
+++ b/packages/normalizr/src/endpoint/EndpointInterface.ts
@@ -11,7 +11,7 @@ export interface EndpointInterface<
   S extends Schema | undefined = Schema | undefined,
   M extends boolean | undefined = boolean | undefined,
 > extends EndpointExtraOptions<F> {
-  (...args: Parameters<F>): InferReturn<F, S>;
+  (...args: Parameters<F>): ReturnType<F>;
   key(...args: Parameters<F>): string;
   readonly sideEffect?: M;
   readonly schema?: S;

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -20,13 +20,19 @@ export interface SchemaSimple<T = any> {
     visit: (...args: any) => any,
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
+    storeEntities?: any,
+    args?: any[],
   ): any;
   denormalize?(
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {},
     unvisit: UnvisitFunction,
   ): [denormalized: T, found: boolean, suspend: boolean];
-  denormalizeOnly?(input: {}, unvisit: (input: any, schema: any) => any): T;
+  denormalizeOnly?(
+    input: {},
+    args: any,
+    unvisit: (input: any, schema: any) => any,
+  ): T;
   infer(
     args: readonly any[],
     indexes: NormalizedIndex,
@@ -45,7 +51,12 @@ export interface SchemaClass<T = any, N = T | undefined>
 
 export interface EntityInterface<T = any> extends SchemaSimple {
   createIfValid?(props: any): any;
-  pk(params: any, parent?: any, key?: string): string | undefined;
+  pk(
+    params: any,
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | undefined;
   readonly key: string;
   merge(existing: any, incoming: any): any;
   expiresAt?(meta: any, input: any): number;

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -15,6 +15,8 @@ const visit = (
     id: string,
   ) => void,
   visitedEntities: any,
+  storeEntities: any,
+  args: any[],
 ) => {
   if (!value || !schema) {
     return value;
@@ -29,6 +31,8 @@ const visit = (
       visit,
       addEntity,
       visitedEntities,
+      storeEntities,
+      args,
     );
   }
 
@@ -40,7 +44,17 @@ const visit = (
   if (typeof value !== 'object' || typeof schema !== 'object') return value;
 
   const method = Array.isArray(schema) ? arrayNormalize : objectNormalize;
-  return method(schema, value, parent, key, visit, addEntity, visitedEntities);
+  return method(
+    schema,
+    value,
+    parent,
+    key,
+    visit,
+    addEntity,
+    visitedEntities,
+    storeEntities,
+    args,
+  );
 };
 
 const addEntities =
@@ -256,6 +270,7 @@ export const normalize = <
 >(
   input: any,
   schema?: S,
+  args: any[] = [],
   storeEntities: Readonly<E> = {} as any,
   storeIndexes: Readonly<NormalizedIndex> = {},
   storeEntityMeta: {
@@ -352,6 +367,8 @@ See https://resthooks.io/rest/api/RestEndpoint#parseResponse for more informatio
     schema,
     addEntity,
     visitedEntities,
+    storeEntities,
+    args,
   );
   return { entities, indexes, result, entityMeta };
 };

--- a/packages/normalizr/src/schemas/Array.ts
+++ b/packages/normalizr/src/schemas/Array.ts
@@ -25,6 +25,8 @@ export const normalize = (
   visit: any,
   addEntity: any,
   visitedEntities: any,
+  storeEntities: any,
+  args: any[],
 ) => {
   schema = validateSchema(schema);
 
@@ -33,11 +35,25 @@ export const normalize = (
   // Special case: Arrays pass *their* parent on to their children, since there
   // is not any special information that can be gathered from themselves directly
   return values.map((value, index) =>
-    visit(value, parent, key, schema, addEntity, visitedEntities),
+    visit(
+      value,
+      parent,
+      key,
+      schema,
+      addEntity,
+      visitedEntities,
+      storeEntities,
+      args,
+    ),
   );
 };
 
-export const denormalize = (schema: any, input: any, unvisit: any): any => {
+export const denormalize = (
+  schema: any,
+  input: any,
+  args: readonly any[],
+  unvisit: any,
+): any => {
   schema = validateSchema(schema);
   return input.map
     ? input.map(entityOrId => unvisit(entityOrId, schema)).filter(filterEmpty)

--- a/packages/normalizr/src/schemas/ImmutableUtils.ts
+++ b/packages/normalizr/src/schemas/ImmutableUtils.ts
@@ -37,6 +37,7 @@ export function isImmutable(object: {}): object is {
 export function denormalizeImmutable(
   schema: any,
   input: any,
+  args: readonly any[],
   unvisit: any,
 ): any {
   let deleted = false;

--- a/packages/normalizr/src/schemas/Object.ts
+++ b/packages/normalizr/src/schemas/Object.ts
@@ -9,6 +9,8 @@ export const normalize = (
   visit: any,
   addEntity: any,
   visitedEntities: any,
+  storeEntities: any,
+  args: any[],
 ) => {
   const object = { ...input };
   Object.keys(schema).forEach(key => {
@@ -20,6 +22,8 @@ export const normalize = (
       localSchema,
       addEntity,
       visitedEntities,
+      storeEntities,
+      args,
     );
     if (value === undefined || value === null) {
       delete object[key];
@@ -34,10 +38,11 @@ export const denormalize = (
   schema: any,
   // eslint-disable-next-line @typescript-eslint/ban-types
   input: {},
+  args: readonly any[],
   unvisit: any,
 ): any => {
   if (isImmutable(input)) {
-    return denormalizeImmutable(schema, input, unvisit);
+    return denormalizeImmutable(schema, input, args, unvisit);
   }
 
   const object = { ...input };

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -87,7 +87,7 @@ export type Denormalize<S> = S extends EntityInterface<infer U>
   ? AbstractInstanceType<S>
   : S extends { denormalizeOnly: (...args: any) => any }
   ? ReturnType<S['denormalizeOnly']>
-  : S extends SchemaClass
+  : S extends { denormalize: (...args: any) => any }
   ? DenormalizeReturnType<S['denormalize']>
   : S extends Serializable<infer T>
   ? T
@@ -101,7 +101,7 @@ export type DenormalizeNullable<S> = S extends EntityInterface<any>
   ? DenormalizeNullableNestedSchema<S> | undefined
   : S extends RecordClass
   ? DenormalizeNullableNestedSchema<S>
-  : S extends SchemaClass
+  : S extends { _denormalizeNullable: (...args: any) => any }
   ? DenormalizeReturnType<S['_denormalizeNullable']>
   : S extends Serializable<infer T>
   ? T
@@ -115,7 +115,7 @@ export type Normalize<S> = S extends EntityInterface
   ? string
   : S extends RecordClass
   ? NormalizeObject<S['schema']>
-  : S extends SchemaClass
+  : S extends { normalize: (...args: any) => any }
   ? NormalizeReturnType<S['normalize']>
   : S extends Serializable<infer T>
   ? T
@@ -129,7 +129,7 @@ export type NormalizeNullable<S> = S extends EntityInterface
   ? string | undefined
   : S extends RecordClass
   ? NormalizedNullableObject<S['schema']>
-  : S extends SchemaClass
+  : S extends { _normalizeNullable: (...args: any) => any }
   ? NormalizeReturnType<S['_normalizeNullable']>
   : S extends Serializable<infer T>
   ? T

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -1,0 +1,755 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CacheProvider RestEndpoint/current endpoint.assign should add to schema.Values Collections 1`] = `
+Article {
+  "author": null,
+  "content": "blah",
+  "id": 1,
+  "tags": [],
+  "title": "newly assigned",
+}
+`;
+
+exports[`CacheProvider RestEndpoint/current pagination should work with cursor field parameters 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/current should update collection on push/unshift 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": 3,
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": 5,
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/current should update on get for a paginated resource 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/current should update on get for a paginated resource with searchParams 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/next endpoint.assign should add to schema.Values Collections 1`] = `
+Article {
+  "author": null,
+  "content": "blah",
+  "id": 1,
+  "tags": [],
+  "title": "newly assigned",
+}
+`;
+
+exports[`CacheProvider RestEndpoint/next pagination should work with cursor field parameters 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/next should update collection on push/unshift 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": 3,
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": 5,
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/next should update on get for a paginated resource 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/next should update on get for a paginated resource with searchParams 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider should work with unions 1`] = `
+[
+  [
+    "Schema attribute "another" is not expected.
+Expected one of: "first", "second"
+
+Value: {
+  "id": "6",
+  "body": "hi",
+  "type": "another"
+}",
+  ],
+  [
+    "Schema attribute undefined is not expected.
+Expected one of: "first", "second"
+
+Value: {
+  "id": "7",
+  "body": "hi"
+}",
+  ],
+  [
+    "TypeError: Unable to infer schema for ArraySchema
+Value: {
+  "id": "6",
+  "body": "hi",
+  "type": "another"
+}.",
+  ],
+  [
+    "TypeError: Unable to infer schema for ArraySchema
+Value: {
+  "id": "7",
+  "body": "hi"
+}.",
+  ],
+]
+`;
+
+exports[`CacheProvider should work with unions 2`] = `
+[
+  FirstUnion {
+    "body": "hi",
+    "firstOnlyField": 5,
+    "id": "5",
+    "type": "first",
+  },
+  {
+    "body": "hi",
+    "id": "6",
+    "type": "another",
+  },
+  {
+    "body": "hi",
+    "id": "7",
+  },
+  SecondUnion {
+    "body": "hi",
+    "id": 100,
+    "secondeOnlyField": 10,
+    "type": "second",
+  },
+]
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/current endpoint.assign should add to schema.Values Collections 1`] = `
+Article {
+  "author": null,
+  "content": "blah",
+  "id": 1,
+  "tags": [],
+  "title": "newly assigned",
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/current pagination should work with cursor field parameters 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/current should update collection on push/unshift 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": 3,
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": 5,
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/current should update on get for a paginated resource 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/current should update on get for a paginated resource with searchParams 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/next endpoint.assign should add to schema.Values Collections 1`] = `
+Article {
+  "author": null,
+  "content": "blah",
+  "id": 1,
+  "tags": [],
+  "title": "newly assigned",
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/next pagination should work with cursor field parameters 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/next should update collection on push/unshift 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": 3,
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": 5,
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": 5,
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/next should update on get for a paginated resource 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/next should update on get for a paginated resource with searchParams 1`] = `
+{
+  "results": [
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 5,
+      "tags": [
+        "a",
+        "best",
+        "react",
+      ],
+      "title": "hi ho",
+    },
+    Article {
+      "author": User {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+      "content": "whatever",
+      "id": 3,
+      "tags": [],
+      "title": "the next time",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider should work with unions 1`] = `
+[
+  [
+    "Schema attribute "another" is not expected.
+Expected one of: "first", "second"
+
+Value: {
+  "id": "6",
+  "body": "hi",
+  "type": "another"
+}",
+  ],
+  [
+    "Schema attribute undefined is not expected.
+Expected one of: "first", "second"
+
+Value: {
+  "id": "7",
+  "body": "hi"
+}",
+  ],
+  [
+    "TypeError: Unable to infer schema for ArraySchema
+Value: {
+  "id": "6",
+  "body": "hi",
+  "type": "another"
+}.",
+  ],
+  [
+    "TypeError: Unable to infer schema for ArraySchema
+Value: {
+  "id": "7",
+  "body": "hi"
+}.",
+  ],
+]
+`;
+
+exports[`ExternalCacheProvider should work with unions 2`] = `
+[
+  FirstUnion {
+    "body": "hi",
+    "firstOnlyField": 5,
+    "id": "5",
+    "type": "first",
+  },
+  {
+    "body": "hi",
+    "id": "6",
+    "type": "another",
+  },
+  {
+    "body": "hi",
+    "id": "7",
+  },
+  SecondUnion {
+    "body": "hi",
+    "id": 100,
+    "secondeOnlyField": 10,
+    "type": "second",
+  },
+]
+`;

--- a/packages/react/src/__tests__/integration-collections.tsx
+++ b/packages/react/src/__tests__/integration-collections.tsx
@@ -1,0 +1,477 @@
+import { CacheProvider } from '@rest-hooks/react';
+import { CacheProvider as ExternalCacheProvider } from '@rest-hooks/redux';
+import { schema, RestEndpoint } from '@rest-hooks/rest';
+import { createResource } from '@rest-hooks/rest/next';
+import {
+  IDEntity,
+  Article,
+  UnionSchema,
+  FirstUnion,
+  SecondUnion,
+} from '__tests__/new';
+import nock from 'nock';
+
+import { makeRenderRestHook, act } from '../../../test';
+import { useSuspense } from '../hooks';
+import {
+  paginatedFirstPage,
+  paginatedSecondPage,
+  valuesFixture,
+} from '../test-fixtures';
+
+class Todo extends IDEntity {
+  userId = 0;
+  title = '';
+  completed = false;
+
+  static key = 'Todo';
+}
+
+class User extends IDEntity {
+  name = '';
+  username = '';
+  email = '';
+  todos: Todo[] = [];
+
+  static key = 'User';
+  static schema = {
+    todos: new schema.Collection(new schema.Array(Todo), {
+      nestKey: (parent, key) => ({
+        userId: parent.id,
+      }),
+    }),
+  };
+}
+
+const UserResource = createResource({
+  path: '/users/:id',
+  schema: User,
+});
+const TodoResource = createResource({
+  path: '/todos/:id',
+  searchParams: {} as { userId?: string } | undefined,
+  schema: Todo,
+});
+// for nesting test
+const BaseArticleResource = createResource({
+  urlPrefix: 'http://test.com',
+  path: '/article/:id',
+  schema: Article,
+});
+const ArticleResource = {
+  ...BaseArticleResource,
+  getList: BaseArticleResource.getList.extend({
+    schema: {
+      results: new schema.Collection([Article], {
+        argsKey: (urlParams, body) => ({
+          ...urlParams,
+        }),
+      }),
+      prevPage: '',
+      nextPage: '',
+    },
+  }),
+};
+const UnionResource = createResource({
+  path: '/union/:id',
+  schema: UnionSchema,
+});
+
+const UserResourceLegacy = createResource({
+  path: '/users/:id',
+  schema: User,
+  Endpoint: RestEndpoint as any,
+});
+const TodoResourceLegacy = createResource({
+  path: '/todos/:id',
+  searchParams: {} as { userId?: string } | undefined,
+  schema: Todo,
+  Endpoint: RestEndpoint as any,
+});
+const BaseArticleResourceLegacy = createResource({
+  urlPrefix: 'http://test.com',
+  path: '/article/:id',
+  schema: Article,
+  Endpoint: RestEndpoint as any,
+});
+const ArticleResourceLegacy = {
+  ...BaseArticleResourceLegacy,
+  getList: BaseArticleResourceLegacy.getList.extend({
+    schema: new schema.Object({
+      results: new schema.Collection([Article], {
+        argsKey: (urlParams, body) => ({
+          ...urlParams,
+        }),
+      }),
+      prevPage: '',
+      nextPage: '',
+    }),
+  }),
+};
+
+describe.each([
+  ['CacheProvider', CacheProvider],
+  ['ExternalCacheProvider', ExternalCacheProvider],
+] as const)(`%s`, (_, makeProvider) => {
+  // TODO: add nested resource test case that has multiple partials to test merge functionality
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+
+  beforeEach(() => {
+    renderRestHook = makeRenderRestHook(makeProvider);
+  });
+
+  it('should work with unions', async () => {
+    const prevWarn = global.console.warn;
+    global.console.warn = jest.fn();
+
+    const { result, controller } = renderRestHook(
+      () => {
+        return useSuspense(UnionResource.getList);
+      },
+      {
+        initialFixtures: [
+          {
+            endpoint: UnionResource.getList,
+            args: [],
+            response: [
+              null,
+              { id: '5', body: 'hi', type: 'first' },
+              { id: '6', body: 'hi', type: 'another' },
+              { id: '7', body: 'hi' },
+            ],
+          },
+        ],
+        resolverFixtures: [
+          {
+            endpoint: UnionResource.getList.push,
+            args: [],
+            response(body) {
+              return body;
+            },
+          },
+        ],
+      },
+    );
+    expect(result.current).toBeDefined();
+    expect(result.current[0]).toBeInstanceOf(FirstUnion);
+    expect(result.current[1]).not.toBeInstanceOf(FirstUnion);
+    expect(result.current[2]).not.toBeInstanceOf(FirstUnion);
+    expect((global.console.warn as jest.Mock).mock.calls).toMatchSnapshot();
+
+    await act(async () => {
+      await controller.fetch(UnionResource.getList.push, {
+        body: 'hi',
+        type: 'second',
+        id: 100,
+      });
+    });
+    expect(result.current[3]).toBeInstanceOf(SecondUnion);
+    expect(result.current).toMatchSnapshot();
+    global.console.warn = prevWarn;
+  });
+
+  describe.each([
+    ['/next', { UserResource, TodoResource, ArticleResource }],
+    [
+      '/current',
+      {
+        UserResource: UserResourceLegacy,
+        TodoResource: TodoResourceLegacy,
+        ArticleResource: ArticleResourceLegacy,
+      },
+    ],
+  ] as const)(
+    `RestEndpoint%s`,
+    (_, { UserResource, TodoResource, ArticleResource }) => {
+      let mynock: nock.Scope;
+
+      beforeEach(() => {
+        nock(/.*/)
+          .persist()
+          .defaultReplyHeaders({
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
+          })
+          .options(/.*/)
+          .reply(200)
+          .get(`/users/1`)
+          .reply(200, {
+            id: '1',
+            username: 'bob',
+            todos: [{ id: 5, title: 'do things', userId: '1' }],
+          })
+          .get(`/todos`)
+          .reply(200, [
+            { id: 5, title: 'do things', userId: '1' },
+            { id: 3, title: 'ssdf', userId: '2' },
+          ])
+          .get(`/todos?userId=1`)
+          .reply(200, [{ id: 5, title: 'do things', userId: '1' }])
+          .post(`/todos`)
+          .reply(200, (uri, body: any) => ({ ...body }))
+          .post(`/todos?userId=5`)
+          .reply(200, (uri, body: any) => ({ userId: '5', ...body }))
+          .post(`/todos?userId=1`)
+          .reply(200, (uri, body: any) => ({ userId: '1', ...body }));
+
+        mynock = nock(/.*/).defaultReplyHeaders({
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json',
+        });
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      it('should update collection on push/unshift', async () => {
+        const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+          const todos = useSuspense(TodoResource.getList);
+          const userTodos = useSuspense(TodoResource.getList, { userId: '1' });
+          const user = useSuspense(UserResource.get, { id: '1' });
+          return { todos, userTodos, user };
+        });
+        await waitForNextUpdate();
+        expect(result.current).toMatchSnapshot();
+        const firstUserTodos = result.current.userTodos;
+        const firstUser = result.current.user;
+        // referential equality guarantee
+        expect(result.current.user.todos).toBe(result.current.userTodos);
+        await act(async () => {
+          await controller.fetch(
+            TodoResource.getList.push,
+            { userId: '5' },
+            {
+              id: 1,
+              title: 'push',
+              userId: '5',
+            },
+          );
+        });
+        expect(result.current.userTodos.map(({ id }) => id)).toEqual([5]);
+        expect(result.current.todos.map(({ id }) => id)).toEqual([5, 3, 1]);
+        expect(result.current.user.todos).toBe(result.current.userTodos);
+        // userTodos didn't change so should maintain referential equality
+        expect(result.current.userTodos).toBe(firstUserTodos);
+        expect(result.current.user).toBe(firstUser);
+
+        await act(async () => {
+          await controller.fetch(
+            TodoResource.getList.unshift,
+            { userId: '1' },
+            {
+              id: 55,
+              title: 'unshift',
+            },
+          );
+        });
+        // this adds to both the base todo list, the one with userId filter, and the nested todo list inside user object
+        expect(result.current.todos.map(({ id }) => id)).toEqual([55, 5, 3, 1]);
+        expect(result.current.userTodos.map(({ id }) => id)).toEqual([55, 5]);
+        expect(result.current.user.todos).toBe(result.current.userTodos);
+
+        // type checks
+
+        () =>
+          controller.fetch(
+            TodoResource.getList.unshift,
+            // @ts-expect-error
+            { sdf: '1' },
+            {
+              id: 55,
+              title: 'unshift',
+            },
+          );
+
+        () =>
+          controller.fetch(
+            TodoResource.getList.unshift,
+            // @ts-expect-error
+            5,
+            {
+              id: 55,
+              title: 'unshift',
+            },
+          );
+      });
+
+      it('should update on get for a paginated resource', async () => {
+        mynock.get(`/article`).reply(200, paginatedFirstPage);
+        mynock.get(`/article?cursor=2`).reply(200, paginatedSecondPage);
+
+        const getNextPage = ArticleResource.getList.paginated(
+          ({ cursor, ...rest }: { cursor?: number }) => [],
+        );
+
+        const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+          const ret = useSuspense(ArticleResource.getList);
+          return ret;
+        });
+        await waitForNextUpdate();
+        expect(result.current).toMatchSnapshot();
+
+        await controller.fetch(getNextPage, { cursor: 2 });
+
+        expect(result.current.results.map(({ id }) => id)).toEqual([
+          5, 3, 7, 8,
+        ]);
+      });
+
+      it('should update on get for a paginated resource with searchParams', async () => {
+        mynock.get(`/article`).reply(200, paginatedFirstPage);
+        mynock.get(`/article?userId=2`).reply(200, paginatedFirstPage);
+        mynock.get(`/article?userId=1`).reply(200, paginatedFirstPage);
+        mynock
+          .get(`/article?userId=1&cursor=2`)
+          .reply(200, paginatedSecondPage);
+
+        const getArticles = ArticleResource.getList.extend({
+          searchParams: {} as { userId?: number } | undefined,
+        });
+        const getNextPage = getArticles.paginated(
+          ({ cursor, ...rest }: { cursor?: number; userId?: number }) => [rest],
+        );
+
+        const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+          const userArticles = useSuspense(getArticles, { userId: 1 });
+          const anotherUserArticles = useSuspense(getArticles, { userId: 2 });
+          const allArticles = useSuspense(getArticles);
+          return { userArticles, allArticles, anotherUserArticles };
+        });
+        await waitForNextUpdate();
+        expect(result.current.userArticles).toMatchSnapshot();
+
+        await controller.fetch(getNextPage, { cursor: 2, userId: 1 });
+
+        expect(result.current.userArticles.results.map(({ id }) => id)).toEqual(
+          [5, 3, 7, 8],
+        );
+        // pagination we only explicitly extend one
+        expect(result.current.allArticles.results.map(({ id }) => id)).toEqual([
+          5, 3,
+        ]);
+        expect(
+          result.current.anotherUserArticles.results.map(({ id }) => id),
+        ).toEqual([5, 3]);
+
+        () =>
+          // @ts-expect-error
+          controller.fetch(getNextPage, { cursor: 2, userId: 1, sdlkjfsd: 5 });
+      });
+
+      it('pagination should work with cursor field parameters', async () => {
+        mynock.get(`/article`).reply(200, paginatedFirstPage);
+        mynock.get(`/article?userId=2`).reply(200, paginatedFirstPage);
+        mynock.get(`/article?userId=1`).reply(200, paginatedFirstPage);
+        mynock
+          .get(`/article?userId=1&cursor=2`)
+          .reply(200, paginatedSecondPage);
+
+        const getArticles = ArticleResource.getList.extend({
+          searchParams: {} as { userId?: number } | undefined,
+        });
+        const getNextPage = getArticles.paginated('cursor');
+
+        const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+          const userArticles = useSuspense(getArticles, { userId: 1 });
+          const anotherUserArticles = useSuspense(getArticles, { userId: 2 });
+          const allArticles = useSuspense(getArticles);
+          return { userArticles, allArticles, anotherUserArticles };
+        });
+        await waitForNextUpdate();
+        expect(result.current.userArticles).toMatchSnapshot();
+
+        await controller.fetch(getNextPage, { cursor: 2, userId: 1 });
+
+        expect(result.current.userArticles.results.map(({ id }) => id)).toEqual(
+          [5, 3, 7, 8],
+        );
+        // pagination we only explicitly extend one
+        expect(result.current.allArticles.results.map(({ id }) => id)).toEqual([
+          5, 3,
+        ]);
+        expect(
+          result.current.anotherUserArticles.results.map(({ id }) => id),
+        ).toEqual([5, 3]);
+
+        () =>
+          // @ts-expect-error
+          controller.fetch(getNextPage, { cursor: 2, userId: 1, sdlkjfsd: 5 });
+        () =>
+          // @ts-expect-error
+          controller.fetch(getNextPage, { sdf: 2, userId: 1 });
+      });
+
+      it('should update nested collection on push/unshift', async () => {
+        mynock.get(`/article`).reply(200, paginatedFirstPage);
+        mynock
+          .persist()
+          .post(`/article`)
+          .reply(200, (uri, body: any) => ({ ...body }));
+
+        const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+          return useSuspense(ArticleResource.getList);
+        });
+        await waitForNextUpdate();
+        expect(result.current.results.map(({ id }) => id)).toEqual([5, 3]);
+
+        await act(async () => {
+          await controller.fetch(ArticleResource.create, {
+            id: 1,
+            title: 'create',
+          });
+        });
+        expect(result.current.results.map(({ id }) => id)).toEqual([5, 3, 1]);
+        await act(async () => {
+          await controller.fetch(ArticleResource.getList.push, {
+            id: 11,
+            title: 'push',
+          });
+        });
+        expect(result.current.results.map(({ id }) => id)).toEqual([
+          5, 3, 1, 11,
+        ]);
+      });
+
+      it('endpoint.assign should add to schema.Values Collections', async () => {
+        mynock.get(`/article`).reply(200, valuesFixture);
+        mynock
+          .persist()
+          .post(`/article`)
+          .reply(200, (uri, body: any) => ({ ...body }));
+
+        const getValues = ArticleResource.getList.extend({
+          schema: new schema.Collection(new schema.Values(Article), {
+            argsKey: (urlParams, body) => ({
+              ...urlParams,
+            }),
+          }),
+        });
+
+        const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+          return useSuspense(getValues);
+        });
+        expect(result.current).toBeUndefined();
+        await waitForNextUpdate();
+        Object.keys(result.current).forEach(k => {
+          expect(result.current[k] instanceof Article).toBe(true);
+          expect(result.current[k].title).toBeDefined();
+          // @ts-expect-error
+          expect(result.current[k].doesnotexist).toBeUndefined();
+        });
+
+        await act(async () => {
+          await controller.fetch(getValues.assign, {
+            added: {
+              id: 1,
+              title: 'newly assigned',
+            },
+          });
+        });
+
+        expect(result.current.added).toBeInstanceOf(Article);
+        expect(result.current.added).toMatchSnapshot();
+      });
+    },
+  );
+});

--- a/packages/react/src/__tests__/integration-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-endpoint.web.tsx
@@ -738,6 +738,36 @@ describe.each([
     ).toEqual([5, 3, 1]);
   });
 
+  it('should update collection on push/unshift', async () => {
+    const getArticles = CoolerArticleResource.getList.extend({
+      schema: new schema.Collection([CoolerArticle], {
+        argsKey: (urlParams, body) => ({
+          ...urlParams,
+        }),
+      }),
+    });
+    const { result, waitForNextUpdate, controller } = renderRestHook(() => {
+      const articles = useSuspense(getArticles);
+      return articles;
+    });
+    await waitForNextUpdate();
+    expect(result.current.map(({ id }: Partial<CoolerArticle>) => id)).toEqual([
+      5, 3,
+    ]);
+    await act(async () => {
+      await controller.fetch(getArticles.push, { id: 1, title: 'hi' });
+    });
+    expect(result.current.map(({ id }: Partial<CoolerArticle>) => id)).toEqual([
+      5, 3, 1,
+    ]);
+    await act(async () => {
+      await controller.fetch(getArticles.unshift, { id: 55, title: 'hi' });
+    });
+    expect(result.current.map(({ id }: Partial<CoolerArticle>) => id)).toEqual([
+      55, 5, 3, 1,
+    ]);
+  });
+
   it('should update on get for a paginated resource', async () => {
     mynock.get(`/article-paginated`).reply(200, paginatedFirstPage);
     mynock.get(`/article-paginated?cursor=2`).reply(200, paginatedSecondPage);

--- a/packages/rest/src/OptionsToFunction.ts
+++ b/packages/rest/src/OptionsToFunction.ts
@@ -4,12 +4,13 @@ import { PathArgs } from './pathTypes.js';
 import {
   PartialRestGenerics,
   RestInstance,
+  RestInstanceBase,
   RestFetch,
 } from './RestEndpoint.js';
 
 export type OptionsToFunction<
   O extends PartialRestGenerics,
-  E extends RestInstance & { body?: any },
+  E extends RestInstanceBase & { body?: any },
   F extends FetchFunction,
 > = 'path' extends keyof O
   ? RestFetch<

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -7,12 +7,13 @@ import type {
   ResolveType,
 } from '@rest-hooks/endpoint';
 
+import type { ExtractCollection } from './extractCollection.js';
 import { OptionsToFunction } from './OptionsToFunction.js';
 import { PathArgs } from './pathTypes.js';
 import { EndpointUpdateFunction } from './RestEndpointTypeHelp.js';
 import { RequiredKeys } from './utiltypes.js';
 
-export interface RestInstance<
+export interface RestInstanceBase<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = any,
   M extends true | undefined = true | undefined,
@@ -63,22 +64,53 @@ export interface RestInstance<
   testKey(key: string): boolean;
 
   /* extenders */
+  extend<E extends RestInstanceBase, O extends PartialRestGenerics | {}>(
+    this: E,
+    options: Readonly<RestEndpointExtendOptions<O, E, F> & O>,
+  ): RestExtendedEndpoint<O, E>;
   paginated<
-    E extends RestInstance<FetchFunction, Schema | undefined, undefined>,
+    E extends RestInstanceBase<FetchFunction, any, undefined>,
     A extends any[],
   >(
     this: E,
     removeCursor: (...args: A) => readonly [...Parameters<E>],
   ): PaginationEndpoint<E, A>;
-  extend<E extends RestInstance, O extends PartialRestGenerics | {}>(
+  paginated<
+    E extends RestInstanceBase<FetchFunction, any, undefined>,
+    C extends string,
+  >(
     this: E,
-    options: Readonly<RestEndpointExtendOptions<O, E, F> & O>,
-  ): RestExtendedEndpoint<O, E>;
+    cursorField: C,
+  ): PaginationFieldEndpoint<E, C>;
 }
+
+export interface RestInstance<
+  F extends FetchFunction = FetchFunction,
+  S extends Schema | undefined = any,
+  M extends true | undefined = true | undefined,
+  O extends {
+    path: string;
+    body?: any;
+    searchParams?: any;
+  } = { path: string },
+> extends RestInstanceBase<F, S, M, O> {
+  push: AddEndpoint<F, S, O>;
+  unshift: AddEndpoint<F, S, O>;
+  assign: AddEndpoint<F, S, O>;
+}
+
+export type ContainsCollectionArray =
+  | { push: any; unshift: any }
+  | { [K: string]: ContainsCollectionArray }
+  | { schema: { [K: string]: ContainsCollectionArray } };
+export type ContainsCollectionValues =
+  | { assign: any }
+  | { [K: string]: ContainsCollectionValues }
+  | { schema: { [K: string]: ContainsCollectionValues } };
 
 export type RestEndpointExtendOptions<
   O extends PartialRestGenerics | {},
-  E extends RestInstance,
+  E extends RestInstanceBase,
   F extends FetchFunction,
 > = RestEndpointOptions<
   OptionsToFunction<O, E, F>,
@@ -86,11 +118,11 @@ export type RestEndpointExtendOptions<
     ? Extract<O['schema'], Schema | undefined>
     : E['schema']
 > &
-  Partial<Omit<E, KeyofRestEndpoint | 'body' | 'searchParams'>>;
+  Partial<Omit<E, KeyofRestEndpoint | keyof PartialRestGenerics>>;
 
 type OptionsToRestEndpoint<
   O extends PartialRestGenerics,
-  E extends RestInstance & { body?: any },
+  E extends RestInstanceBase & { body?: any },
   F extends FetchFunction,
 > = 'path' extends keyof O
   ? RestType<
@@ -156,7 +188,7 @@ type OptionsToRestEndpoint<
 
 export type RestExtendedEndpoint<
   O extends PartialRestGenerics,
-  E extends RestInstance,
+  E extends RestInstanceBase,
 > = OptionsToRestEndpoint<
   O,
   E,
@@ -189,7 +221,7 @@ export interface RestGenerics extends PartialRestGenerics {
 }
 
 export type PaginationEndpoint<
-  E extends RestInstance,
+  E extends RestInstanceBase,
   A extends any[],
 > = RestInstance<
   ParamFetchNoBody<A[0], ResolveType<E>>,
@@ -199,6 +231,41 @@ export type PaginationEndpoint<
     searchParams: Omit<A[0], keyof PathArgs<E['path']>>;
   }
 >;
+export type PaginationFieldEndpoint<
+  E extends RestInstanceBase,
+  C extends string,
+> = RestInstance<
+  ParamFetchNoBody<
+    { [K in C]: string | number | boolean } & E['searchParams'] &
+      PathArgs<Exclude<E['path'], undefined>>,
+    ResolveType<E>
+  >,
+  E['schema'],
+  E['sideEffect'],
+  Pick<E, 'path' | 'searchParams' | 'body'> & {
+    searchParams: { [K in C]: string | number | boolean } & E['searchParams'];
+  }
+>;
+export type AddEndpoint<
+  F extends FetchFunction = FetchFunction,
+  S extends Schema | undefined = any,
+  O extends {
+    path: string;
+    body?: any;
+    searchParams?: any;
+  } = { path: string },
+> = RestInstanceBase<
+  RestFetch<
+    'searchParams' extends keyof O
+      ? O['searchParams'] & PathArgs<Exclude<O['path'], undefined>>
+      : PathArgs<Exclude<O['path'], undefined>>,
+    any,
+    ReturnType<F>
+  >,
+  ExtractCollection<S>,
+  true,
+  Omit<O, 'body'>
+> & { method: 'POST' };
 
 export type BodyDefault<O extends RestGenerics> = 'body' extends keyof O
   ? O['body']
@@ -220,7 +287,7 @@ export interface RestEndpointOptions<
   urlPrefix?: string;
   requestInit?: RequestInit;
   key?(...args: Parameters<F>): string;
-  sideEffect?: true | undefined;
+  readonly sideEffect?: true | undefined;
   name?: string;
   signal?: AbortSignal;
   url?(...args: Parameters<F>): string;
@@ -265,7 +332,7 @@ export interface RestEndpointConstructor {
     MethodToSide<O['method']>,
     OptionsBodyDefault<O>
   >;
-  readonly prototype: RestInstance;
+  readonly prototype: RestInstanceBase;
 }
 
 /** Simplifies endpoint definitions that follow REST patterns

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -1,7 +1,10 @@
 import { Endpoint } from '@rest-hooks/endpoint';
 import { pathToRegexp } from 'path-to-regexp';
 
+import extractCollection from './extractCollection.js';
+import mapCollection from './mapCollection.js';
 import NetworkError from './NetworkError.js';
+import { paginatedMerge, paginatedFilter } from './paginatedCollections.js';
 import paginationUpdate from './paginationUpdate.js';
 import paramsToString from './paramsToString.js';
 import { getUrlBase, getUrlTokens, isPojo } from './RestHelpers.js';
@@ -29,7 +32,10 @@ export default class RestEndpoint extends Endpoint {
       options,
     );
     // we want to use the prototype chain here
-    if (!('sideEffect' in this)) {
+    if (
+      !('sideEffect' in this) ||
+      ('method' in options && !('sideEffect' in options))
+    ) {
       this.sideEffect =
         options.method === 'GET' || options.method === undefined
           ? undefined
@@ -203,7 +209,45 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
   }
 
   paginated(removeCursor) {
+    if (typeof removeCursor === 'string') {
+      const fieldName = removeCursor;
+      removeCursor = ({ ...params }) => {
+        delete params[fieldName];
+        return [params];
+      };
+    }
+    let found = false;
+    const createPaginatedSchema = collection => {
+      found = true;
+      return collection.addWith(paginatedMerge, paginatedFilter(removeCursor));
+    };
+    const newSchema = mapCollection(this.schema, createPaginatedSchema);
+    if (found) {
+      return this.extend({ schema: newSchema });
+    }
+
     return this.extend({ update: paginationUpdate(this, removeCursor) });
+  }
+
+  get push() {
+    return this.extend({
+      method: 'POST',
+      schema: extractCollection(this.schema, s => s.push),
+    });
+  }
+
+  get unshift() {
+    return this.extend({
+      method: 'POST',
+      schema: extractCollection(this.schema, s => s.unshift),
+    });
+  }
+
+  get assign() {
+    return this.extend({
+      method: 'POST',
+      schema: extractCollection(this.schema, s => s.assign),
+    });
   }
 }
 

--- a/packages/rest/src/extractCollection.ts
+++ b/packages/rest/src/extractCollection.ts
@@ -1,0 +1,34 @@
+import { Schema, schema } from '@rest-hooks/endpoint';
+
+export default function extractCollection<
+  M extends <C extends schema.CollectionType>(collection: C) => any,
+  S extends Schema | undefined,
+>(s: S, mapper: M): ExtractCollection<S> | undefined {
+  if (typeof s !== 'object' || s === undefined || Array.isArray(s)) return;
+  if (s instanceof schema.Collection) {
+    return mapper(s as any);
+  }
+  const objCopy: Record<string, Schema> = {
+    ...(s instanceof schema.Object ? (s as any).schema : s),
+  };
+  for (const k in objCopy) {
+    if (!objCopy[k]) continue;
+    const collection = extractCollection(objCopy[k], mapper);
+    if (collection) return collection;
+  }
+}
+
+export type ExtractCollection<S extends Schema | undefined> =
+  S extends schema.CollectionSchema
+    ? S
+    : S extends schema.Object<infer T>
+    ? ExtractObject<T>
+    : S extends Exclude<Schema, { [K: string]: any }>
+    ? never
+    : S extends { [K: string]: Schema }
+    ? ExtractObject<S>
+    : never;
+
+export type ExtractObject<S extends Record<string, any>> = {
+  [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
+}[keyof S];

--- a/packages/rest/src/mapCollection.ts
+++ b/packages/rest/src/mapCollection.ts
@@ -1,0 +1,54 @@
+import { Schema, schema } from '@rest-hooks/endpoint';
+
+export default function mapCollection<
+  M extends <C extends schema.CollectionType>(collection: C) => any,
+  S extends Schema | undefined,
+>(
+  s: S,
+  mapper: M,
+): S extends schema.CollectionType
+  ? ReturnType<typeof mapper<S>>
+  : S extends schema.Object<infer T>
+  ? {
+      [K in keyof T]: T[K] extends Schema
+        ? typeof mapCollection<M, T[K]>
+        : T[K];
+    }
+  : S extends { [K: string]: any }
+  ? {
+      [K in keyof S]: S[K] extends Schema
+        ? typeof mapCollection<M, S[K]>
+        : S[K];
+    }
+  : S {
+  if (typeof s !== 'object' || s === undefined) return s as any;
+  if (s instanceof schema.Collection) {
+    return mapper(s as any);
+  }
+  const objCopy: Record<string, Schema> = {
+    ...(s instanceof schema.Object ? (s as any).schema : s),
+  };
+  for (const k in objCopy) {
+    if (!objCopy[k]) continue;
+    objCopy[k] = mapCollection(objCopy[k], mapper) as any;
+  }
+  return objCopy as any;
+}
+
+type MapCollection<
+  M extends <C extends schema.CollectionType>(collection: C) => any,
+  S extends Schema | undefined,
+> = S extends schema.CollectionType
+  ? ReturnType<M>
+  : S extends schema.Object<infer T>
+  ? MapCollection<M, T>
+  : S extends { [K: string]: any }
+  ? MapObject<M, S>
+  : never;
+
+export type MapObject<
+  M extends (collection: schema.CollectionType) => any,
+  S extends Record<string, any>,
+> = {
+  [K in keyof S]: S[K] extends Schema ? MapCollection<M, S[K]> : S[K];
+};

--- a/packages/rest/src/next/OptionsToFunction.ts
+++ b/packages/rest/src/next/OptionsToFunction.ts
@@ -2,14 +2,14 @@ import type { FetchFunction, ResolveType } from '@rest-hooks/endpoint';
 
 import {
   PartialRestGenerics,
-  RestInstance,
+  RestInstanceBase,
   RestFetch,
 } from './RestEndpoint.js';
 import { PathArgs } from '../pathTypes.js';
 
 export type OptionsToFunction<
   O extends PartialRestGenerics,
-  E extends RestInstance & { body?: any },
+  E extends RestInstanceBase & { body?: any },
   F extends FetchFunction,
 > = 'path' extends keyof O
   ? RestFetch<

--- a/packages/rest/src/next/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/next/__tests__/RestEndpoint.ts
@@ -1291,6 +1291,10 @@ describe('RestEndpoint.fetch()', () => {
     });
     expect(res).toEqual({ id, title: 'hi' });
   });
+
+  it('without Collection in schema - endpoint.push schema should be null', () => {
+    expect(getArticleList2.push.schema).toBeFalsy();
+  });
 });
 const proto = Object.prototype;
 const gpo = Object.getPrototypeOf;

--- a/packages/rest/src/next/createResource.ts
+++ b/packages/rest/src/next/createResource.ts
@@ -1,0 +1,145 @@
+import { schema } from '@rest-hooks/endpoint';
+import type {
+  Schema,
+  Denormalize,
+  EndpointExtraOptions,
+} from '@rest-hooks/endpoint';
+
+import RestEndpoint, {
+  GetEndpoint,
+  MutateEndpoint,
+  ResourceGenerics,
+  RestTypeNoBody,
+  ResourceOptions,
+} from './RestEndpoint.js';
+import { PathArgs, ShortenPath } from '../pathTypes.js';
+import { shortenPath } from '../RestHelpers.js';
+
+const { Delete, Collection } = schema;
+
+/** Creates collection of Endpoints for common operations on a given data/schema.
+ *
+ * @see https://resthooks.io/rest/api/createResource
+ */
+export default function createResource<O extends ResourceGenerics>({
+  path,
+  schema,
+  Endpoint = RestEndpoint,
+  ...extraOptions
+}: Readonly<
+  ResourceOptions & {
+    readonly Endpoint?: typeof RestEndpoint;
+  } & O
+>): Resource<O> {
+  const shortenedPath = shortenPath(path);
+  const getName = (name: string) => `${(schema as any)?.name}.${name}`;
+  const getList = new Endpoint({
+    ...extraOptions,
+    path: shortenedPath,
+    schema: new Collection([schema as any], {
+      argsKey: (urlParams, body) => ({
+        ...urlParams,
+      }),
+    }),
+    name: getName('getList'),
+  });
+  return {
+    get: new Endpoint({ ...extraOptions, path, schema, name: getName('get') }),
+    getList,
+    create: getList.push.extend({ name: getName('create') }),
+    update: new Endpoint({
+      ...extraOptions,
+      path,
+      schema,
+      method: 'PUT',
+      name: getName('update'),
+    }),
+    partialUpdate: new Endpoint({
+      ...extraOptions,
+      path,
+      schema,
+      method: 'PATCH',
+      name: getName('partialUpdate'),
+    }),
+    delete: new Endpoint({
+      ...extraOptions,
+      path,
+      schema: (schema as any).process ? new Delete(schema as any) : schema,
+      method: 'DELETE',
+      name: getName('delete'),
+      process(res: any, params: any) {
+        return res && Object.keys(res).length ? res : params;
+      },
+    }),
+  } as any;
+}
+
+export interface Resource<
+  O extends ResourceGenerics = { path: string; schema: Schema },
+> {
+  /** Get a singular item
+   *
+   * @see https://resthooks.io/rest/api/createResource#get
+   */
+  get: GetEndpoint<Omit<O, 'searchParams' | 'body'>>;
+  /** Get a list of item
+   *
+   * @see https://resthooks.io/rest/api/createResource#getlist
+   */
+  getList: GetEndpoint<
+    Omit<O, 'schema' | 'body' | 'path'> & {
+      readonly path: ShortenPath<O['path']>;
+      readonly schema: schema.CollectionType<O['schema'][]>;
+    }
+  >;
+  /** Create a new item (POST)
+   *
+   * @see https://resthooks.io/rest/api/createResource#create
+   */
+  create: MutateEndpoint<
+    {
+      readonly path: ShortenPath<O['path']>;
+      readonly body: 'body' extends keyof O
+        ? O['body']
+        : Partial<Denormalize<O['schema']>>;
+      readonly schema: schema.CollectionType<schema.Array<O['schema']>>['push'];
+    } & Omit<O, 'path' | 'body' | 'schema'>
+  >;
+  /** Update an item (PUT)
+   *
+   * @see https://resthooks.io/rest/api/createResource#update
+   */
+  update: MutateEndpoint<
+    {
+      readonly body: 'body' extends keyof O
+        ? O['body']
+        : Partial<Denormalize<O['schema']>>;
+    } & O
+  >;
+  /** Update an item (PATCH)
+   *
+   * @see https://resthooks.io/rest/api/createResource#partialupdate
+   */
+  partialUpdate: MutateEndpoint<
+    {
+      readonly body: 'body' extends keyof O
+        ? O['body']
+        : Partial<Denormalize<O['schema']>>;
+    } & O
+  >;
+  /** Delete an item (DELETE)
+   *
+   * @see https://resthooks.io/rest/api/createResource#delete
+   */
+  delete: RestTypeNoBody<
+    PathArgs<O['path']>,
+    O['schema'] extends schema.EntityInterface & { process: any }
+      ? schema.Delete<O['schema']>
+      : O['schema'],
+    undefined,
+    Partial<PathArgs<O['path']>>,
+    {
+      path: O['path'];
+    }
+  >;
+}

--- a/packages/rest/src/next/index.ts
+++ b/packages/rest/src/next/index.ts
@@ -1,8 +1,6 @@
 export type {
   GetEndpoint,
   MutateEndpoint,
-  NewGetEndpoint,
-  NewMutateEndpoint,
   Defaults,
   RestGenerics,
   FetchGet,
@@ -11,5 +9,8 @@ export type {
   RestType,
   KeyofRestEndpoint,
   RestEndpointConstructorOptions,
+  ResourceOptions,
+  ResourceGenerics,
 } from './RestEndpoint.js';
 export { default as RestEndpoint } from './RestEndpoint.js';
+export { default as createResource } from './createResource.js';

--- a/packages/rest/src/paginatedCollections.ts
+++ b/packages/rest/src/paginatedCollections.ts
@@ -1,0 +1,32 @@
+export function paginatedMerge(existing: any[], incoming: any[]) {
+  const existingSet: Set<string> = new Set(existing);
+  const mergedList = [...existing];
+  for (const pk of incoming) {
+    if (!existingSet.has(pk)) mergedList.push(pk);
+  }
+  return mergedList;
+}
+export const paginatedFilter =
+  <C extends (...args: readonly any[]) => readonly any[]>(removeCursor: C) =>
+  (...args: Parameters<C>) => {
+    const noCursorArgs = removeCursor(...args);
+    return (collectionKey: Record<string, any>) =>
+      shallowEqual(collectionKey, noCursorArgs[0] ?? {});
+  };
+
+function shallowEqual(
+  object1: Record<string, any>,
+  object2: Record<string, any>,
+) {
+  const keys1 = Object.keys(object1);
+  const keys2 = Object.keys(object2);
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+  for (const key of keys1) {
+    if (object1[key] !== object2[key]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/test/src/createControllerInterceptor.tsx
+++ b/packages/test/src/createControllerInterceptor.tsx
@@ -103,12 +103,12 @@ export function createControllerInterceptor<T>(
   If you were expecting to see results, it is likely due to data not being found in fixtures.
   Double check your params and Endpoint match. For example:
 
-  useResource(ArticleResource.list(), { maxResults: 10 });
+  useSuspense(ArticleResource.getList, { maxResults: 10 });
 
   and
 
   {
-    endpoint: ArticleResource.list(),
+    endpoint: ArticleResource.getList,
     args: [{ maxResults: 10 }],
     response: [],
   }`,

--- a/packages/test/src/makeRenderRestHook/index.tsx
+++ b/packages/test/src/makeRenderRestHook/index.tsx
@@ -77,38 +77,38 @@ export default function makeRenderRestHook(
 
     // TODO: controller provided to middleware should be same as useController() - so pull out the mockresolver stuff and don't actually
     // use the component here
-    const ProviderWithResolver: React.ComponentType<any> =
-      options?.resolverFixtures
-        ? memo(function ProviderWithResolver({
-            children,
-          }: React.PropsWithChildren<P>) {
-            return (
-              <Provider
-                initialState={initialState}
-                Controller={ActController}
-                managers={managers}
-              >
-                <MockResolver
-                  fixtures={options.resolverFixtures as FixtureEndpoint[]}
-                >
-                  {children}
-                </MockResolver>
-              </Provider>
-            );
-          })
-        : memo(function ProviderWithResolver({
-            children,
-          }: React.PropsWithChildren<P>) {
-            return (
-              <Provider
-                initialState={initialState}
-                Controller={ActController}
-                managers={managers}
+    const ProviderWithResolver: React.ComponentType<any> = options
+      ?.resolverFixtures?.length
+      ? memo(function ProviderWithResolver({
+          children,
+        }: React.PropsWithChildren<P>) {
+          return (
+            <Provider
+              initialState={initialState}
+              Controller={ActController}
+              managers={managers}
+            >
+              <MockResolver
+                fixtures={options.resolverFixtures as FixtureEndpoint[]}
               >
                 {children}
-              </Provider>
-            );
-          });
+              </MockResolver>
+            </Provider>
+          );
+        })
+      : memo(function ProviderWithResolver({
+          children,
+        }: React.PropsWithChildren<P>) {
+          return (
+            <Provider
+              initialState={initialState}
+              Controller={ActController}
+              managers={managers}
+            >
+              {children}
+            </Provider>
+          );
+        });
 
     const Wrapper = options?.wrapper;
     const ProviderWithWrapper = Wrapper
@@ -142,6 +142,7 @@ export default function makeRenderRestHook(
       fixtureMap,
       interceptors,
       options?.getInitialInterceptorData ?? (() => ({})),
+      !options?.resolverFixtures?.length,
     );
     return ret;
   }) as any;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2566 .

## Motivation

[Atomic mutations](https://resthooks.io/docs/concepts/atomic-mutations) are one of the core values of Rest Hooks. However, while update was in the first pre-release, and delete quickly added for version 1, create has always been a [bit awkward](https://resthooks.io/rest/api/RestEndpoint#update).

**Often creating a new element you are on a view where you want to see it added to a list somewhere.**

One of the challenges here is that there can be many distinct lists you view. Furthermore, where something is added to a list isn't always the same.

## Previously

https://resthooks.io/docs/concepts/atomic-mutations#create

```ts
const createUser = new Endpoint(postToUserFunction, {
  schema: User,
  update: (newUserId: string) => ({
    [userList.key()]: (users = []) => [newUserId, ...users],
  }),
});
```

Problems:

- Very awkward code we force users to write
- Users only had access to the pk, rather than full entity
- Only works on top level results (doesn't work with nesting)
- Forces users to enumerate all lists they might want to add - even if they aren't in store
  - Which means they may create a list that hasn't been populated


### TODO

- [x] Test Values
- [x] Test addWith
- [x] Test pagination
- [x] Add simpler cursor name pagination
- [x] Test nested collections
- [x] Unions
- [ ] .insert

## Solution

### Collections: Entities but for Arrays and Values instead of classes.

They literally are entities, so they get normalized as such. They just have different lifecycle implementations.

Inspiration: [Backbone collections](https://backbonejs.org/#Collection-unshift)

### Usage

```ts
class Todo extends IDEntity {
  userId = 0;
  title = '';
  completed = false;

  static key = 'Todo';
}

class User extends IDEntity {
  name = '';
  username = '';
  email = '';
  todos: Todo[] = [];

  static key = 'User';
  static schema = {
    todos: new schema.Collection([Todo], {
      nestKey: (parent, key) => ({
        userId: parent.id,
      }),
    }),
  };
}

const UserResource = createResource({
  path: '/users/:id',
  schema: User,
});
const TodoResource = createResource({
  path: '/todos/:id',
  searchParams: {} as { userId?: string } | undefined,
  schema: Todo,
});
```

```ts
const handleCreate = data => ctrl.fetch(TodoResource.getList.push, { userId: currentuser.id }, data);
```

This will add to these if they are already in store (but only if they already exist):

- User({ id: currentUser.id }).todos
- getTodo({ userId: currentUser.id })
- getTodo()

### Collection

#### construction

Takes Array or Values as first arg. Second arg is options object.

```ts
const userTodos = new schema.Collection(new schema.Array(Todo), {
  argsKey: ({ userId }: { userId: string }) => ({
    userId,
  }),
});
```

Options:

Must provide `argsKey` *or* `nestKey` to compute a serializable object to be used in PK table. argsKey takes ...args and nestKey takes (parent,key) as inputs.

`createCollectionFilter` is optional and can be used to override the default filter algorithm. This is used by the "adders" as they inherit from the collection.

```ts
const defaultFilter =
  (urlParams: Record<string, any>, body?: Record<string, any>) =>
  (collectionKey: Record<string, any>) =>
    Object.entries(collectionKey).every(
      ([key, value]) =>
        key.startsWith('order') ||
        urlParams[key] === value ||
        body?.[key] === value,
    );
```

#### addWith(merge, createCollectionFilter)

This is the general `collection extender` method. All specializations simply call this method. This is also used in the paginator as it has a custom algorithm.

`merge` overrides the `Entity.merge()` algorithm. This is used to determine where new values are placed (end, beginning, somewhere in the middle?)

`createCollectionFilter` is optional and will override the inherited function from the Collection itself.

#### push/unshift/assign

These all call `addWith()` with variations on merge to place newly created objects at the beginning or end respectively for Arrays. `assign` is for Values() and simply merges (there is no concept of order in Values)

#### RestEndpoint adder specializations

For a `RestEndpoint` containing a collection schema, the extenders `push/unshift/assign` can be used as convenience to create an appropriate endpoint. They use the parent schema, but us their respective `addWith()` variations. Additionally this sets the `method` to "POST".

### Pagination

`.paginated()` now detects whether there is a collection or array. With collections it will use a custom extender. Arrays will work via update.

**new** `.paginated('cursor')` - 99% of paginations simply extract one field from the args. Let the user specify that field name rather than writing a whole function.

```ts
const handleLoadNextPage = () => ctrl.fetch(TodoResource.getList.paginated('cursor'), {cursor});
```

### Normalizr changes

`args` are now part of both normalization and denormalization. Of course these will default to an empty array in case users don't need args. However, they will need to be passed on my implementations such as schema.normalize(). This shouldn't be a problem as schema implementations without it wont be expecting it anyway.

`pk()` now takes a fourth argument - args. 

### next/createResource

- Uses collections instead of arrays
  - create uses getList.push
- Added new options
  - searchParams
    - `searchParams` only applies to getList and create.
  - body
    - `body` only applies to update,create,partialUpdate
  - urlPrefix
  - requestInit
  - getHeaders
  - getRequestInit
  - fetchResponse
  - parseResponse
