### PR TITLE
enhance: Add missing type exports

### DIFF
--- a/.changeset/afraid-emus-cover.md
+++ b/.changeset/afraid-emus-cover.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/endpoint': patch
+'@rest-hooks/rest': patch
+---
+
+fix: TypeScript 'cannot be named without reference' by adding type exports

--- a/.changeset/orange-numbers-eat.md
+++ b/.changeset/orange-numbers-eat.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/endpoint': patch
+'@rest-hooks/rest': patch
+---
+
+Collections match schemas on interfaces, rather than realized types

--- a/.changeset/shiny-moose-tell.md
+++ b/.changeset/shiny-moose-tell.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': patch
+---
+
+Use Invalidate instead of Delete in /new/createResource (same thing, diff name)

--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -97,7 +97,7 @@ export function createGithubResource<O extends ResourceGenerics>(
     Omit<O, 'schema' | 'body' | 'path'> & {
       readonly path: ShortenPath<O['path']>;
       readonly schema: {
-        results: schema.CollectionType<O['schema'][]>;
+        results: schema.Collection<O['schema'][]>;
         link: string;
       };
     }
@@ -120,7 +120,7 @@ export interface GithubResource<
     Omit<O, 'schema' | 'body' | 'path'> & {
       readonly path: ShortenPath<O['path']>;
       readonly schema: {
-        results: schema.CollectionType<O['schema'][]>;
+        results: schema.Collection<O['schema'][]>;
         link: string;
       };
     }
@@ -130,7 +130,7 @@ export interface GithubResource<
       Omit<O, 'body' | 'schema' | 'path'> & {
         readonly path: ShortenPath<O['path']>;
         readonly schema: {
-          results: schema.CollectionType<O['schema'][]>;
+          results: schema.Collection<O['schema'][]>;
           link: string;
         };
       }

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -5,24 +5,32 @@ Object.hasOwn =
   };
 
 export type {
-  EndpointInterface,
-  ReadEndpoint,
-  MutateEndpoint,
-} from './interface.js';
-export type {
   EndpointOptions,
   EndpointInstance,
   EndpointInstanceInterface,
   EndpointExtendOptions,
 } from './endpoint.js';
 export * as schema from './schema.js';
+export type {
+  CollectionInterface,
+  CollectionFromSchema,
+  //Array,
+  //Invalidate,
+} from './schema.js';
 export { default as Entity } from './schemas/Entity.js';
 export { default as validateRequired } from './validateRequired.js';
 export { DELETED, INVALID } from './special.js';
 export type {
+  EndpointInterface,
+  ReadEndpoint,
+  MutateEndpoint,
   Schema,
   SnapshotInterface,
   ExpiryStatusInterface,
+  SchemaSimple,
+  SchemaClass,
+  SchemaSimpleNew,
+  PolymorphicInterface,
 } from './interface.js';
 export type {
   AbstractInstanceType,

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -46,6 +46,30 @@ export interface SchemaSimple<T = any> {
   ): any;
 }
 
