### PR TITLE
enhance: Improve loose null typing

### DIFF
--- a/examples/todo-app/src/pages/Home/NewTodo.tsx
+++ b/examples/todo-app/src/pages/Home/NewTodo.tsx
@@ -22,7 +22,7 @@ export default function NewTodo({
         ctrl.fetch(TodoResource.create, {
           ...payload.current,
           title: e.currentTarget.value,
-        } as any);
+        });
         e.currentTarget.value = '';
       }
     },

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -370,7 +370,8 @@ export type RestType<
   RestInstance<
     keyof UrlParams extends never
       ? (this: EndpointInstanceInterface, body?: Body) => Promise<R>
-      : string extends keyof UrlParams
+      : // even with loose null, this will only be true when all members are optional
+      {} extends UrlParams
       ?
           | ((this: EndpointInstanceInterface, body?: Body) => Promise<R>)
           | ((
@@ -434,7 +435,8 @@ export type RestFetch<
 export type ParamFetchWithBody<P, B = {}, R = any> = IfTypeScriptLooseNull<
   keyof P extends never
     ? (this: EndpointInstanceInterface, body: B) => Promise<R>
-    : string extends keyof P
+    : // even with loose null, this will only be true when all members are optional
+    {} extends P
     ?
         | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
         | ((this: EndpointInstanceInterface, params: P, body: B) => Promise<R>)
@@ -453,7 +455,8 @@ export type ParamFetchWithBody<P, B = {}, R = any> = IfTypeScriptLooseNull<
 export type ParamFetchNoBody<P, R = any> = IfTypeScriptLooseNull<
   keyof P extends never
     ? (this: EndpointInstanceInterface) => Promise<R>
-    : string extends keyof P
+    : // even with loose null, this will only be true when all members are optional
+    {} extends P
     ? (this: EndpointInstanceInterface, params?: P) => Promise<R>
     : (this: EndpointInstanceInterface, params: P) => Promise<R>,
   P extends undefined

--- a/packages/rest/src/next/RestEndpoint.d.ts
+++ b/packages/rest/src/next/RestEndpoint.d.ts
@@ -361,7 +361,8 @@ export type RestType<
   RestInstance<
     keyof UrlParams extends never
       ? (this: EndpointInstanceInterface, body?: Body) => Promise<R>
-      : string extends keyof UrlParams
+      : // even with loose null, this will only be true when all members are optional
+      {} extends UrlParams
       ?
           | ((this: EndpointInstanceInterface, body?: Body) => Promise<R>)
           | ((
@@ -425,7 +426,8 @@ export type RestFetch<
 export type ParamFetchWithBody<P, B = {}, R = any> = IfTypeScriptLooseNull<
   keyof P extends never
     ? (this: EndpointInstanceInterface, body: B) => Promise<R>
-    : string extends keyof P
+    : // even with loose null, this will only be true when all members are optional
+    {} extends P
     ?
         | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
         | ((this: EndpointInstanceInterface, params: P, body: B) => Promise<R>)
@@ -444,7 +446,8 @@ export type ParamFetchWithBody<P, B = {}, R = any> = IfTypeScriptLooseNull<
 export type ParamFetchNoBody<P, R = any> = IfTypeScriptLooseNull<
   keyof P extends never
     ? (this: EndpointInstanceInterface) => Promise<R>
-    : string extends keyof P
+    : // even with loose null, this will only be true when all members are optional
+    {} extends P
     ? (this: EndpointInstanceInterface, params?: P) => Promise<R>
     : (this: EndpointInstanceInterface, params: P) => Promise<R>,
   P extends undefined


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

When users specify searchParams with all optional fields, we want it to be optional

```ts
TodoResourceBase.create.extend({
    searchParams: {} as { userId?: string | number } | undefined,
    getOptimisticResponse(snap, body) {
      return body;
    },
  })
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
For non-loose we can detect `undefined`. However, previously we only tried to match against `string` type. By using `{} extends UrlParams` we can handle both string case, as well as optional fields.