### PR TITLE
enhance: Infer non-nested Collections

### DIFF
--- a/.changeset/polite-ties-joke.md
+++ b/.changeset/polite-ties-joke.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/endpoint': patch
+'@rest-hooks/graphql': patch
+'@rest-hooks/rest': patch
+---
+
+Non-nested Collections will infer

--- a/.changeset/strange-waves-develop.md
+++ b/.changeset/strange-waves-develop.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/endpoint': patch
+'@rest-hooks/rest': patch
+'@rest-hooks/graphql': patch
+---
+
+Update createCollectionFilter's collectionKey type to reflect values are always strings

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -357,7 +357,7 @@ export class CollectionInterface<
     merge: (existing: any, incoming: any) => any,
     createCollectionFilter?: (
       ...args: P
-    ) => (collectionKey: Record<string, any>) => boolean,
+    ) => (collectionKey: Record<string, string>) => boolean,
   ): schema.Collection<S, P>;
 
   readonly cacheWith: object;

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -398,4 +398,47 @@ describe(`${schema.Collection.name} denormalization`, () => {
       `);
     });
   });
+
+  it('should infer with matching args', () => {
+    const inferred = inferResults(
+      userTodos,
+      [{ userId: '1' }],
+      {},
+      normalizeNested.entities,
+    );
+    expect(inferred).toBeDefined();
+    // now ensure our inferred result is usable
+    const results = denormalize(inferred, userTodos, normalizeNested.entities);
+    expect(results).toBeDefined();
+    expect(results).toMatchInlineSnapshot(`
+      [
+        Todo {
+          "completed": false,
+          "id": "5",
+          "title": "finish collections",
+          "userId": 0,
+        },
+      ]
+    `);
+  });
+
+  it('should infer undefined when not in cache', () => {
+    const inferred = inferResults(
+      userTodos,
+      [{ userId: '100' }],
+      {},
+      normalizeNested.entities,
+    );
+    expect(inferred).toBeUndefined();
+  });
+
+  it('should infer undefined with nested Collection', () => {
+    const inferred = inferResults(
+      User.schema.todos,
+      [{ userId: '1' }],
+      {},
+      normalizeNested.entities,
+    );
+    expect(inferred).toBeUndefined();
+  });
 });

--- a/packages/rest/src/paginatedCollections.ts
+++ b/packages/rest/src/paginatedCollections.ts
@@ -10,7 +10,7 @@ export const paginatedFilter =
   <C extends (...args: readonly any[]) => readonly any[]>(removeCursor: C) =>
   (...args: Parameters<C>) => {
     const noCursorArgs = removeCursor(...args);
-    return (collectionKey: Record<string, any>) =>
+    return (collectionKey: Record<string, string>) =>
       shallowEqual(collectionKey, noCursorArgs[0] ?? {});
   };
 

--- a/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
@@ -56,10 +56,10 @@ type CollectionOptions<Parent extends any[] = [
     body?: Record<string, any>
 ]> = {
     nestKey: (parent: any, key: string) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
     argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 };
 
 /**
@@ -584,7 +584,7 @@ declare class CollectionInterface<
     merge: (existing: any, incoming: any) => any,
     createCollectionFilter?: (
       ...args: P
-    ) => (collectionKey: Record<string, any>) => boolean,
+    ) => (collectionKey: Record<string, string>) => boolean,
   ): Collection<S, P>;
 
   readonly cacheWith: object;

--- a/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
@@ -56,10 +56,10 @@ type CollectionOptions<Parent extends any[] = [
     body?: Record<string, any>
 ]> = {
     nestKey: (parent: any, key: string) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
     argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 };
 
 /**
@@ -584,7 +584,7 @@ declare class CollectionInterface<
     merge: (existing: any, incoming: any) => any,
     createCollectionFilter?: (
       ...args: P
-    ) => (collectionKey: Record<string, any>) => boolean,
+    ) => (collectionKey: Record<string, string>) => boolean,
   ): Collection<S, P>;
 
   readonly cacheWith: object;

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -56,10 +56,10 @@ type CollectionOptions<Parent extends any[] = [
     body?: Record<string, any>
 ]> = {
     nestKey: (parent: any, key: string) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
     argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 };
 
 /**
@@ -584,7 +584,7 @@ declare class CollectionInterface<
     merge: (existing: any, incoming: any) => any,
     createCollectionFilter?: (
       ...args: P
-    ) => (collectionKey: Record<string, any>) => boolean,
+    ) => (collectionKey: Record<string, string>) => boolean,
   ): Collection<S, P>;
 
   readonly cacheWith: object;

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
@@ -56,10 +56,10 @@ type CollectionOptions<Parent extends any[] = [
     body?: Record<string, any>
 ]> = {
     nestKey: (parent: any, key: string) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
     argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, any>) => boolean;
+    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 };
 
 /**
@@ -214,7 +214,7 @@ declare class CollectionInterface<
     merge: (existing: any, incoming: any) => any,
     createCollectionFilter?: (
       ...args: P
-    ) => (collectionKey: Record<string, any>) => boolean,
+    ) => (collectionKey: Record<string, string>) => boolean,
   ): Collection<S, P>;
 
   readonly cacheWith: object;

--- a/website/src/components/Playground/styles.module.css
+++ b/website/src/components/Playground/styles.module.css
@@ -253,10 +253,16 @@ div > .playgroundHeader.subtabs {
   background-color: var(--ifm-color-emphasis-400);
 }
 
+:root .playgroundPreview {
+  --ifm-heading-margin-bottom: .5ex;
+}
 .playgroundPreview button {
   margin-bottom: 8px;
   margin-right: 8px;
   padding: 2px 6px;
+}
+.playgroundPreview section {
+  margin-bottom: 2ex;
 }
 
 .fixtureBlock {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
"The fastest fetch is the one that never happens." - Nathaniel

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
For argsKey based Collections they will 100% have everything needed to infer results.

In other words, if we have a Collection in store from another fetch (say we nested Todos by user inside User fetch). Now when we want to get just todos by user, we don't need to do any fetch because the data is already there.