### PR TITLE
enhance: Collections should use .cacheWith to tell cache what to vary on

### DIFF
--- a/.changeset/gentle-tables-shop.md
+++ b/.changeset/gentle-tables-shop.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/normalizr': patch
+---
+
+fix: Use schema.cacheWith for special case cache variance

--- a/.changeset/sixty-pans-melt.md
+++ b/.changeset/sixty-pans-melt.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/endpoint': patch
+---
+
+fix: Collection should expose .cacehWith to vary cache on its Entity

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -364,6 +364,8 @@ export class CollectionInterface<
     ) => (collectionKey: Record<string, any>) => boolean,
   ): Collection<S, P>;
 
+  readonly cacheWith: object;
+
   readonly schema: S;
   key: string;
   pk(value: any, parent: any, key: string, args: any[]): string;

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -86,6 +86,10 @@ export default class CollectionSchema<
     }
   }
 
+  get cacheWith(): object {
+    return this.schema.schema;
+  }
+
   toJSON() {
     return {
       name: `Collection(${this.schema.schema.name})`,

--- a/packages/normalizr/src/denormalize/globalCache.ts
+++ b/packages/normalizr/src/denormalize/globalCache.ts
@@ -140,8 +140,7 @@ const getEntityCaches = (entityCache: DenormalizeCache['entities']) => {
     const key = schema.key;
     // collections should use the entities they collect over
     // TODO: this should be based on a public interface
-    const entityInstance: EntityInterface =
-      (schema.schema?.schema as any) ?? schema;
+    const entityInstance: EntityInterface = (schema.cacheWith as any) ?? schema;
 
     if (!(key in entityCache)) {
       entityCache[key] = Object.create(null);

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -81,6 +81,7 @@ export interface EntityInterface<T = any> extends SchemaSimple {
   ): boolean;
   indexes?: any;
   schema: Record<string, Schema>;
+  cacheWith?: object;
   prototype: T;
 }
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Consistent public interface

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since Collections should overlap with different instances, we should not have distinct caches per instance. However, we still must support Entity uniqueness, so we expose those with `Collection.cacheWith`