### PR TITLE
enhance: Set Collection key in constructor

### DIFF
--- a/.changeset/big-ways-care.md
+++ b/.changeset/big-ways-care.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/endpoint': patch
+---
+
+Set Collection key in constructor

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -363,7 +363,7 @@ export class CollectionInterface<
   readonly cacheWith: object;
 
   readonly schema: S;
-  key: string;
+  readonly key: string;
   pk(value: any, parent: any, key: string, args: any[]): string;
   normalize(
     input: any,

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -38,6 +38,8 @@ export default class CollectionSchema<
 
   declare readonly schema: S;
 
+  declare readonly key: string;
+
   declare push: S extends ArraySchema<any>
     ? CollectionSchema<S, Parent>
     : undefined;
@@ -72,6 +74,10 @@ export default class CollectionSchema<
         this.argsKey = options.argsKey;
       }
     }
+    // this assumes the definition of Array/Values is Entity
+    this.key = `COLLECT:${this.schema.constructor.name}(${
+      (this.schema.schema as any).key
+    })`;
     this.createCollectionFilter =
       options?.createCollectionFilter ?? (defaultFilter as any);
 
@@ -96,13 +102,6 @@ export default class CollectionSchema<
       schema: this.schema.schema,
       key: this.key,
     };
-  }
-
-  get key() {
-    // this assumes the definition of Array/Values is Entity
-    return `COLLECT:${this.schema.constructor.name}(${
-      (this.schema.schema as any).key
-    })`;
   }
 
   pk(value: any, parent: any, key: string, args: readonly any[]) {
@@ -253,6 +252,7 @@ function CreateAdder<C extends CollectionSchema<any, any>, P extends any[]>(
   const properties: PropertyDescriptorMap = {
     merge: { value: merge },
     normalize: { value: normalizeCreate },
+    infer: { value: inferCreate },
   };
   if (collection.schema instanceof ArraySchema) {
     properties.createIfValid = { value: createIfValid };
@@ -263,6 +263,8 @@ function CreateAdder<C extends CollectionSchema<any, any>, P extends any[]>(
   }
   return Object.create(collection, properties);
 }
+
+function inferCreate() {}
 
 function normalizeCreate(
   this: CollectionSchema<any, any>,

--- a/scripts/copywebsitetypes.sh
+++ b/scripts/copywebsitetypes.sh
@@ -12,3 +12,4 @@ mkdir -p ./website/src/components/Playground/editor-types/@rest-hooks/react
 cp ./packages/rest/next.d.ts ./website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
 cp ./packages/core/next.d.ts ./website/src/components/Playground/editor-types/@rest-hooks/core/next.d.ts
 cp ./packages/react/next.d.ts ./website/src/components/Playground/editor-types/@rest-hooks/react/next.d.ts
+cp ./node_modules/@types/react/index.d.ts ./website/src/components/Playground/editor-types/react.d.ts

--- a/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/endpoint.d.ts
@@ -590,7 +590,7 @@ declare class CollectionInterface<
   readonly cacheWith: object;
 
   readonly schema: S;
-  key: string;
+  readonly key: string;
   pk(value: any, parent: any, key: string, args: any[]): string;
   normalize(
     input: any,

--- a/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/graphql.d.ts
@@ -590,7 +590,7 @@ declare class CollectionInterface<
   readonly cacheWith: object;
 
   readonly schema: S;
-  key: string;
+  readonly key: string;
   pk(value: any, parent: any, key: string, args: any[]): string;
   normalize(
     input: any,

--- a/website/src/components/Playground/editor-types/@rest-hooks/react.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/react.d.ts
@@ -2,6 +2,7 @@ import * as _rest_hooks_core from '@rest-hooks/core';
 import { Manager, State as State$1, Controller, NetworkError, EndpointInterface, FetchFunction, Schema, DenormalizeNullable, ResolveType, Denormalize, UnknownError, ErrorTypes as ErrorTypes$1, ActionTypes, DenormalizeCache, legacyActions, __INTERNAL__, createReducer, applyManager } from '@rest-hooks/core';
 export { AbstractInstanceType, ActionTypes, CompatibleDispatch, Controller, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ReceiveAction, ReceiveTypes, ResetAction, ResolveType, Schema, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@rest-hooks/core';
 import React$1, { Context } from 'react';
+import * as react_jsx_runtime from 'react/jsx-runtime';
 
 declare const _default$1: React$1.NamedExoticComponent<{
     children: React$1.ReactNode;
@@ -18,7 +19,7 @@ interface ProviderProps {
  * Manages state, providing all context needed to use the hooks.
  * @see https://resthooks.io/docs/api/CacheProvider
  */
-declare function CacheProvider({ children, managers, initialState, Controller, }: ProviderProps): JSX.Element;
+declare function CacheProvider({ children, managers, initialState, Controller, }: ProviderProps): react_jsx_runtime.JSX.Element;
 declare namespace CacheProvider {
     var defaultProps: {
         managers: Manager<_rest_hooks_core.CombinedActionTypes>[];
@@ -38,7 +39,7 @@ declare function AsyncBoundary({ children, errorComponent, fallback, }: {
     errorComponent?: React$1.ComponentType<{
         error: NetworkError;
     }>;
-}): JSX.Element;
+}): react_jsx_runtime.JSX.Element;
 declare const _default: React$1.MemoExoticComponent<typeof AsyncBoundary>;
 //# sourceMappingURL=AsyncBoundary.d.ts.map
 
@@ -59,7 +60,7 @@ declare class NetworkErrorBoundary<E extends NetworkError> extends React$1.Compo
     static defaultProps: {
         fallbackComponent: ({ error }: {
             error: NetworkError;
-        }) => JSX.Element;
+        }) => react_jsx_runtime.JSX.Element;
     };
     static getDerivedStateFromError(error: NetworkError | any): {
         error: NetworkError;

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -590,7 +590,7 @@ declare class CollectionInterface<
   readonly cacheWith: object;
 
   readonly schema: S;
-  key: string;
+  readonly key: string;
   pk(value: any, parent: any, key: string, args: any[]): string;
   normalize(
     input: any,

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
@@ -220,7 +220,7 @@ declare class CollectionInterface<
   readonly cacheWith: object;
 
   readonly schema: S;
-  key: string;
+  readonly key: string;
   pk(value: any, parent: any, key: string, args: any[]): string;
   normalize(
     input: any,

--- a/website/src/components/Playground/editor-types/react.d.ts
+++ b/website/src/components/Playground/editor-types/react.d.ts
@@ -238,7 +238,23 @@ declare namespace React {
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = Iterable<ReactNode>;
-    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
+
+    /**
+     * For internal usage only.
+     * Different release channels declare additional types of ReactNode this particular release channel accepts.
+     * App or library types should never augment this interface.
+     */
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {}
+    type ReactNode =
+        | ReactElement
+        | string
+        | number
+        | ReactFragment
+        | ReactPortal
+        | boolean
+        | null
+        | undefined
+        | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES];
 
     //
     // Top Level API
@@ -1381,6 +1397,9 @@ declare namespace React {
 
     interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {
     }
+
+    interface SVGLineElementAttributes<T> extends SVGProps<T> {}
+    interface SVGTextElementAttributes<T> extends SVGProps<T> {}
 
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
@@ -3099,6 +3118,19 @@ declare namespace React {
          */
         componentStack: string;
     }
+
+    namespace JSX {
+        interface Element extends GlobalJSXElement {}
+        interface ElementClass extends GlobalJSXElementClass {}
+        interface ElementAttributesProperty extends GlobalJSXElementAttributesProperty {}
+        interface ElementChildrenAttribute extends GlobalJSXElementChildrenAttribute {}
+
+        type LibraryManagedAttributes<C, P> = GlobalJSXLibraryManagedAttributes<C, P>;
+
+        interface IntrinsicAttributes extends GlobalJSXIntrinsicAttributes {}
+        interface IntrinsicClassAttributes<T> extends GlobalJSXIntrinsicClassAttributes<T> {}
+        interface IntrinsicElements extends GlobalJSXIntrinsicElements {}
+    }
 }
 
 // naked 'any' type in a conditional type will short circuit and union both the then/else branches
@@ -3146,6 +3178,9 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
             : P;
 
 declare global {
+    /**
+     * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
+     */
     namespace JSX {
         interface Element extends React.ReactElement<any, any> { }
         interface ElementClass extends React.Component<any> {
@@ -3326,7 +3361,7 @@ declare global {
             foreignObject: React.SVGProps<SVGForeignObjectElement>;
             g: React.SVGProps<SVGGElement>;
             image: React.SVGProps<SVGImageElement>;
-            line: React.SVGProps<SVGLineElement>;
+            line: React.SVGLineElementAttributes<SVGLineElement>;
             linearGradient: React.SVGProps<SVGLinearGradientElement>;
             marker: React.SVGProps<SVGMarkerElement>;
             mask: React.SVGProps<SVGMaskElement>;
@@ -3341,7 +3376,7 @@ declare global {
             stop: React.SVGProps<SVGStopElement>;
             switch: React.SVGProps<SVGSwitchElement>;
             symbol: React.SVGProps<SVGSymbolElement>;
-            text: React.SVGProps<SVGTextElement>;
+            text: React.SVGTextElementAttributes<SVGTextElement>;
             textPath: React.SVGProps<SVGTextPathElement>;
             tspan: React.SVGProps<SVGTSpanElement>;
             use: React.SVGProps<SVGUseElement>;
@@ -3349,3 +3384,18 @@ declare global {
         }
     }
 }
+
+// React.JSX needs to point to global.JSX to keep global module augmentations intact.
+// But we can't access global.JSX so we need to create these aliases instead.
+// Once the global JSX namespace will be removed we replace React.JSX with the contents of global.JSX
+interface GlobalJSXElement extends JSX.Element {}
+interface GlobalJSXElementClass extends JSX.ElementClass {}
+interface GlobalJSXElementAttributesProperty extends JSX.ElementAttributesProperty {}
+interface GlobalJSXElementChildrenAttribute extends JSX.ElementChildrenAttribute {}
+
+type GlobalJSXLibraryManagedAttributes<C, P> = JSX.LibraryManagedAttributes<C, P>;
+
+interface GlobalJSXIntrinsicAttributes extends JSX.IntrinsicAttributes {}
+interface GlobalJSXIntrinsicClassAttributes<T> extends JSX.IntrinsicClassAttributes<T> {}
+
+interface GlobalJSXIntrinsicElements extends JSX.IntrinsicElements {}

--- a/website/src/components/Playground/editor-types/rest-hooks.d.ts
+++ b/website/src/components/Playground/editor-types/rest-hooks.d.ts
@@ -2,6 +2,7 @@ import * as _rest_hooks_core from '@rest-hooks/core';
 import { Manager, State as State$1, Controller, NetworkError as NetworkError$1, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, DenormalizeNullable as DenormalizeNullable$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, ErrorTypes as ErrorTypes$2, ActionTypes, DenormalizeCache, legacyActions, __INTERNAL__, EndpointExtraOptions as EndpointExtraOptions$1, createReducer as createReducer$1, applyManager as applyManager$1, ExpiryStatus, UnknownError as UnknownError$1 } from '@rest-hooks/core';
 export { AbstractInstanceType, ActionTypes, CompatibleDispatch, Controller, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ReceiveAction, ReceiveTypes, ResetAction, ResolveType, Schema, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@rest-hooks/core';
 import React$1, { Context } from 'react';
+import * as react_jsx_runtime from 'react/jsx-runtime';
 
 type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
@@ -361,7 +362,7 @@ interface ProviderProps {
  * Manages state, providing all context needed to use the hooks.
  * @see https://resthooks.io/docs/api/CacheProvider
  */
-declare function CacheProvider({ children, managers, initialState, Controller, }: ProviderProps): JSX.Element;
+declare function CacheProvider({ children, managers, initialState, Controller, }: ProviderProps): react_jsx_runtime.JSX.Element;
 declare namespace CacheProvider {
     var defaultProps: {
         managers: Manager<_rest_hooks_core.CombinedActionTypes>[];
@@ -381,7 +382,7 @@ declare function AsyncBoundary({ children, errorComponent, fallback, }: {
     errorComponent?: React$1.ComponentType<{
         error: NetworkError$1;
     }>;
-}): JSX.Element;
+}): react_jsx_runtime.JSX.Element;
 declare const _default: React$1.MemoExoticComponent<typeof AsyncBoundary>;
 //# sourceMappingURL=AsyncBoundary.d.ts.map
 
@@ -402,7 +403,7 @@ declare class NetworkErrorBoundary<E extends NetworkError$1> extends React$1.Com
     static defaultProps: {
         fallbackComponent: ({ error }: {
             error: NetworkError$1;
-        }) => JSX.Element;
+        }) => react_jsx_runtime.JSX.Element;
     };
     static getDerivedStateFromError(error: NetworkError$1 | any): {
         error: NetworkError$1;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`.key` is called a lot, so this is a slight optimization

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Set key in constructor since `schema` is readonly