### PR TITLE
enhance: Collection has default argsKey

### DIFF
--- a/.changeset/five-spoons-admire.md
+++ b/.changeset/five-spoons-admire.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/endpoint': patch
+'@rest-hooks/graphql': patch
+'@rest-hooks/rest': patch
+---
+
+Collections now have a default argsKey

--- a/docs/rest/api/Collection.md
+++ b/docs/rest/api/Collection.md
@@ -43,7 +43,7 @@ delay: 150,
 },
 ]}>
 
-```ts title="api/Todo" {15-17}
+```ts title="api/Todo" {15}
 export class Todo extends Entity {
   id = '';
   userId = 0;
@@ -58,9 +58,7 @@ export class Todo extends Entity {
 
 export const getTodos = new RestEndpoint({
   path: '/todos',
-  schema: new schema.Collection([Todo], {
-    argsKey: urlParams => ({ ...urlParams }),
-  }),
+  schema: new schema.Collection([Todo]),
 });
 ```
 

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -468,7 +468,7 @@ export interface CollectionConstructor {
     ],
   >(
     schema: S,
-    options: CollectionOptions,
+    options?: CollectionOptions,
   ): CollectionFromSchema<S, Parent>;
   readonly prototype: CollectionInterface;
 }

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -59,21 +59,21 @@ export default class CollectionSchema<
     return CreateAdder(this, merge, createCollectionFilter);
   }
 
-  constructor(schema: S, options: CollectionOptions) {
+  constructor(schema: S, options?: CollectionOptions) {
     this.schema = Array.isArray(schema)
       ? (new ArraySchema(schema[0]) as any)
       : schema;
-    if ('nestKey' in options) {
-      this.nestKey = options.nestKey;
+    if (!options) {
+      this.argsKey = params => ({ ...params });
     } else {
-      if (process.env.NODE_ENV !== 'production') {
-        if (!('argsKey' in options))
-          throw new Error('argsKey or nestKey needed');
+      if ('nestKey' in options) {
+        this.nestKey = options.nestKey;
+      } else {
+        this.argsKey = options.argsKey;
       }
-      this.argsKey = options.argsKey;
     }
     this.createCollectionFilter =
-      options.createCollectionFilter ?? (defaultFilter as any);
+      options?.createCollectionFilter ?? (defaultFilter as any);
 
     // >>>>>>>>>>>>>>CREATION<<<<<<<<<<<<<<
     if (this.schema instanceof ArraySchema) {

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -65,11 +65,6 @@ describe(`${schema.Collection.name} normalization`, () => {
   });
   beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
 
-  test('throws without a key option', () => {
-    // @ts-expect-error
-    expect(() => new schema.Collection(new schema.Array(Todo), {})).toThrow();
-  });
-
   test('should throw a custom error if data loads with string unexpected value', () => {
     function normalizeBad() {
       normalize('abc', userTodos);
@@ -118,6 +113,18 @@ describe(`${schema.Collection.name} normalization`, () => {
     const state = normalize(
       [{ id: '5', title: 'finish collections' }],
       userTodos,
+      [{ userId: '1' }],
+    );
+    expect(state).toMatchSnapshot();
+    //const a: string[] | undefined = state.result;
+    // @ts-expect-error
+    const b: Record<any, any> | undefined = state.result;
+  });
+
+  test('normalizes top level collections (no args)', () => {
+    const state = normalize(
+      [{ id: '5', title: 'finish collections' }],
+      new schema.Collection(new schema.Array(Todo)),
       [{ userId: '1' }],
     );
     expect(state).toMatchSnapshot();

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
@@ -178,6 +178,42 @@ exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
 }
 `;
 
+exports[`CollectionSchema normalization normalizes top level collections (no args) 1`] = `
+{
+  "entities": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
+    "Todo": {
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+    },
+  },
+  "entityMeta": {
+    "COLLECT:ArraySchema(Todo)": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Todo": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "{"userId":"1"}",
+}
+`;
+
 exports[`CollectionSchema normalization normalizes top level collections 1`] = `
 {
   "entities": {

--- a/packages/rest/src/next/createResource.ts
+++ b/packages/rest/src/next/createResource.ts
@@ -27,11 +27,7 @@ export default function createResource<O extends ResourceGenerics>({
   const getList = new Endpoint({
     ...extraOptions,
     path: shortenedPath,
-    schema: new Collection([schema as any], {
-      argsKey: (urlParams, body) => ({
-        ...urlParams,
-      }),
-    }),
+    schema: new Collection([schema as any]),
     name: getName('getList'),
   });
   return {

--- a/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
@@ -695,7 +695,7 @@ interface CollectionConstructor {
     ],
   >(
     schema: S,
-    options: CollectionOptions,
+    options?: CollectionOptions,
   ): CollectionFromSchema<S, Parent>;
   readonly prototype: CollectionInterface;
 }

--- a/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
@@ -695,7 +695,7 @@ interface CollectionConstructor {
     ],
   >(
     schema: S,
-    options: CollectionOptions,
+    options?: CollectionOptions,
   ): CollectionFromSchema<S, Parent>;
   readonly prototype: CollectionInterface;
 }

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -695,7 +695,7 @@ interface CollectionConstructor {
     ],
   >(
     schema: S,
-    options: CollectionOptions,
+    options?: CollectionOptions,
   ): CollectionFromSchema<S, Parent>;
   readonly prototype: CollectionInterface;
 }

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
@@ -325,7 +325,7 @@ interface CollectionConstructor {
     ],
   >(
     schema: S,
-    options: CollectionOptions,
+    options?: CollectionOptions,
   ): CollectionFromSchema<S, Parent>;
   readonly prototype: CollectionInterface;
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Sane defaults. Easy overrides.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
After lots of usage I found the most common as well as obvious case we simply want to spread. This alleviates the need to specify a key for these cases.

```ts
new schema.Collection([Todo])
```