### PR TITLE
enhance: Disallow non-object when all path members are optional

### DIFF
--- a/.changeset/late-bobcats-design.md
+++ b/.changeset/late-bobcats-design.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': patch
+---
+
+Disallow non-object when all path members are optional

--- a/.changeset/silent-chicken-protect.md
+++ b/.changeset/silent-chicken-protect.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': patch
+---
+
+Simplify ParamFetch<> type algorithm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,9 @@ jobs:
             fi
             yarn run tsc --project examples/todo-app/tsconfig.typetest.json
             yarn run tsc --project examples/github-app/tsconfig.typetest.json
+            if [ "<< parameters.typescript-version >>" != "~4.0" ]; then
+            yarn run tsc --project examples/todo-app/tsconfig.typetest41.json
+            fi
 
   esmodule-loosenulltypes:
     docker: *docker
@@ -145,7 +148,9 @@ jobs:
           command: |
             yarn run tsc --project examples/todo-app/tsconfig.json --strictNullChecks false
             yarn run tsc --project examples/github-app/tsconfig.json --strictNullChecks false
-
+            yarn run tsc --project examples/todo-app/tsconfig.typetest.json --strictNullChecks false
+            yarn run tsc --project examples/github-app/tsconfig.typetest.json --strictNullChecks false
+            yarn run tsc --project examples/todo-app/tsconfig.typetest41.json --strictNullChecks false
 
   esmodule-exactOptionalPropertyTypes:
     docker: *docker
@@ -157,6 +162,7 @@ jobs:
           command: |
             yarn run tsc --project examples/todo-app/tsconfig.typetest.json --exactOptionalPropertyTypes true
             yarn run tsc --project examples/github-app/tsconfig.typetest.json --exactOptionalPropertyTypes true
+            yarn run tsc --project examples/todo-app/tsconfig.typetest41.json --exactOptionalPropertyTypes true
 
   validate-esmodule-browser-build:
     docker: *docker

