### PR TITLE
enhance: Fix rest/next types

### DIFF
--- a/.changeset/brown-countries-turn.md
+++ b/.changeset/brown-countries-turn.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': patch
+---
+
+Use type widening in RestEndpoint and createResource constructors for non-generics

--- a/docs/core/api/useDLE.md
+++ b/docs/core/api/useDLE.md
@@ -7,7 +7,7 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@rest-hooks/rest';
 
 <head>
-  <title>useDLE() - [D]ata [L]oading [E]rror: Stateful Data Fetching for React</title>
+  <title>useDLE() - [D]ata [L]oading [E]rror React State</title>
 </head>
 
 import PkgTabs from '@site/src/components/PkgTabs';

--- a/packages/endpoint/src-4.0-types/schemas/Entity.d.ts
+++ b/packages/endpoint/src-4.0-types/schemas/Entity.d.ts
@@ -1,13 +1,21 @@
 // we just removed instances of 'abstract new'
-import { UnvisitFunction } from '../interface.js';
+import type { UnvisitFunction } from '../interface.js';
 import { AbstractInstanceType } from '../normal.js';
 declare const Entity_base: import('./EntitySchema.js').IEntityClass<
   new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined): string | undefined;
+    pk(
+      parent?: any,
+      key?: string | undefined,
+      args?: readonly any[] | undefined,
+    ): string | undefined;
   }
 > &
   (new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined): string | undefined;
+    pk(
+      parent?: any,
+      key?: string | undefined,
+      args?: readonly any[] | undefined,
+    ): string | undefined;
   });
 /**
  * Represents data that should be deduped by specifying a primary key.
@@ -20,7 +28,12 @@ export default abstract class Entity extends Entity_base {
    * @param [parent] When normalizing, the object which included the entity
    * @param [key] When normalizing, the key where this entity was found
    */
-  abstract pk(parent?: any, key?: string): string | undefined;
+  abstract pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | undefined;
+
   /** Control how automatic schema validation is handled
    *
    * `undefined`: Defaults - throw error in worst offense
@@ -63,6 +76,25 @@ export default abstract class Entity extends Entity_base {
     incoming: any,
   ): any;
 
+  static mergeMetaWithStore(
+    existingMeta: {
+      expiresAt: number;
+      date: number;
+      fetchedAt: number;
+    },
+    incomingMeta: {
+      expiresAt: number;
+      date: number;
+      fetchedAt: number;
+    },
+    existing: any,
+    incoming: any,
+  ): {
+    expiresAt: number;
+    date: number;
+    fetchedAt: number;
+  };
+
   /** Factory method to convert from Plain JS Objects.
    *
    * @param [props] Plain Object of properties to assign.
@@ -84,6 +116,7 @@ export default abstract class Entity extends Entity_base {
     value: Partial<AbstractInstanceType<T>>,
     parent?: any,
     key?: string,
+    args?: any[],
   ) => string | undefined;
 
   /** Do any transformations when first receiving input */
@@ -93,14 +126,9 @@ export default abstract class Entity extends Entity_base {
     this: T,
     input: any,
     unvisit: UnvisitFunction,
-  ): [
-    /*denormalized*/ AbstractInstanceType<T>,
-    /*found*/ boolean,
-    /*suspend*/ boolean,
-  ];
+  ): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
 
   /** Used by denormalize to set nested members */
   protected static set?(entity: any, key: string, value: any): void;
 }
 export {};
-//# sourceMappingURL=Entity.d.ts.map

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -33,6 +33,9 @@ export interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
   readonly pollFrequency?: number;
   /** Marks cached resources as invalid if they are stale */
   readonly invalidIfStale?: boolean;
+  /** Determines whether to throw or fallback to */
+  errorPolicy?(error: any): 'hard' | 'soft' | undefined;
+
   /** Enables optimistic updates for this request - uses return value as assumed network response
    * @deprecated use https://resthooks.io/docs/api/Endpoint#getoptimisticresponse instead
    */
@@ -42,8 +45,6 @@ export interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
     snap: SnapshotInterface,
     ...args: Parameters<F>
   ): ResolveType<F>;