+export interface SchemaSimpleNew<T = any> {
+  normalize(
+    input: any,
+    parent: any,
+    key: any,
+    visit: (...args: any) => any,
+    addEntity: (...args: any) => any,
+    visitedEntities: Record<string, any>,
+    storeEntities: any,
+    args?: any[],
+  ): any;
+  denormalizeOnly(
+    input: {},
+    args: readonly any[],
+    unvisit: (input: any, schema: any) => any,
+  ): T;
+  infer(
+    args: readonly any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+    entities: EntityTable,
+  ): any;
+}
+
 export interface SchemaClass<T = any, N = T | undefined>
   extends SchemaSimple<T> {
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
@@ -82,6 +106,15 @@ export interface EntityInterface<T = any> extends SchemaSimple {
   indexes?: any;
   schema: Record<string, Schema>;
   prototype: T;
+}
+
+/** Represents Array or Values */
+export interface PolymorphicInterface<T = any> extends SchemaSimpleNew<T> {
+  readonly schema: any;
+  // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
+  _normalizeNullable(): any;
+  // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
+  _denormalizeNullable(): [any, boolean, boolean];
 }
 
 export interface UnvisitFunction {

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -1,3 +1,4 @@
+import { PolymorphicInterface } from '../interface.js';
 import {
   Entity as EntitySchema,
   Values,
@@ -21,7 +22,7 @@ const createValue = (value: any) => ({ ...value });
  * @see https://resthooks.io/rest/api/Collection
  */
 export default class CollectionSchema<
-  S extends ArraySchema<any> | Values<any> = any,
+  S extends PolymorphicInterface = any,
   Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,

--- a/packages/endpoint/src/schemas/Invalidate.ts
+++ b/packages/endpoint/src/schemas/Invalidate.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import type { EntityInterface } from '../interface.js';
+import type { EntityInterface, SchemaSimpleNew } from '../interface.js';
 import type { AbstractInstanceType } from '../normal.js';
-import { SchemaSimpleNew, UnvisitFunction } from '../schema.js';
 import { INVALID } from '../special.js';
 
 /**

--- a/packages/rest/src/extractCollection.ts
+++ b/packages/rest/src/extractCollection.ts
@@ -19,7 +19,7 @@ export default function extractCollection<
 }
 
 export type ExtractCollection<S extends Schema | undefined> =
-  S extends schema.CollectionSchema
+  S extends schema.CollectionInterface
     ? S
     : S extends schema.Object<infer T>
     ? ExtractObject<T>

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -30,7 +30,7 @@ export type {
 } from './hookifyResource.js';
 export { default as NetworkError } from './NetworkError.js';
 export { default as paginationUpdate } from './paginationUpdate.js';
-
+export type { OptionsToFunction } from './OptionsToFunction.js';
 export type {
   ShortenPath,
   PathArgs,

--- a/packages/rest/src/next/RestEndpoint.d.ts
+++ b/packages/rest/src/next/RestEndpoint.d.ts
@@ -103,15 +103,6 @@ export interface RestInstance<
   assign: AddEndpoint<F, S, O>;
 }
 
-export type ContainsCollectionArray =
-  | { push: any; unshift: any }
-  | { [K: string]: ContainsCollectionArray }
-  | { schema: { [K: string]: ContainsCollectionArray } };
-export type ContainsCollectionValues =
-  | { assign: any }
-  | { [K: string]: ContainsCollectionValues }
-  | { schema: { [K: string]: ContainsCollectionValues } };
-
 export type RestEndpointExtendOptions<
   O extends PartialRestGenerics,
   E extends RestInstanceBase,

--- a/packages/rest/src/next/createResource.ts
+++ b/packages/rest/src/next/createResource.ts
@@ -10,7 +10,7 @@ import RestEndpoint, {
 import { PathArgs, ShortenPath } from '../pathTypes.js';
 import { shortenPath } from '../RestHelpers.js';
 
-const { Delete, Collection } = schema;
+const { Invalidate, Collection } = schema;
 
 /** Creates collection of Endpoints for common operations on a given data/schema.
  *
@@ -55,7 +55,7 @@ export default function createResource<O extends ResourceGenerics>({
     delete: new Endpoint({
       ...extraOptions,
       path,
-      schema: (schema as any).process ? new Delete(schema as any) : schema,
+      schema: (schema as any).process ? new Invalidate(schema as any) : schema,
       method: 'DELETE',
       name: getName('delete'),
       process(res: any, params: any) {
@@ -145,7 +145,7 @@ export interface Resource<
   delete: RestTypeNoBody<
     PathArgs<O['path']>,
     O['schema'] extends schema.EntityInterface & { process: any }
-      ? schema.Delete<O['schema']>
+      ? schema.Invalidate<O['schema']>
       : O['schema'],
     undefined,
     Partial<PathArgs<O['path']>>,

--- a/packages/rest/src/next/index.ts
+++ b/packages/rest/src/next/index.ts
@@ -1,18 +1,4 @@
-export type {
-  GetEndpoint,
-  MutateEndpoint,
-  Defaults,
-  RestGenerics,
-  FetchGet,
-  FetchMutate,
-  RestFetch,
-  RestType,
-  RestInstance,
-  KeyofRestEndpoint,
-  RestEndpointConstructorOptions,
-  PaginationFieldEndpoint,
-  AddEndpoint,
-} from './RestEndpoint.js';
+export * from './RestEndpoint.js';
 export { default as RestEndpoint } from './RestEndpoint.js';
 export { default as createResource } from './createResource.js';
 export type { Resource } from './createResource.js';

--- a/packages/rest/src/next/resourceTypes.ts
+++ b/packages/rest/src/next/resourceTypes.ts
@@ -1,10 +1,4 @@
-import type {
-  EndpointExtraOptions,
-  EndpointInstanceInterface,
-  Schema,
-  FetchFunction,
-  ResolveType,
-} from '@rest-hooks/endpoint';
+import type { Schema } from '@rest-hooks/endpoint';
 
 import RestEndpoint from './RestEndpoint.js';
 

--- a/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
@@ -109,7 +109,7 @@ declare class Invalidate<E extends EntityInterface & {
  */
 declare class Delete<E extends EntityInterface & {
     process: any;
-}> extends Invalidate<E> implements SchemaClass {
+}> extends Invalidate<E> implements SchemaClass$1 {
     denormalize(id: string, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<E>, found: boolean, suspend: boolean];
 }
 
@@ -269,7 +269,7 @@ interface IEntityInstance {
  * Represents arrays
  * @see https://resthooks.io/rest/api/Array
  */
-declare class Array$1<S extends Schema = Schema> implements SchemaClass {
+declare class Array$1<S extends Schema = Schema> implements SchemaClass$1 {
   constructor(
     definition: S,
     schemaAttribute?: S extends EntityMap<infer T>
@@ -331,7 +331,7 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass {
  */
 declare class All<
   S extends EntityMap | EntityInterface = EntityMap | EntityInterface,
-> implements SchemaClass
+> implements SchemaClass$1
 {
   constructor(
     definition: S,
@@ -393,7 +393,7 @@ declare class All<
  * @see https://resthooks.io/rest/api/Object
  */
 declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
-  implements SchemaClass
+  implements SchemaClass$1
 {
   constructor(definition: O);
   define(definition: Schema): void;
@@ -436,7 +436,7 @@ declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
  * Represents polymorphic values.
  * @see https://resthooks.io/rest/api/Union
  */
-declare class Union<Choices extends EntityMap = any> implements SchemaClass {
+declare class Union<Choices extends EntityMap = any> implements SchemaClass$1 {
   constructor(
     definition: Choices,
     schemaAttribute:
@@ -494,7 +494,7 @@ declare class Union<Choices extends EntityMap = any> implements SchemaClass {
  * Represents variably sized objects
  * @see https://resthooks.io/rest/api/Values
  */
-declare class Values<Choices extends Schema = any> implements SchemaClass {
+declare class Values<Choices extends Schema = any> implements SchemaClass$1 {
   constructor(
     definition: Choices,
     schemaAttribute?: Choices extends EntityMap<infer T>
@@ -580,8 +580,8 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
  * Entities but for Arrays instead of classes
  * @see https://resthooks.io/rest/api/Collection
  */
-declare class CollectionSchema<
-  S extends Array$1<any> | Values<any> = any,
+declare class CollectionInterface<
+  S extends PolymorphicInterface = any,
   Parent extends any[] = any,
 > {
   addWith<P extends any[] = Parent>(
@@ -589,7 +589,7 @@ declare class CollectionSchema<
     createCollectionFilter?: (
       ...args: P
     ) => (collectionKey: Record<string, any>) => boolean,
-  ): CollectionSchema<S, P>;
+  ): Collection<S, P>;
 
   readonly schema: S;
   key: string;
@@ -668,21 +668,26 @@ declare class CollectionSchema<
   _denormalizeNullable(): ReturnType<S['_denormalizeNullable']>;
   _normalizeNullable(): ReturnType<S['_normalizeNullable']>;
 
-  push: S extends Array$1<any> ? CollectionSchema<S, Parent> : never;
-  unshift: S extends Array$1<any> ? CollectionSchema<S, Parent> : never;
-  assign: S extends Values<any> ? CollectionSchema<S, Parent> : never;
+  push: S extends { denormalizeOnly(): any[] } ? Collection<S, Parent> : never;
+  unshift: S extends { denormalizeOnly(): any[] }
+    ? Collection<S, Parent>
+    : never;
+
+  assign: S extends { denormalizeOnly(): Record<string, unknown> }
+    ? Collection<S, Parent>
+    : never;
 }
-type CollectionType<
-  S extends any[] | Array$1<any> | Values<any> = any,
+type CollectionFromSchema<
+  S extends any[] | PolymorphicInterface = any,
   Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
   ],
-> = CollectionSchema<S extends any[] ? Array$1<S[number]> : S, Parent>;
+> = CollectionInterface<S extends any[] ? Array$1<S[number]> : S, Parent>;
 
 interface CollectionConstructor {
   new <
-    S extends SchemaSimple[] | Array$1<any> | Values<any> = any,
+    S extends SchemaSimpleNew[] | PolymorphicInterface = any,
     Parent extends any[] = [
       urlParams: Record<string, any>,
       body?: Record<string, any>,
@@ -690,8 +695,8 @@ interface CollectionConstructor {
   >(
     schema: S,
     options: CollectionOptions,
-  ): CollectionType<S, Parent>;
-  readonly prototype: CollectionSchema;
+  ): CollectionFromSchema<S, Parent>;
+  readonly prototype: CollectionInterface;
 }
 declare let CollectionRoot: CollectionConstructor;
 /**
@@ -699,7 +704,7 @@ declare let CollectionRoot: CollectionConstructor;
  * @see https://resthooks.io/rest/api/Collection
  */
 declare class Collection<
-  S extends any[] | Array$1<any> | Values<any> = any,
+  S extends any[] | PolymorphicInterface = any,
   Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
@@ -723,36 +728,12 @@ type UnionResult<Choices extends EntityMap> = {
   id: string;
   schema: keyof Choices;
 };
-interface SchemaClass<T = any, N = T | undefined>
+interface SchemaClass$1<T = any, N = T | undefined>
   extends SchemaSimple<T> {
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
   _normalizeNullable(): any;
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
   _denormalizeNullable(): [N, boolean, boolean];
-}
-
-interface SchemaSimpleNew<T = any> {
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: (...args: any) => any,
-    addEntity: (...args: any) => any,
-    visitedEntities: Record<string, any>,
-    storeEntities: any,
-    args?: any[],
-  ): any;
-  denormalizeOnly(
-    input: {},
-    args: readonly any[],
-    unvisit: (input: any, schema: any) => any,
-  ): T;
-  infer(
-    args: readonly any[],
-    indexes: NormalizedIndex,
-    recurse: (...args: any) => any,
-    entities: EntityTable,
-  ): any;
 }
 
 // id is in Instance, so we default to that as pk
@@ -793,15 +774,15 @@ type schema_d_Union<Choices extends EntityMap = any> = Union<Choices>;
 declare const schema_d_Union: typeof Union;
 type schema_d_Values<Choices extends Schema = any> = Values<Choices>;
 declare const schema_d_Values: typeof Values;
-type schema_d_CollectionSchema<S extends Array$1<any> | Values<any> = any, Parent extends any[] = any> = CollectionSchema<S, Parent>;
-declare const schema_d_CollectionSchema: typeof CollectionSchema;
-type schema_d_CollectionType<S extends any[] | Array$1<any> | Values<any> = any, Parent extends any[] = [
+type schema_d_CollectionInterface<S extends PolymorphicInterface = any, Parent extends any[] = any> = CollectionInterface<S, Parent>;
+declare const schema_d_CollectionInterface: typeof CollectionInterface;
+type schema_d_CollectionFromSchema<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
-  ]> = CollectionType<S, Parent>;
+  ]> = CollectionFromSchema<S, Parent>;
 type schema_d_CollectionConstructor = CollectionConstructor;
 declare const schema_d_CollectionRoot: typeof CollectionRoot;
-type schema_d_Collection<S extends any[] | Array$1<any> | Values<any> = any, Parent extends any[] = [
+type schema_d_Collection<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
   ]> = Collection<S, Parent>;
@@ -811,8 +792,6 @@ type schema_d_SchemaFunction<K = string> = SchemaFunction<K>;
 type schema_d_MergeFunction = MergeFunction;
 type schema_d_SchemaAttributeFunction<S extends Schema> = SchemaAttributeFunction<S>;
 type schema_d_UnionResult<Choices extends EntityMap> = UnionResult<Choices>;
-type schema_d_SchemaClass<T = any, N = T | undefined> = SchemaClass<T, N>;
-type schema_d_SchemaSimpleNew<T = any> = SchemaSimpleNew<T>;
 type schema_d_EntityInterface<T = any> = EntityInterface<T>;
 declare namespace schema_d {
   export {
@@ -825,8 +804,8 @@ declare namespace schema_d {
     Object$1 as Object,
     schema_d_Union as Union,
     schema_d_Values as Values,
-    schema_d_CollectionSchema as CollectionSchema,
-    schema_d_CollectionType as CollectionType,
+    schema_d_CollectionInterface as CollectionInterface,
+    schema_d_CollectionFromSchema as CollectionFromSchema,
     schema_d_CollectionConstructor as CollectionConstructor,
     schema_d_CollectionRoot as CollectionRoot,
     schema_d_Collection as Collection,
@@ -835,8 +814,7 @@ declare namespace schema_d {
     schema_d_MergeFunction as MergeFunction,
     schema_d_SchemaAttributeFunction as SchemaAttributeFunction,
     schema_d_UnionResult as UnionResult,
-    schema_d_SchemaClass as SchemaClass,
-    schema_d_SchemaSimpleNew as SchemaSimpleNew,
+    SchemaClass$1 as SchemaClass,
     Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
   };
@@ -875,11 +853,11 @@ type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Pr
 /** @deprecated */
 type SchemaDetail<T> = EntityInterface<T> | {
     [K: string]: any;
-} | SchemaClass;
+} | SchemaClass$1;
 /** @deprecated */
 type SchemaList<T> = EntityInterface<T>[] | {
     [K: string]: any;
-} | Schema[] | SchemaClass;
+} | Schema[] | SchemaClass$1;
 interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
     /** Default data expiry length, will fall back to NetworkManager default if not defined */
     readonly dataExpiryLength?: number;
@@ -917,6 +895,15 @@ interface SchemaSimple<T = any> {
     denormalizeOnly?(input: {}, args: any, unvisit: (input: any, schema: any) => any): T;
     infer(args: readonly any[], indexes: NormalizedIndex, recurse: (...args: any) => any, entities: EntityTable): any;
 }
+interface SchemaSimpleNew<T = any> {
+    normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: any, args?: any[]): any;
+    denormalizeOnly(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): T;
+    infer(args: readonly any[], indexes: NormalizedIndex, recurse: (...args: any) => any, entities: EntityTable): any;
+}
+interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
+    _normalizeNullable(): any;
+    _denormalizeNullable(): [N, boolean, boolean];
+}
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid?(props: any): any;
     pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
@@ -929,6 +916,12 @@ interface EntityInterface<T = any> extends SchemaSimple {
     indexes?: any;
     schema: Record<string, Schema>;
     prototype: T;
+}
+/** Represents Array or Values */
+interface PolymorphicInterface<T = any> extends SchemaSimpleNew<T> {
+    readonly schema: any;
+    _normalizeNullable(): any;
+    _denormalizeNullable(): [any, boolean, boolean];
 }
 interface UnvisitFunction {
     (input: any, schema: any): [any, boolean, boolean] | any;
@@ -1283,4 +1276,4 @@ type QuerySchema<Schema, R> = Exclude<Schema, 'denormalize' | '_denormalizeNulla
 declare class AbortOptimistic extends Error {
 }
 
-export { AbortOptimistic, AbstractInstanceType, ArrayElement, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Index, IndexParams, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, Query, ReadEndpoint, ResolveType, Schema, SchemaDetail, SchemaList, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbortOptimistic, AbstractInstanceType, ArrayElement, CollectionFromSchema, CollectionInterface, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Index, IndexParams, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Schema, SchemaClass, SchemaDetail, SchemaList, SchemaSimple, SchemaSimpleNew, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
@@ -109,7 +109,7 @@ declare class Invalidate<E extends EntityInterface & {
  */
 declare class Delete<E extends EntityInterface & {
     process: any;
-}> extends Invalidate<E> implements SchemaClass {
+}> extends Invalidate<E> implements SchemaClass$1 {
     denormalize(id: string, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<E>, found: boolean, suspend: boolean];
 }
 
@@ -269,7 +269,7 @@ interface IEntityInstance {
  * Represents arrays
  * @see https://resthooks.io/rest/api/Array
  */
-declare class Array$1<S extends Schema = Schema> implements SchemaClass {
+declare class Array$1<S extends Schema = Schema> implements SchemaClass$1 {
   constructor(
     definition: S,
     schemaAttribute?: S extends EntityMap<infer T>
@@ -331,7 +331,7 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass {
  */
 declare class All<
   S extends EntityMap | EntityInterface = EntityMap | EntityInterface,
-> implements SchemaClass
+> implements SchemaClass$1
 {
   constructor(
     definition: S,
@@ -393,7 +393,7 @@ declare class All<
  * @see https://resthooks.io/rest/api/Object
  */
 declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
-  implements SchemaClass
+  implements SchemaClass$1
 {
   constructor(definition: O);
   define(definition: Schema): void;
@@ -436,7 +436,7 @@ declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
  * Represents polymorphic values.
  * @see https://resthooks.io/rest/api/Union
  */
-declare class Union<Choices extends EntityMap = any> implements SchemaClass {
+declare class Union<Choices extends EntityMap = any> implements SchemaClass$1 {
   constructor(
     definition: Choices,
     schemaAttribute:
@@ -494,7 +494,7 @@ declare class Union<Choices extends EntityMap = any> implements SchemaClass {
  * Represents variably sized objects
  * @see https://resthooks.io/rest/api/Values
  */
-declare class Values<Choices extends Schema = any> implements SchemaClass {
+declare class Values<Choices extends Schema = any> implements SchemaClass$1 {
   constructor(
     definition: Choices,
     schemaAttribute?: Choices extends EntityMap<infer T>
@@ -580,8 +580,8 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
  * Entities but for Arrays instead of classes
  * @see https://resthooks.io/rest/api/Collection
  */
-declare class CollectionSchema<
-  S extends Array$1<any> | Values<any> = any,
+declare class CollectionInterface<
+  S extends PolymorphicInterface = any,
   Parent extends any[] = any,
 > {
   addWith<P extends any[] = Parent>(
@@ -589,7 +589,7 @@ declare class CollectionSchema<
     createCollectionFilter?: (
       ...args: P
     ) => (collectionKey: Record<string, any>) => boolean,
-  ): CollectionSchema<S, P>;
+  ): Collection<S, P>;
 
   readonly schema: S;
   key: string;
@@ -668,21 +668,26 @@ declare class CollectionSchema<
   _denormalizeNullable(): ReturnType<S['_denormalizeNullable']>;
   _normalizeNullable(): ReturnType<S['_normalizeNullable']>;
 
-  push: S extends Array$1<any> ? CollectionSchema<S, Parent> : never;
-  unshift: S extends Array$1<any> ? CollectionSchema<S, Parent> : never;
-  assign: S extends Values<any> ? CollectionSchema<S, Parent> : never;
+  push: S extends { denormalizeOnly(): any[] } ? Collection<S, Parent> : never;
+  unshift: S extends { denormalizeOnly(): any[] }
+    ? Collection<S, Parent>
+    : never;
+
+  assign: S extends { denormalizeOnly(): Record<string, unknown> }
+    ? Collection<S, Parent>
+    : never;
 }
-type CollectionType<
-  S extends any[] | Array$1<any> | Values<any> = any,
+type CollectionFromSchema<
+  S extends any[] | PolymorphicInterface = any,
   Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
   ],
-> = CollectionSchema<S extends any[] ? Array$1<S[number]> : S, Parent>;
+> = CollectionInterface<S extends any[] ? Array$1<S[number]> : S, Parent>;
 
 interface CollectionConstructor {
   new <
-    S extends SchemaSimple[] | Array$1<any> | Values<any> = any,
+    S extends SchemaSimpleNew[] | PolymorphicInterface = any,
     Parent extends any[] = [
       urlParams: Record<string, any>,
       body?: Record<string, any>,
@@ -690,8 +695,8 @@ interface CollectionConstructor {
   >(
     schema: S,
     options: CollectionOptions,
-  ): CollectionType<S, Parent>;
-  readonly prototype: CollectionSchema;
+  ): CollectionFromSchema<S, Parent>;
+  readonly prototype: CollectionInterface;
 }
 declare let CollectionRoot: CollectionConstructor;
 /**
@@ -699,7 +704,7 @@ declare let CollectionRoot: CollectionConstructor;
  * @see https://resthooks.io/rest/api/Collection
  */
 declare class Collection<
-  S extends any[] | Array$1<any> | Values<any> = any,
+  S extends any[] | PolymorphicInterface = any,
   Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
@@ -723,36 +728,12 @@ type UnionResult<Choices extends EntityMap> = {
   id: string;
   schema: keyof Choices;
 };
-interface SchemaClass<T = any, N = T | undefined>
+interface SchemaClass$1<T = any, N = T | undefined>
   extends SchemaSimple<T> {
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
   _normalizeNullable(): any;
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
   _denormalizeNullable(): [N, boolean, boolean];
-}
-
-interface SchemaSimpleNew<T = any> {
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: (...args: any) => any,
-    addEntity: (...args: any) => any,
-    visitedEntities: Record<string, any>,
-    storeEntities: any,
-    args?: any[],
-  ): any;
-  denormalizeOnly(
-    input: {},
-    args: readonly any[],
-    unvisit: (input: any, schema: any) => any,
-  ): T;
-  infer(
-    args: readonly any[],
-    indexes: NormalizedIndex,
-    recurse: (...args: any) => any,
-    entities: EntityTable,
-  ): any;
 }
 
 // id is in Instance, so we default to that as pk
@@ -793,15 +774,15 @@ type schema_d_Union<Choices extends EntityMap = any> = Union<Choices>;
 declare const schema_d_Union: typeof Union;
 type schema_d_Values<Choices extends Schema = any> = Values<Choices>;
 declare const schema_d_Values: typeof Values;
-type schema_d_CollectionSchema<S extends Array$1<any> | Values<any> = any, Parent extends any[] = any> = CollectionSchema<S, Parent>;
-declare const schema_d_CollectionSchema: typeof CollectionSchema;
-type schema_d_CollectionType<S extends any[] | Array$1<any> | Values<any> = any, Parent extends any[] = [
+type schema_d_CollectionInterface<S extends PolymorphicInterface = any, Parent extends any[] = any> = CollectionInterface<S, Parent>;
+declare const schema_d_CollectionInterface: typeof CollectionInterface;
+type schema_d_CollectionFromSchema<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
-  ]> = CollectionType<S, Parent>;
+  ]> = CollectionFromSchema<S, Parent>;
 type schema_d_CollectionConstructor = CollectionConstructor;
 declare const schema_d_CollectionRoot: typeof CollectionRoot;
-type schema_d_Collection<S extends any[] | Array$1<any> | Values<any> = any, Parent extends any[] = [
+type schema_d_Collection<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>,
   ]> = Collection<S, Parent>;
@@ -811,8 +792,6 @@ type schema_d_SchemaFunction<K = string> = SchemaFunction<K>;
 type schema_d_MergeFunction = MergeFunction;
 type schema_d_SchemaAttributeFunction<S extends Schema> = SchemaAttributeFunction<S>;
 type schema_d_UnionResult<Choices extends EntityMap> = UnionResult<Choices>;
-type schema_d_SchemaClass<T = any, N = T | undefined> = SchemaClass<T, N>;
-type schema_d_SchemaSimpleNew<T = any> = SchemaSimpleNew<T>;
 type schema_d_EntityInterface<T = any> = EntityInterface<T>;
 declare namespace schema_d {
   export {
@@ -825,8 +804,8 @@ declare namespace schema_d {
     Object$1 as Object,
     schema_d_Union as Union,
     schema_d_Values as Values,
-    schema_d_CollectionSchema as CollectionSchema,
-    schema_d_CollectionType as CollectionType,
+    schema_d_CollectionInterface as CollectionInterface,
+    schema_d_CollectionFromSchema as CollectionFromSchema,
     schema_d_CollectionConstructor as CollectionConstructor,
     schema_d_CollectionRoot as CollectionRoot,
     schema_d_Collection as Collection,
@@ -835,8 +814,7 @@ declare namespace schema_d {
     schema_d_MergeFunction as MergeFunction,
     schema_d_SchemaAttributeFunction as SchemaAttributeFunction,
     schema_d_UnionResult as UnionResult,
-    schema_d_SchemaClass as SchemaClass,
-    schema_d_SchemaSimpleNew as SchemaSimpleNew,
+    SchemaClass$1 as SchemaClass,
     Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
   };
@@ -875,11 +853,11 @@ type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Pr
 /** @deprecated */
 type SchemaDetail<T> = EntityInterface<T> | {
     [K: string]: any;
-} | SchemaClass;
+} | SchemaClass$1;
 /** @deprecated */
 type SchemaList<T> = EntityInterface<T>[] | {
     [K: string]: any;
-} | Schema[] | SchemaClass;
+} | Schema[] | SchemaClass$1;
 interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
     /** Default data expiry length, will fall back to NetworkManager default if not defined */
     readonly dataExpiryLength?: number;
@@ -917,6 +895,15 @@ interface SchemaSimple<T = any> {
     denormalizeOnly?(input: {}, args: any, unvisit: (input: any, schema: any) => any): T;
     infer(args: readonly any[], indexes: NormalizedIndex, recurse: (...args: any) => any, entities: EntityTable): any;
 }
+interface SchemaSimpleNew<T = any> {
+    normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: any, args?: any[]): any;
+    denormalizeOnly(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): T;
+    infer(args: readonly any[], indexes: NormalizedIndex, recurse: (...args: any) => any, entities: EntityTable): any;
+}
+interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
+    _normalizeNullable(): any;
+    _denormalizeNullable(): [N, boolean, boolean];
+}
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid?(props: any): any;
     pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
@@ -929,6 +916,12 @@ interface EntityInterface<T = any> extends SchemaSimple {
     indexes?: any;
     schema: Record<string, Schema>;
     prototype: T;
+}
+/** Represents Array or Values */
+interface PolymorphicInterface<T = any> extends SchemaSimpleNew<T> {
+    readonly schema: any;
+    _normalizeNullable(): any;
+    _denormalizeNullable(): [any, boolean, boolean];
 }
 interface UnvisitFunction {
     (input: any, schema: any): [any, boolean, boolean] | any;
@@ -1325,4 +1318,4 @@ interface GQLError {
     path: (string | number)[];
 }
 
-export { AbortOptimistic, AbstractInstanceType, ArrayElement, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Index, IndexParams, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, Query, ReadEndpoint, ResolveType, Schema, SchemaDetail, SchemaList, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbortOptimistic, AbstractInstanceType, ArrayElement, CollectionFromSchema, CollectionInterface, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Index, IndexParams, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Schema, SchemaClass, SchemaDetail, SchemaList, SchemaSimple, SchemaSimpleNew, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };


### PR DESCRIPTION
### Motivation

![missingtypes](https://user-images.githubusercontent.com/866147/236010623-20cd73af-ab01-4aa1-a8b2-d9e22f177169.png)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### Endpoint

- export  SchemaSimpleNew,  PolymorphicInterface,
- Collection matches Polymoprhic interface, rather than Array | Values [Prefer base types over union](https://github.com/microsoft/TypeScript/wiki/Performance#preferring-base-types-over-unions)
- Collection push/unshift/assign ternary matches against base interface, rather than fully realized types

#### Rest

- use Invalidate instead of Delete (same thing, different name) for /new createResource
- export every type from /new/RestEndpoint.js