--- a/examples/github-app/src/resources/Reaction.tsx
+++ b/examples/github-app/src/resources/Reaction.tsx
@@ -34,7 +34,7 @@ export const ReactionResource = {
     path: 'repos/:owner/:repo/issues/comments/:comment/reactions',
   }),
   create: base.create.extend({
-    getOptimisticResponse: (snap, params, body) => body as any,
+    getOptimisticResponse: (snap, params, body) => body,
   }),
   delete: base.delete.extend({
     getOptimisticResponse: (snap, params) => params,

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -1,4 +1,4 @@
-import { Denormalize, Entity, Schema } from '@rest-hooks/rest';
+import { Entity } from '@rest-hooks/rest';
 import {
   RestEndpoint,
   createResource,

--- a/examples/todo-app/src/resources/TodoResource.ts
+++ b/examples/todo-app/src/resources/TodoResource.ts
@@ -1,5 +1,4 @@
 import { Query, schema } from '@rest-hooks/rest';
-import { createResource } from '@rest-hooks/rest/next';
 
 import {
   createPlaceholderResource,

--- a/examples/todo-app/src/resources/TodoResource.ts
+++ b/examples/todo-app/src/resources/TodoResource.ts
@@ -33,8 +33,8 @@ export const TodoResource = {
   }),
   create: TodoResourceBase.create.extend({
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, body) {
-      return body;
+    getOptimisticResponse(snap, ...args) {
+      return args[args.length - 1];
     },
   }),
   delete: TodoResourceBase.delete.extend({

--- a/examples/todo-app/tsconfig.typetest41.json
+++ b/examples/todo-app/tsconfig.typetest41.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "skipDefaultLibCheck": true,
+  },
+  "include": ["typetest41.ts"],
+}

--- a/examples/todo-app/typetest41.ts
+++ b/examples/todo-app/typetest41.ts
@@ -1,0 +1,297 @@
+// this lets us validate the published/built types
+import { RestEndpoint } from '@rest-hooks/rest/next';
+
+// path: '/todos'
+() => {
+  const optionalUndefSearch = new RestEndpoint({
+    path: '/todos',
+    searchParams: {} as
+      | {
+          userId?: string | number;
+        }
+      | undefined,
+  });
+  const optionalSearch = new RestEndpoint({
+    path: '/todos',
+    searchParams: {} as {
+      userId?: string | number;
+    },
+  });
+  const undef = new RestEndpoint({
+    path: '/todos',
+    searchParams: undefined,
+  });
+  const requiredSearch = new RestEndpoint({
+    path: '/todos',
+    searchParams: {} as {
+      userId: string | number;
+    },
+  });
+  const noSearch = new RestEndpoint({
+    path: '/todos',
+  });
+  () => optionalUndefSearch();
+  () => optionalUndefSearch({});
+  () => optionalUndefSearch({ userId: 'hi' });
+  // @ts-expect-error
+  () => optionalUndefSearch(5);
+  // @ts-expect-error
+  () => optionalUndefSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  () => optionalSearch();
+  () => optionalSearch({});
+  () => optionalSearch({ userId: 'hi' });
+  // @ts-expect-error
+  () => optionalSearch(5);
+  // @ts-expect-error
+  () => optionalSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  // @ts-expect-error
+  () => requiredSearch();
+  // @ts-expect-error
+  () => requiredSearch({});
+  () => requiredSearch({ userId: 'hi' });
+  // @ts-expect-error
+  () => requiredSearch(5);
+  // @ts-expect-error
+  () => requiredSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  () => undef();
+  // @ts-expect-error
+  () => undef({});
+  // @ts-expect-error
+  () => undef({ userId: 'hi' });
+  // @ts-expect-error
+  () => undef(5);
+
+  () => noSearch();
+  // @ts-expect-error
+  () => noSearch({});
+  // @ts-expect-error
+  () => noSearch({ userId: 'hi' });
+  // @ts-expect-error
+  () => noSearch(5);
+};
+// path: '/todos/:id?'
+() => {
+  const optionalUndefSearch = new RestEndpoint({
+    path: '/todos/:id?',
+    searchParams: {} as
+      | {
+          userId?: string | number;
+        }
+      | undefined,
+  });
+  const optionalSearch = new RestEndpoint({
+    path: '/todos/:id?',
+    searchParams: {} as {
+      userId?: string | number;
+    },
+  });
+  const undef = new RestEndpoint({
+    path: '/todos/:id?',
+    searchParams: undefined,
+  });
+  const requiredSearch = new RestEndpoint({
+    path: '/todos/:id?',
+    searchParams: {} as {
+      userId: string | number;
+    },
+  });
+  const noSearch = new RestEndpoint({
+    path: '/todos/:id?',
+  });
+  () => optionalUndefSearch();
+  () => optionalUndefSearch({});
+  () => optionalUndefSearch({ id: '5' });
+  () => optionalUndefSearch({ userId: 'hi' });
+  () => optionalUndefSearch({ userId: 'hi', id: '5' });
+  // @ts-expect-error
+  () => optionalUndefSearch(5);
+  // @ts-expect-error
+  () => optionalUndefSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  () => optionalSearch();
+  () => optionalSearch({});
+  () => optionalSearch({ id: '5' });
+  () => optionalSearch({ userId: 'hi' });
+  () => optionalSearch({ userId: 'hi', id: '5' });
+  // @ts-expect-error
+  () => optionalSearch(5);
+  // @ts-expect-error
+  () => optionalSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  // @ts-expect-error
+  () => requiredSearch();
+  // @ts-expect-error
+  () => requiredSearch({});
+  // @ts-expect-error
+  () => requiredSearch({ id: '5' });
+  () => requiredSearch({ userId: 'hi' });
+  () => requiredSearch({ userId: 'hi', id: '5' });
+  // @ts-expect-error
+  () => requiredSearch(5);
+  // @ts-expect-error
+  () => requiredSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  () => undef();
+  // @ts-expect-error
+  () => undef({ userId: 'hi' });
+  // @ts-expect-error
+  () => undef(5);
+
+  () => noSearch();
+  () => noSearch({});
+  () => noSearch({ id: '5' });
+  // @ts-expect-error
+  () => noSearch({ userId: 'hi' });
+  // @ts-expect-error
+  () => noSearch(5);
+};
+// path: '/todos/:id'
+() => {
+  const optionalUndefSearch = new RestEndpoint({
+    path: '/todos/:id',
+    searchParams: {} as
+      | {
+          userId?: string | number;
+        }
+      | undefined,
+  });
+  const optionalSearch = new RestEndpoint({
+    path: '/todos/:id',
+    searchParams: {} as {
+      userId?: string | number;
+    },
+  });
+  const undef = new RestEndpoint({
+    path: '/todos/:id',
+    searchParams: undefined,
+  });
+  const requiredSearch = new RestEndpoint({
+    path: '/todos/:id',
+    searchParams: {} as {
+      userId: string | number;
+    },
+  });
+  const noSearch = new RestEndpoint({
+    path: '/todos/:id',
+  });
+  // @ts-expect-error
+  () => optionalUndefSearch();
+  () => optionalUndefSearch({ id: '5' });
+  () => optionalUndefSearch({ id: '5', userId: 'hi' });
+  // @ts-expect-error
+  () => optionalUndefSearch(5);
+  () =>
+    // @ts-expect-error
+    optionalUndefSearch({ id: '5', userId: 'hi' }, { id: '5', userId: 'hi' });
+
+  // @ts-expect-error
+  () => optionalSearch();
+  () => optionalSearch({ id: '5' });
+  () => optionalSearch({ id: '5', userId: 'hi' });
+  // @ts-expect-error
+  () => optionalSearch(5);
+  // @ts-expect-error
+  () => optionalSearch({ id: '5', userId: 'hi' }, { id: '5', userId: 'hi' });
+
+  // @ts-expect-error
+  () => requiredSearch();
+  // @ts-expect-error
+  () => requiredSearch({ id: '5' });
+  () => requiredSearch({ id: '5', userId: 'hi' });
+  // @ts-expect-error
+  () => requiredSearch(5);
+  // @ts-expect-error
+  () => requiredSearch({ id: '5', userId: 'hi' }, { id: '5', userId: 'hi' });
+
+  () => undef();
+  // @ts-expect-error
+  () => undef({});
+  // @ts-expect-error
+  () => undef({ id: '5', userId: 'hi' });
+  // @ts-expect-error
+  () => undef(5);
+
+  // @ts-expect-error
+  () => noSearch();
+  () => noSearch({ id: '5' });
+  // @ts-expect-error
+  () => noSearch({ id: '5', userId: 'hi' });
+  // @ts-expect-error
+  () => noSearch(5);
+};
+// path: string
+() => {
+  const optionalUndefSearch = new RestEndpoint({
+    path: '' as string,
+    searchParams: {} as
+      | {
+          userId?: string | number;
+        }
+      | undefined,
+  });
+  const optionalSearch = new RestEndpoint({
+    path: '' as string,
+    searchParams: {} as {
+      userId?: string | number;
+    },
+  });
+  const undef = new RestEndpoint({
+    path: '' as string,
+    searchParams: undefined,
+  });
+  const requiredSearch = new RestEndpoint({
+    path: '' as string,
+    searchParams: {} as {
+      userId: string | number;
+    },
+  });
+  const noSearch = new RestEndpoint({
+    path: '' as string,
+  });
+  () => optionalUndefSearch();
+  () => optionalUndefSearch({});
+  () => optionalUndefSearch({ id: '5' });
+  () => optionalUndefSearch({ userId: 'hi' });
+  () => optionalUndefSearch({ userId: 'hi', id: '5' });
+  // @ts-expect-error
+  () => optionalUndefSearch(5);
+  // @ts-expect-error
+  () => optionalUndefSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  () => optionalSearch();
+  () => optionalSearch({});
+  () => optionalSearch({ id: '5' });
+  () => optionalSearch({ userId: 'hi' });
+  () => optionalSearch({ userId: 'hi', id: '5' });
+  // @ts-expect-error
+  () => optionalSearch(5);
+  // @ts-expect-error
+  () => optionalSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  // @ts-expect-error
+  () => requiredSearch();
+  // @ts-expect-error
+  () => requiredSearch({});
+  // @ts-expect-error
+  () => requiredSearch({ id: '5' });
+  () => requiredSearch({ userId: 'hi' });
+  () => requiredSearch({ userId: 'hi', id: '5' });
+  // @ts-expect-error
+  () => requiredSearch(5);
+  // @ts-expect-error
+  () => requiredSearch({ userId: 'hi' }, { userId: 'hi' });
+
+  () => undef();
+  // @ts-expect-error
+  () => undef(5);
+
+  () => noSearch();
+  () => noSearch({});
+  () => noSearch({ id: '5' });
+  () => noSearch({ userId: 'hi' });
+  // @ts-expect-error
+  () => noSearch(5);
+};

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -432,41 +432,37 @@ export type RestFetch<
     : ParamFetchNoBody<UrlParams, Resolve>
 >;
 
-export type ParamFetchWithBody<P, B = {}, R = any> = IfTypeScriptLooseNull<
-  keyof P extends never
+export type ParamFetchWithBody<P, B = {}, R = any> =
+  // we must always allow undefined in a union and give it a type without params
+  P extends undefined
     ? (this: EndpointInstanceInterface, body: B) => Promise<R>
     : // even with loose null, this will only be true when all members are optional
     {} extends P
-    ?
-        | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
-        | ((this: EndpointInstanceInterface, params: P, body: B) => Promise<R>)
-    : (this: EndpointInstanceInterface, params: P, body: B) => Promise<R>,
-  P extends undefined
-    ? (this: EndpointInstanceInterface, body: B) => Promise<R>
-    : undefined extends P
-    ? (this: EndpointInstanceInterface, body: B) => Promise<R>
-    : RequiredKeys<P> extends never
-    ?
-        | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
-        | ((this: EndpointInstanceInterface, params: P, body: B) => Promise<R>)
-    : (this: EndpointInstanceInterface, params: P, body: B) => Promise<R>
->;
+    ? // this safely handles PathArgs with no members that results in a simple `unknown` type
+      keyof P extends never
+      ? (this: EndpointInstanceInterface, body: B) => Promise<R>
+      :
+          | ((
+              this: EndpointInstanceInterface,
+              params: P,
+              body: B,
+            ) => Promise<R>)
+          | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
+    : (this: EndpointInstanceInterface, params: P, body: B) => Promise<R>;
 
-export type ParamFetchNoBody<P, R = any> = IfTypeScriptLooseNull<
-  keyof P extends never
+export type ParamFetchNoBody<P, R = any> =
+  // we must always allow undefined in a union and give it a type without params
+  P extends undefined
     ? (this: EndpointInstanceInterface) => Promise<R>
     : // even with loose null, this will only be true when all members are optional
     {} extends P
-    ? (this: EndpointInstanceInterface, params?: P) => Promise<R>
-    : (this: EndpointInstanceInterface, params: P) => Promise<R>,
-  P extends undefined
-    ? (this: EndpointInstanceInterface) => Promise<R>
-    : undefined extends P
-    ? (this: EndpointInstanceInterface) => Promise<R>
-    : RequiredKeys<P> extends never
-    ? (this: EndpointInstanceInterface, params?: P) => Promise<R>
-    : (this: EndpointInstanceInterface, params: P) => Promise<R>
->;
+    ? // this safely handles PathArgs with no members that results in a simple `unknown` type
+      keyof P extends never
+      ? (this: EndpointInstanceInterface) => Promise<R>
+      :
+          | ((this: EndpointInstanceInterface, params: P) => Promise<R>)
+          | ((this: EndpointInstanceInterface) => Promise<R>)
+    : (this: EndpointInstanceInterface, params: P) => Promise<R>;
 
 type IfTypeScriptLooseNull<Y, N> = 1 | undefined extends 1 ? Y : N;
 

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -39,6 +39,8 @@ describe('PathArgs', () => {
     () => A({ idasd: 'ho' });
     // @ts-expect-error
     () => A({ next: 'hi', title: 'ho', id: 'hi' });
+    // @ts-expect-error
+    () => A(5);
   });
 
   it('should be flexible for string type', () => {

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -273,8 +273,8 @@ it('should customize resources', () => {
   });
   TodoResourceBase.create.extend({
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, body) {
-      return body;
+    getOptimisticResponse(snap, ...args) {
+      return args[args.length - 1];
     },
   });
   TodoResourceBase.create
@@ -287,8 +287,8 @@ it('should customize resources', () => {
     })
     .extend({
       searchParams: {} as { userId?: string | number } | undefined,
-      getOptimisticResponse(snap, body) {
-        return body;
+      getOptimisticResponse(snap, ...args) {
+        return args[args.length - 1];
       },
     });
 });

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -208,21 +208,21 @@ it('RestEndpoint construct and extend with typed options', () => {
   new RestEndpoint({
     path: '/todos/:id',
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, args, body) {
+    getOptimisticResponse(snap, params, body) {
       return body;
     },
     schema: User,
     method: 'POST',
   });
-  /*new RestEndpoint({
+  new RestEndpoint({
     path: '/todos/:id',
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, args) {
-      return args as any;
+    getOptimisticResponse(snap, params, body) {
+      return body;
     },
     schema: User,
     method: 'POST',
-  });*/
+  });
 
   const nopath = new RestEndpoint({
     path: '/todos/',

--- a/packages/rest/src/next/RestEndpoint.d.ts
+++ b/packages/rest/src/next/RestEndpoint.d.ts
@@ -423,41 +423,37 @@ export type RestFetch<
     : ParamFetchNoBody<UrlParams, Resolve>
 >;
 
-export type ParamFetchWithBody<P, B = {}, R = any> = IfTypeScriptLooseNull<
-  keyof P extends never
+export type ParamFetchWithBody<P, B = {}, R = any> =
+  // we must always allow undefined in a union and give it a type without params
+  P extends undefined
     ? (this: EndpointInstanceInterface, body: B) => Promise<R>
     : // even with loose null, this will only be true when all members are optional
     {} extends P
-    ?
-        | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
-        | ((this: EndpointInstanceInterface, params: P, body: B) => Promise<R>)
-    : (this: EndpointInstanceInterface, params: P, body: B) => Promise<R>,
-  P extends undefined
-    ? (this: EndpointInstanceInterface, body: B) => Promise<R>
-    : undefined extends P
-    ? (this: EndpointInstanceInterface, body: B) => Promise<R>
-    : RequiredKeys<P> extends never
-    ?
-        | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
-        | ((this: EndpointInstanceInterface, params: P, body: B) => Promise<R>)
-    : (this: EndpointInstanceInterface, params: P, body: B) => Promise<R>
->;
+    ? // this safely handles PathArgs with no members that results in a simple `unknown` type
+      keyof P extends never
+      ? (this: EndpointInstanceInterface, body: B) => Promise<R>
+      :
+          | ((
+              this: EndpointInstanceInterface,
+              params: P,
+              body: B,
+            ) => Promise<R>)
+          | ((this: EndpointInstanceInterface, body: B) => Promise<R>)
+    : (this: EndpointInstanceInterface, params: P, body: B) => Promise<R>;
 
-export type ParamFetchNoBody<P, R = any> = IfTypeScriptLooseNull<
-  keyof P extends never
+export type ParamFetchNoBody<P, R = any> =
+  // we must always allow undefined in a union and give it a type without params
+  P extends undefined
     ? (this: EndpointInstanceInterface) => Promise<R>
     : // even with loose null, this will only be true when all members are optional
     {} extends P
-    ? (this: EndpointInstanceInterface, params?: P) => Promise<R>
-    : (this: EndpointInstanceInterface, params: P) => Promise<R>,
-  P extends undefined
-    ? (this: EndpointInstanceInterface) => Promise<R>
-    : undefined extends P
-    ? (this: EndpointInstanceInterface) => Promise<R>
-    : RequiredKeys<P> extends never
-    ? (this: EndpointInstanceInterface, params?: P) => Promise<R>
-    : (this: EndpointInstanceInterface, params: P) => Promise<R>
->;
+    ? // this safely handles PathArgs with no members that results in a simple `unknown` type
+      keyof P extends never
+      ? (this: EndpointInstanceInterface) => Promise<R>
+      :
+          | ((this: EndpointInstanceInterface, params: P) => Promise<R>)
+          | ((this: EndpointInstanceInterface) => Promise<R>)
+    : (this: EndpointInstanceInterface, params: P) => Promise<R>;
 
 type IfTypeScriptLooseNull<Y, N> = 1 | undefined extends 1 ? Y : N;
 

--- a/packages/rest/src/next/__tests__/types.test.ts
+++ b/packages/rest/src/next/__tests__/types.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Entity, schema } from '@rest-hooks/endpoint';
 import { useSuspense } from '@rest-hooks/react';
 import { User } from '__tests__/new';
@@ -92,8 +93,8 @@ it('should customize resources', () => {
   });
   TodoResource.create.extend({
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, body) {
-      return body;
+    getOptimisticResponse(snap, ...args) {
+      return args[args.length - 1];
     },
   });
   const partial = TodoResource.partialUpdate.extend({
@@ -112,10 +113,316 @@ it('should customize resources', () => {
   }> = TodoResource.create.extend({ schema: Todo }) as any;
   a.extend({
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, body) {
-      return body;
+    getOptimisticResponse(snap, ...args) {
+      return args[args.length - 1];
     },
   });
 
   () => useSuspense(TodoResource.getList);
+});
+
+// path: ['/todos', '/todos/:id', '/todos/:id?', string]
+it('should precisely type function arguments', () => {
+  // path: '/todos'
+  () => {
+    const optionalUndefSearch = new RestEndpoint({
+      path: '/todos',
+      searchParams: {} as
+        | {
+            userId?: string | number;
+          }
+        | undefined,
+    });
+    const optionalSearch = new RestEndpoint({
+      path: '/todos',
+      searchParams: {} as {
+        userId?: string | number;
+      },
+    });
+    const undef = new RestEndpoint({
+      path: '/todos',
+      searchParams: undefined,
+    });
+    const requiredSearch = new RestEndpoint({
+      path: '/todos',
+      searchParams: {} as {
+        userId: string | number;
+      },
+    });
+    const noSearch = new RestEndpoint({
+      path: '/todos',
+    });
+    () => optionalUndefSearch();
+    () => optionalUndefSearch({});
+    () => optionalUndefSearch({ userId: 'hi' });
+    // @ts-expect-error
+    () => optionalUndefSearch(5);
+    // @ts-expect-error
+    () => optionalUndefSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    () => optionalSearch();
+    () => optionalSearch({});
+    () => optionalSearch({ userId: 'hi' });
+    // @ts-expect-error
+    () => optionalSearch(5);
+    // @ts-expect-error
+    () => optionalSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    // @ts-expect-error
+    () => requiredSearch();
+    // @ts-expect-error
+    () => requiredSearch({});
+    () => requiredSearch({ userId: 'hi' });
+    // @ts-expect-error
+    () => requiredSearch(5);
+    // @ts-expect-error
+    () => requiredSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    () => undef();
+    // @ts-expect-error
+    () => undef({});
+    // @ts-expect-error
+    () => undef({ userId: 'hi' });
+    // @ts-expect-error
+    () => undef(5);
+
+    () => noSearch();
+    // @ts-expect-error
+    () => noSearch({});
+    // @ts-expect-error
+    () => noSearch({ userId: 'hi' });
+    // @ts-expect-error
+    () => noSearch(5);
+  };
+  // path: '/todos/:id?'
+  () => {
+    const optionalUndefSearch = new RestEndpoint({
+      path: '/todos/:id?',
+      searchParams: {} as
+        | {
+            userId?: string | number;
+          }
+        | undefined,
+    });
+    const optionalSearch = new RestEndpoint({
+      path: '/todos/:id?',
+      searchParams: {} as {
+        userId?: string | number;
+      },
+    });
+    const undef = new RestEndpoint({
+      path: '/todos/:id?',
+      searchParams: undefined,
+    });
+    const requiredSearch = new RestEndpoint({
+      path: '/todos/:id?',
+      searchParams: {} as {
+        userId: string | number;
+      },
+    });
+    const noSearch = new RestEndpoint({
+      path: '/todos/:id?',
+    });
+    () => optionalUndefSearch();
+    () => optionalUndefSearch({});
+    () => optionalUndefSearch({ id: '5' });
+    () => optionalUndefSearch({ userId: 'hi' });
+    () => optionalUndefSearch({ userId: 'hi', id: '5' });
+    // @ts-expect-error
+    () => optionalUndefSearch(5);
+    // @ts-expect-error
+    () => optionalUndefSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    () => optionalSearch();
+    () => optionalSearch({});
+    () => optionalSearch({ id: '5' });
+    () => optionalSearch({ userId: 'hi' });
+    () => optionalSearch({ userId: 'hi', id: '5' });
+    // @ts-expect-error
+    () => optionalSearch(5);
+    // @ts-expect-error
+    () => optionalSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    // @ts-expect-error
+    () => requiredSearch();
+    // @ts-expect-error
+    () => requiredSearch({});
+    // @ts-expect-error
+    () => requiredSearch({ id: '5' });
+    () => requiredSearch({ userId: 'hi' });
+    () => requiredSearch({ userId: 'hi', id: '5' });
+    // @ts-expect-error
+    () => requiredSearch(5);
+    // @ts-expect-error
+    () => requiredSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    () => undef();
+    // @ts-ignore TODO
+    () => undef({});
+    // @ts-ignore TODO
+    () => undef({ id: '5' });
+    // @ts-expect-error
+    () => undef({ userId: 'hi' });
+    // @ts-expect-error
+    () => undef(5);
+
+    () => noSearch();
+    () => noSearch({});
+    () => noSearch({ id: '5' });
+    // @ts-expect-error
+    () => noSearch({ userId: 'hi' });
+    // @ts-expect-error
+    () => noSearch(5);
+  };
+  // path: '/todos/:id'
+  () => {
+    const optionalUndefSearch = new RestEndpoint({
+      path: '/todos/:id',
+      searchParams: {} as
+        | {
+            userId?: string | number;
+          }
+        | undefined,
+    });
+    const optionalSearch = new RestEndpoint({
+      path: '/todos/:id',
+      searchParams: {} as {
+        userId?: string | number;
+      },
+    });
+    const undef = new RestEndpoint({
+      path: '/todos/:id',
+      searchParams: undefined,
+    });
+    const requiredSearch = new RestEndpoint({
+      path: '/todos/:id',
+      searchParams: {} as {
+        userId: string | number;
+      },
+    });
+    const noSearch = new RestEndpoint({
+      path: '/todos/:id',
+    });
+    // @ts-expect-error
+    () => optionalUndefSearch();
+    () => optionalUndefSearch({ id: '5' });
+    () => optionalUndefSearch({ id: '5', userId: 'hi' });
+    // @ts-expect-error
+    () => optionalUndefSearch(5);
+    () =>
+      // @ts-expect-error
+      optionalUndefSearch({ id: '5', userId: 'hi' }, { id: '5', userId: 'hi' });
+
+    // @ts-expect-error
+    () => optionalSearch();
+    () => optionalSearch({ id: '5' });
+    () => optionalSearch({ id: '5', userId: 'hi' });
+    // @ts-expect-error
+    () => optionalSearch(5);
+    // @ts-expect-error
+    () => optionalSearch({ id: '5', userId: 'hi' }, { id: '5', userId: 'hi' });
+
+    // @ts-expect-error
+    () => requiredSearch();
+    // @ts-expect-error
+    () => requiredSearch({ id: '5' });
+    () => requiredSearch({ id: '5', userId: 'hi' });
+    // @ts-expect-error
+    () => requiredSearch(5);
+    // @ts-expect-error
+    () => requiredSearch({ id: '5', userId: 'hi' }, { id: '5', userId: 'hi' });
+
+    () => undef();
+    // @ts-expect-error
+    () => undef({});
+    // @ts-expect-error
+    () => undef({ id: '5', userId: 'hi' });
+    // @ts-expect-error
+    () => undef(5);
+
+    // @ts-expect-error
+    () => noSearch();
+    () => noSearch({ id: '5' });
+    // @ts-expect-error
+    () => noSearch({ id: '5', userId: 'hi' });
+    // @ts-expect-error
+    () => noSearch(5);
+  };
+  // path: string
+  () => {
+    const optionalUndefSearch = new RestEndpoint({
+      path: '' as string,
+      searchParams: {} as
+        | {
+            userId?: string | number;
+          }
+        | undefined,
+    });
+    const optionalSearch = new RestEndpoint({
+      path: '' as string,
+      searchParams: {} as {
+        userId?: string | number;
+      },
+    });
+    const undef = new RestEndpoint({
+      path: '' as string,
+      searchParams: undefined,
+    });
+    const requiredSearch = new RestEndpoint({
+      path: '' as string,
+      searchParams: {} as {
+        userId: string | number;
+      },
+    });
+    const noSearch = new RestEndpoint({
+      path: '' as string,
+    });
+    () => optionalUndefSearch();
+    () => optionalUndefSearch({});
+    () => optionalUndefSearch({ id: '5' });
+    () => optionalUndefSearch({ userId: 'hi' });
+    () => optionalUndefSearch({ userId: 'hi', id: '5' });
+    // @ts-expect-error
+    () => optionalUndefSearch(5);
+    // @ts-expect-error
+    () => optionalUndefSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    () => optionalSearch();
+    () => optionalSearch({});
+    () => optionalSearch({ id: '5' });
+    () => optionalSearch({ userId: 'hi' });
+    () => optionalSearch({ userId: 'hi', id: '5' });
+    // @ts-expect-error
+    () => optionalSearch(5);
+    // @ts-expect-error
+    () => optionalSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    // @ts-expect-error
+    () => requiredSearch();
+    // @ts-expect-error
+    () => requiredSearch({});
+    // @ts-expect-error
+    () => requiredSearch({ id: '5' });
+    () => requiredSearch({ userId: 'hi' });
+    () => requiredSearch({ userId: 'hi', id: '5' });
+    // @ts-expect-error
+    () => requiredSearch(5);
+    // @ts-expect-error
+    () => requiredSearch({ userId: 'hi' }, { userId: 'hi' });
+
+    () => undef();
+    // @ts-ignore TODO
+    () => undef({});
+    // @ts-ignore TODO
+    () => undef({ id: '5' });
+    // @ts-expect-error
+    () => undef(5);
+
+    () => noSearch();
+    () => noSearch({});
+    () => noSearch({ id: '5' });
+    () => noSearch({ userId: 'hi' });
+    // @ts-expect-error
+    () => noSearch(5);
+  };
 });

--- a/packages/rest/src/next/__tests__/types.test.ts
+++ b/packages/rest/src/next/__tests__/types.test.ts
@@ -28,21 +28,21 @@ it('RestEndpoint construct and extend with typed options', () => {
   new RestEndpoint({
     path: '/todos/:id',
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, args, body) {
+    getOptimisticResponse(snap, params, body) {
       return body;
     },
     schema: User,
     method: 'POST',
   });
-  /*new RestEndpoint({
+  new RestEndpoint({
     path: '/todos/:id',
     searchParams: {} as { userId?: string | number } | undefined,
-    getOptimisticResponse(snap, args) {
-      return args as any;
+    getOptimisticResponse(snap, params, body) {
+      return body;
     },
     schema: User,
     method: 'POST',
-  });*/
+  });
 
   const nopath = new RestEndpoint({
     path: '/todos/',

--- a/packages/rest/src/pathTypes.ts
+++ b/packages/rest/src/pathTypes.ts
@@ -26,9 +26,11 @@ export type PathArgs<S extends string> = PathKeys<S> extends never
 
 export type KeysToArgs<Key extends string> = {
   [K in Key as OnlyOptional<K>]?: string | number;
-} & {
-  [K in Key as OnlyRequired<K>]: string | number;
-};
+} & (OnlyRequired<Key> extends never
+  ? unknown
+  : {
+      [K in Key as OnlyRequired<K>]: string | number;
+    });
 
 export type PathArgsAndSearch<S extends string> = OnlyRequired<
   PathKeys<S>

--- a/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
@@ -576,10 +576,6 @@ declare class Values<Choices extends Schema = any> implements SchemaClass$1 {
   ): any;
 }
 
-/**
- * Entities but for Arrays instead of classes
- * @see https://resthooks.io/rest/api/Collection
- */
 declare class CollectionInterface<
   S extends PolymorphicInterface = any,
   Parent extends any[] = any,
@@ -704,6 +700,7 @@ interface CollectionConstructor {
   readonly prototype: CollectionInterface;
 }
 declare let CollectionRoot: CollectionConstructor;
+
 /**
  * Entities but for Arrays instead of classes
  * @see https://resthooks.io/rest/api/Collection

--- a/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
@@ -576,10 +576,6 @@ declare class Values<Choices extends Schema = any> implements SchemaClass$1 {
   ): any;
 }
 
-/**
- * Entities but for Arrays instead of classes
- * @see https://resthooks.io/rest/api/Collection
- */
 declare class CollectionInterface<
   S extends PolymorphicInterface = any,
   Parent extends any[] = any,
@@ -704,6 +700,7 @@ interface CollectionConstructor {
   readonly prototype: CollectionInterface;
 }
 declare let CollectionRoot: CollectionConstructor;
+
 /**
  * Entities but for Arrays instead of classes
  * @see https://resthooks.io/rest/api/Collection


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Computing function arguments is one of the hottest type paths in this library. It is not only used in all call inference, but used to type options when defining RestEndpoints.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`{} extends P` works even with loose null types - allowing us to remove the loose-type generic split.

We added an extensive type suite to test all combinations of searchParams and path. We run this against the entire type matrix except 4.0 which doesn't have sufficient support for path templates.