-  /** Determines whether to throw or fallback to */
-  errorPolicy?(error: any): 'hard' | 'soft' | undefined;
   /** User-land extra data to send */
   readonly extra?: any;
 }

--- a/packages/react/src/__tests__/integration-collections.tsx
+++ b/packages/react/src/__tests__/integration-collections.tsx
@@ -109,6 +109,24 @@ const ArticleResourceLegacy = {
   }),
 };
 
+const ResourceCombos: [
+  string,
+  {
+    UserResource: typeof UserResource;
+    TodoResource: typeof TodoResource;
+    ArticleResource: typeof ArticleResource;
+  },
+][] = [
+  ['/next', { UserResource, TodoResource, ArticleResource }],
+  [
+    '/current',
+    {
+      UserResource: UserResourceLegacy,
+      TodoResource: TodoResourceLegacy,
+      ArticleResource: ArticleResourceLegacy as any,
+    },
+  ],
+];
 describe.each([
   ['CacheProvider', CacheProvider],
   ['ExternalCacheProvider', ExternalCacheProvider],
@@ -170,17 +188,7 @@ describe.each([
     global.console.warn = prevWarn;
   });
 
-  describe.each([
-    ['/next', { UserResource, TodoResource, ArticleResource }],
-    [
-      '/current',
-      {
-        UserResource: UserResourceLegacy,
-        TodoResource: TodoResourceLegacy,
-        ArticleResource: ArticleResourceLegacy,
-      },
-    ],
-  ] as const)(
+  describe.each(ResourceCombos)(
     `RestEndpoint%s`,
     (_, { UserResource, TodoResource, ArticleResource }) => {
       let mynock: nock.Scope;

--- a/packages/rest/src-4.0-types/next/OptionsToFunction.d.ts
+++ b/packages/rest/src-4.0-types/next/OptionsToFunction.d.ts
@@ -1,0 +1,16 @@
+import type { FetchFunction, ResolveType } from '@rest-hooks/endpoint';
+
+import { PartialRestGenerics, RestInstance } from './RestEndpoint.js';
+
+export type OptionsToFunction<
+  O extends PartialRestGenerics,
+  E extends RestInstance & {
+    body?: any;
+  },
+  F extends FetchFunction,
+> = (
+  this: ThisParameterType<F>,
+  ...args: any
+) => Promise<
+  O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>
+>;

--- a/packages/rest/src/next/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/next/__tests__/RestEndpoint.ts
@@ -732,9 +732,12 @@ describe('RestEndpoint', () => {
         }
       `);
 
-      const newBody = getUser.extend({
-        body: {} as { title: string },
-      });
+      const newBody = getUser
+        .extend({
+          body: {} as { title: string },
+          dataExpiryLength: 0,
+        })
+        .extend({ dataExpiryLength: 5 });
       () => newBody({ group: 'hi', id: 'what' }, { title: 'cool' });
       // @ts-expect-error
       () => newBody({ id: 'what' }, { title: 'cool' });
@@ -745,11 +748,12 @@ describe('RestEndpoint', () => {
       // @ts-expect-error
       () => newBody({ group: 'hi', id: 'what' }, { sdfsd: 'cool' });
 
-      const bodyNoParams = newBody
-        .extend({
-          path: '/',
-        })
-        .extend({ body: {} as { happy: string } });
+      const bodyNoPath = newBody.extend({
+        path: '/',
+      });
+      const bodyNoParams = bodyNoPath.extend({
+        body: {} as { happy: string },
+      });
       () => bodyNoParams({ happy: 'cool' });
       // @ts-expect-error
       () => bodyNoParams({ group: 'hi', id: 'what' }, { happy: 'cool' });
@@ -1012,6 +1016,28 @@ describe('RestEndpoint', () => {
         params.group;
         // @ts-expect-error
         params.id;
+      },
+    });
+
+    const endpoint2 = new RestEndpoint({
+      sideEffect: true,
+      path: 'http\\://test.com/article-cooler/:id',
+      body: 0 as any,
+      schema: CoolerArticle,
+      getOptimisticResponse(snap, params, body) {
+        params.id;
+        // @ts-expect-error
+        params.two;
+
+        body.hi;
+      },
+    }).extend({
+      getOptimisticResponse(snap, params, body) {
+        params.id;
+        // @ts-expect-error
+        params.two;
+
+        body.hi;
       },
     });
   });

--- a/packages/rest/src/next/__tests__/types.test.ts
+++ b/packages/rest/src/next/__tests__/types.test.ts
@@ -1,0 +1,121 @@
+import { Entity, schema } from '@rest-hooks/endpoint';
+import { useSuspense } from '@rest-hooks/react';
+import { User } from '__tests__/new';
+
+import createResource from '../createResource';
+import RestEndpoint, { MutateEndpoint } from '../RestEndpoint';
+
+it('RestEndpoint construct and extend with typed options', () => {
+  new RestEndpoint({
+    path: '/todos/',
+    getOptimisticResponse(snap, body) {
+      return body;
+    },
+    schema: User,
+    method: 'POST',
+  });
+  // variable/unknown number of args
+  new RestEndpoint({
+    path: '/todos/',
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, ...args) {
+      return args[args.length - 1];
+    },
+    schema: User,
+    method: 'POST',
+  });
+  new RestEndpoint({
+    path: '/todos/:id',
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, args, body) {
+      return body;
+    },
+    schema: User,
+    method: 'POST',
+  });
+  /*new RestEndpoint({
+    path: '/todos/:id',
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, args) {
+      return args as any;
+    },
+    schema: User,
+    method: 'POST',
+  });*/
+
+  const nopath = new RestEndpoint({
+    path: '/todos/',
+    schema: User,
+    method: 'POST',
+  });
+  const somepath = new RestEndpoint({
+    path: '/todos/:id',
+    schema: User,
+    method: 'POST',
+  });
+
+  nopath.extend({
+    getOptimisticResponse(snap, body) {
+      return body;
+    },
+  });
+  nopath.extend({
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, ...args) {
+      return args[args.length - 1];
+    },
+  });
+  somepath.extend({
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, args, body) {
+      return body;
+    },
+  });
+});
+
+it('should customize resources', () => {
+  class Todo extends Entity {
+    id = '';
+    userId = 0;
+    title = '';
+    completed = false;
+
+    static key = 'Todo';
+    pk() {
+      return this.id;
+    }
+  }
+
+  const TodoResource = createResource({
+    path: '/todos/:id',
+    schema: Todo,
+  });
+  TodoResource.create.extend({
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, body) {
+      return body;
+    },
+  });
+  const partial = TodoResource.partialUpdate.extend({
+    getOptimisticResponse(snap, { id }, body) {
+      return {
+        id,
+        ...body,
+      };
+    },
+  });
+  () => partial({ id: 5 }, { title: 'hi' });
+  const a: MutateEndpoint<{
+    path: '/todos/';
+    body: Partial<Todo>;
+    schema: typeof Todo;
+  }> = TodoResource.create.extend({ schema: Todo }) as any;
+  a.extend({
+    searchParams: {} as { userId?: string | number } | undefined,
+    getOptimisticResponse(snap, body) {
+      return body;
+    },
+  });
+
+  () => useSuspense(TodoResource.getList);
+});

--- a/packages/rest/src/next/index.ts
+++ b/packages/rest/src/next/index.ts
@@ -10,11 +10,10 @@ export type {
   RestInstance,
   KeyofRestEndpoint,
   RestEndpointConstructorOptions,
-  ResourceOptions,
-  ResourceGenerics,
   PaginationFieldEndpoint,
   AddEndpoint,
 } from './RestEndpoint.js';
 export { default as RestEndpoint } from './RestEndpoint.js';
 export { default as createResource } from './createResource.js';
 export type { Resource } from './createResource.js';
+export type { ResourceOptions, ResourceGenerics } from './resourceTypes.js';

--- a/packages/rest/src/next/resourceTypes.ts
+++ b/packages/rest/src/next/resourceTypes.ts
@@ -1,0 +1,37 @@
+import type {
+  EndpointExtraOptions,
+  EndpointInstanceInterface,
+  Schema,
+  FetchFunction,
+  ResolveType,
+} from '@rest-hooks/endpoint';
+
+import RestEndpoint from './RestEndpoint.js';
+
+export interface ResourceGenerics {
+  readonly path: string;
+  readonly schema: Schema;
+  /** Only used for types */
+  readonly body?: any;
+  /** Only used for types */
+  readonly searchParams?: any;
+}
+export interface ResourceOptions {
+  Endpoint?: typeof RestEndpoint;
+  urlPrefix?: string;
+  requestInit?: RequestInit;
+  getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
+  getRequestInit?(body: any): Promise<RequestInit> | RequestInit;
+  fetchResponse?(input: RequestInfo, init: RequestInit): Promise<any>;
+  parseResponse?(response: Response): Promise<any>;
+  /** Default data expiry length, will fall back to NetworkManager default if not defined */
+  readonly dataExpiryLength?: number;
+  /** Default error expiry length, will fall back to NetworkManager default if not defined */
+  readonly errorExpiryLength?: number;
+  /** Poll with at least this frequency in miliseconds */
+  readonly pollFrequency?: number;
+  /** Marks cached resources as invalid if they are stale */
+  readonly invalidIfStale?: boolean;
+  /** Determines whether to throw or fallback to */
+  errorPolicy?(error: any): 'hard' | 'soft' | undefined;
+}

--- a/packages/rest/src/utiltypes.ts
+++ b/packages/rest/src/utiltypes.ts
@@ -20,4 +20,6 @@ type OnlyRequired<T> = {
     : K;
 };
 
-type Values<T> = T[keyof T];
+// exclude number only required for typescript 4.4 and below
+// https://www.typescriptlang.org/play?ts=4.4.4#code/C4TwDgpgBAglC8UDeUBGB7VAuKBnYATgJYB2A5gNxQDaA1jvseQLo4CsAPo6WVAL4UAsACgRIiAA8w6AsCihIUAEoQAjgFciBCABMA0hBC4APABUAfAigA1AIYAbdRBMB5EvZAqNW3WfPmhUWFJaVl5cGg3Dy9NbR0-KyQRKBo9KFIoWkN0ADMoUyhbXDxCHihJYAgSHWK0gH4oEggANwgCKBw9ZgBaOpwkPnKJSurigAUiAGNaMwAaKD1zZJSoBqbWgmWUzsCBMWEFaDtHZwTEUzpsvNNmQJFDqABhKyjPNVjfGCWDiKgAIT+ViyIFyT3uv0ez0QxycJke5iAA
+type Values<T> = T[Exclude<keyof T, number>];

--- a/packages/rest/tsconfig.typetest.json
+++ b/packages/rest/tsconfig.typetest.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "jsx": "preserve", // this is just to make it work with older typescript versions in our tests
+    "emitDeclarationOnly": false,
+    "noEmit": true
+  },
+  "include": ["./src/next/__tests__/types.test.ts", "./src/__tests__/types.test.ts", "./src/*", "./src/next/*", "../../__tests__"],
+}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Ensure extensive compatibility with type combinations

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Update TS 4.0 Entity types with changes
- Add TS 4.0 OptionsToFunction for /next (just like normal)
- Move Resource specific interfaces to another file
- Exclude number in Value utility for TypeScript 4.4 and below (see https://www.typescriptlang.org/play?ts=4.4.4#code/C4TwDgpgBAglC8UDeUBGB7VAuKBnYATgJYB2A5gNxQDaA1jvseQLo4CsAPo6WVAL4UAsACgRIiAA8w6AsCihIUAEoQAjgFciBCABMA0hBC4APABUAfAigA1AIYAbdRBMB5EvZAqNW3WfPmhUWFJaVl5cGg3Dy9NbR0-KyQRKBo9KFIoWkN0ADMoUyhbXDxCHihJYAgSHWK0gH4oEggANwgCKBw9ZgBaOpwkPnKJSurigAUiAGNaMwAaKD1zZJSoBqbWgmWUzsCBMWEFaDtHZwTEUzpsvNNmQJFDqABhKyjPNVjfGCWDiKgAIT+ViyIFyT3uv0ez0QxycJke5iAA)
- For RestEndpoint/createResource constructors - only wrap the generic options in Readonly. (both /next and normal)
  - This is only needed as a hack when no options show up; but constructors always require `path`.
  - This makes them correctly loosely match the other types like dataExpiryLength should be `number` and not `1000`, etc.