### PR TITLE
feat: Add per-endpoint customization to createResource()

### DIFF
--- a/.changeset/cuddly-eels-sniff.md
+++ b/.changeset/cuddly-eels-sniff.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/rest': minor
+---
+
+Add resource endpoint customization options:
+  - each default endpoint can be customized using its name ('update' for 'update')
+  - additional endpoints can use the 'endpoints' option

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -5,6 +5,7 @@ import {
   ResourceGenerics,
   ResourceOptions,
   Resource,
+  ExtendedResource,
 } from '@rest-hooks/rest/next';
 
 export abstract class PlaceholderEntity extends Entity {
@@ -19,39 +20,34 @@ export abstract class PlaceholderEntity extends Entity {
 /** Common patterns in the https://jsonplaceholder.typicode.com API */
 export function createPlaceholderResource<O extends ResourceGenerics = any>(
   options: Readonly<O> & ResourceOptions,
-): Resource<O> {
-  const base = createResource({
+) {
+  // Endpoint overrides are to compensate for the jsonplaceholder API not returning
+  // the correct ID in certain cases
+  //
+  // This is sometimes needed when you don't control the server API itself
+  // More here: https://resthooks.io/docs/guides/network-transform#case-of-the-missing-id
+  return createResource({
     ...options,
     urlPrefix: 'https://jsonplaceholder.typicode.com',
     // hour expiry time since we want to keep our example mutations and the api itself never actually changes
     dataExpiryLength: 1000 * 60 * 60,
-  });
-  const partialUpdate = base.partialUpdate.extend({
-    fetch: async function (...args: any) {
-      // body only contains what we're changing, but we can find the id in params
-      return {
-        ...(await base.partialUpdate.call(this, ...args)),
-        id: args?.[0]?.id,
-      } as any;
+    partialUpdate: {
+      fetch: async function (...args: any): Promise<any> {
+        // body only contains what we're changing, but we can find the id in params
+        return {
+          ...(await base.partialUpdate.call(this, ...args)),
+          id: args?.[0]?.id,
+        } as any;
+      },
     },
-  });
-  return {
-    ...base,
-    // Endpoint overrides are to compensate for the jsonplaceholder API not returning
-    // the correct ID in certain cases
-    //
-    // This is sometimes needed when you don't control the server API itself
-    // More here: https://resthooks.io/docs/guides/network-transform#case-of-the-missing-id
-    partialUpdate,
-    create: base.create.extend({
-      fetch: async function (...args: any) {
+    create: {
+      fetch: async function (...args: any): Promise<any> {
         // body only contains what we're changing, but we can find the id in params
         return {
           ...(await base.create.call(this, ...args)),
           id: args?.[args.length - 1]?.id,
         } as any;
       },
-    }),
-    // generics don't match up well
-  } as any;
+    },
+  });
 }

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -46,6 +46,7 @@ export type {
   NetworkError,
   UnknownError,
   ErrorTypes,
+  EndpointToFunction,
 } from './types.js';
 
 export { default as Endpoint, ExtendableEndpoint } from './endpoint.js';

--- a/packages/endpoint/src/utility.ts
+++ b/packages/endpoint/src/utility.ts
@@ -25,3 +25,8 @@ export type PartialParameters<T extends (...args: any[]) => any> = T extends (
 ) => any
   ? Partial<P>
   : never;
+
+export type EndpointToFunction<E extends (...args: any) => Promise<any>> = (
+  this: E,
+  ...args: Parameters<E>
+) => ReturnType<E>;

--- a/packages/rest/.gitignore
+++ b/packages/rest/.gitignore
@@ -4,3 +4,4 @@
 /index.d.ts
 /next.d.ts
 /ts4.1
+/ts4.9

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -9,7 +9,7 @@
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
   "typesVersions": {
-    ">=4.1": {
+    ">=5.0": {
       "": [
         "lib/index.d.ts"
       ],
@@ -18,6 +18,17 @@
       ],
       "*": [
         "lib/index.d.ts"
+      ]
+    },
+    ">=4.1": {
+      "": [
+        "ts4.9/index.d.ts"
+      ],
+      "next": [
+        "ts4.9/next/index.d.ts"
+      ],
+      "*": [
+        "ts4.9/index.d.ts"
       ]
     },
     ">=4.0": {
@@ -57,6 +68,7 @@
     "node.mjs",
     "legacy",
     "ts4.0",
+    "ts4.9",
     "LICENSE",
     "README.md"
   ],
@@ -67,7 +79,7 @@
     "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
     "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
     "build:clean": "yarn g:clean ts4.0 index.d.ts next.d.ts",
-    "build:legacy-types": "yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0",
+    "build:legacy-types": "yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:downtypes lib ts4.9 --to=4.9 && yarn g:copy --up 1 ./src-4.9-types/**/*.d.ts ./ts4.9 && yarn g:copy --up 1 ./src-4.9-types/**/*.d.ts ./ts4.0 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0",
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",

--- a/packages/rest/src-4.9-types/next/createResource.d.ts
+++ b/packages/rest/src-4.9-types/next/createResource.d.ts
@@ -1,0 +1,44 @@
+import type {
+  Resource,
+  ResourceEndpointExtensions,
+  ResourceGenerics,
+  ResourceOptions,
+  ExtendedResource,
+} from './resourceTypes.js';
+import { PartialRestGenerics, RestEndpointOptions } from './RestEndpoint.js';
+/** Creates collection of Endpoints for common operations on a given data/schema.
+ *
+ * @see https://resthooks.io/rest/api/createResource
+ */
+export default function createResource<
+  O extends ResourceGenerics,
+  Get extends PartialRestGenerics = any,
+  GetList extends PartialRestGenerics = any,
+  Update extends PartialRestGenerics = any,
+  PartialUpdate extends PartialRestGenerics = any,
+  Create extends PartialRestGenerics = any,
+  Delete extends PartialRestGenerics = any,
+  E extends Record<string, PartialRestGenerics & RestEndpointOptions> = {},
+>(
+  options: Readonly<O> &
+    ResourceOptions &
+    ResourceEndpointExtensions<
+      Resource<O>,
+      Get,
+      GetList,
+      Update,
+      PartialUpdate,
+      Create,
+      Delete
+    >,
+): ExtendedResource<
+  Resource<O>,
+  Get,
+  GetList,
+  Update,
+  PartialUpdate,
+  Create,
+  Delete,
+  E
+>;
+//# sourceMappingURL=createResource.d.ts.map

--- a/packages/rest/src/next/OptionsToFunction.ts
+++ b/packages/rest/src/next/OptionsToFunction.ts
@@ -9,7 +9,7 @@ import { PathArgs } from '../pathTypes.js';
 
 export type OptionsToFunction<
   O extends PartialRestGenerics,
-  E extends RestInstanceBase & { body?: any },
+  E extends { body?: any; path?: string },
   F extends FetchFunction,
 > = 'path' extends keyof O
   ? RestFetch<

--- a/packages/rest/src/next/RestEndpoint.js
+++ b/packages/rest/src/next/RestEndpoint.js
@@ -233,6 +233,9 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({
       method: 'POST',
       schema: extractCollection(this.schema, s => s.push),
+      process(value) {
+        return value;
+      },
     });
   }
 
@@ -240,6 +243,9 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({
       method: 'POST',
       schema: extractCollection(this.schema, s => s.unshift),
+      process(value) {
+        return value;
+      },
     });
   }
 
@@ -247,6 +253,9 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({
       method: 'POST',
       schema: extractCollection(this.schema, s => s.assign),
+      process(value) {
+        return value;
+      },
     });
   }
 }

--- a/packages/rest/src/next/__tests__/createResource.test.ts
+++ b/packages/rest/src/next/__tests__/createResource.test.ts
@@ -1,0 +1,136 @@
+import { Entity, schema } from '@rest-hooks/endpoint';
+import {
+  CacheProvider,
+  useCache,
+  useController,
+  Controller,
+  useSuspense,
+} from '@rest-hooks/react';
+import { makeRenderRestHook } from '@rest-hooks/test';
+import { act } from '@testing-library/react-hooks';
+import nock from 'nock';
+
+import createResource from '../createResource';
+import RestEndpoint, { RestGenerics } from '../RestEndpoint';
+
+describe('createResource()', () => {
+  const renderRestHook: ReturnType<typeof makeRenderRestHook> =
+    makeRenderRestHook(CacheProvider);
+  let mynock: nock.Scope;
+
+  class User extends Entity {
+    readonly id: number | undefined = undefined;
+    readonly username: string = '';
+    readonly email: string = '';
+    readonly isAdmin: boolean = false;
+
+    pk() {
+      return this.id?.toString();
+    }
+  }
+
+  const UserResource = createResource({
+    path: 'http\\://test.com/groups/:group/users/:id',
+    schema: User,
+  });
+
+  const userPayload = {
+    id: 5,
+    username: 'ntucker',
+    email: 'bob@vila.com',
+    isAdmin: true,
+  };
+
+  beforeEach(() => {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      })
+      .get(`/groups/five/users/${userPayload.id}`)
+      .reply(200, userPayload)
+      .get(`/groups/five/users`)
+      .reply(200, [userPayload])
+      .options(/.*/)
+      .reply(200);
+    mynock = nock(/.*/).defaultReplyHeaders({
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('can override endpoint options', () => {
+    const UserResource = createResource({
+      path: 'http\\://test.com/groups/:group/users/:id',
+      schema: User,
+      getList: {
+        path: ':blob',
+        searchParams: {} as { isAdmin?: boolean },
+        getOptimisticResponse(snap, params) {
+          params.isAdmin;
+          params.blob;
+          // @ts-expect-error
+          params.nothere;
+          return [];
+        },
+        /*process(users: User[]) {
+            return users.slice(0, 7);
+          }, TODO: why doesn't this work?*/
+      },
+      partialUpdate: {
+        getOptimisticResponse(snap, params, body) {
+          params.id;
+          params.group;
+          // @ts-expect-error
+          params.nothere;
+          return {
+            id: params.id,
+            ...body,
+          };
+        },
+      },
+      delete: {
+        getOptimisticResponse(snap, params) {
+          return params;
+        },
+      },
+      create: {
+        process(users: any[]) {
+          return users.slice(0, 7);
+        },
+      },
+      endpoints: {
+        justget: {},
+        current: {
+          path: '/current',
+          searchParams: {} as { isAdmin?: boolean },
+        },
+        toggleAdmin: {
+          path: '/toggle/:id',
+          method: 'POST',
+        },
+      },
+    });
+    () => UserResource.getList({ blob: '5', isAdmin: true });
+    () => UserResource.get({ group: '1', id: '5' });
+    () => UserResource.create({ blob: '5' }, { username: 'bob' });
+    () =>
+      UserResource.create({ blob: '5', isAdmin: false }, { username: 'bob' });
+    // @ts-expect-error
+    () => UserResource.create({ group: 'bob' }, { username: 'bob' });
+    () => UserResource.get({ id: 'hi', group: 'group' });
+    () => UserResource.justget({ group: 'blob', id: '5' });
+    // @ts-expect-error
+    () => UserResource.justget({ id: '5' });
+    () => UserResource.current();
+    () => UserResource.current({ isAdmin: true });
+    () => UserResource.toggleAdmin({ id: '5' });
+    // @ts-expect-error
+    () => UserResource.justget({ id: '5' });
+  });
+});

--- a/packages/rest/src/next/index.ts
+++ b/packages/rest/src/next/index.ts
@@ -1,5 +1,8 @@
 export * from './RestEndpoint.js';
 export { default as RestEndpoint } from './RestEndpoint.js';
 export { default as createResource } from './createResource.js';
-export type { Resource } from './createResource.js';
-export type { ResourceOptions, ResourceGenerics } from './resourceTypes.js';
+export type {
+  Resource,
+  ResourceOptions,
+  ResourceGenerics,
+} from './resourceTypes.js';

--- a/packages/rest/src/next/index.ts
+++ b/packages/rest/src/next/index.ts
@@ -5,4 +5,5 @@ export type {
   Resource,
   ResourceOptions,
   ResourceGenerics,
+  ExtendedResource,
 } from './resourceTypes.js';

--- a/packages/rest/src/next/resourceTypes.ts
+++ b/packages/rest/src/next/resourceTypes.ts
@@ -3,6 +3,7 @@ import type {
   schema,
   Denormalize,
   FetchFunction,
+  EndpointToFunction,
 } from '@rest-hooks/endpoint';
 
 import { OptionsToFunction } from './OptionsToFunction.js';
@@ -57,63 +58,51 @@ export interface ResourceEndpointExtensions<
 > {
   readonly get?: RestEndpointOptions<
     unknown extends Get
-      ? R['get']
-      : OptionsToFunction<Get, R['get'], Extract<R['get'], FetchFunction>>,
+      ? EndpointToFunction<R['get']>
+      : OptionsToFunction<Get, R['get'], EndpointToFunction<R['get']>>,
     R['get']['schema']
   > &
     Readonly<Get>;
   readonly getList?: RestEndpointOptions<
     unknown extends GetList
-      ? R['getList']
+      ? EndpointToFunction<R['getList']>
       : OptionsToFunction<
           GetList,
           R['getList'],
-          Extract<R['getList'], FetchFunction>
+          EndpointToFunction<R['getList']>
         >,
     R['getList']['schema']
   > &
     Readonly<GetList>;
   readonly update?: RestEndpointOptions<
     unknown extends Update
-      ? R['update']
-      : OptionsToFunction<
-          Update,
-          R['update'],
-          Extract<R['update'], FetchFunction>
-        >,
+      ? EndpointToFunction<R['update']>
+      : OptionsToFunction<Update, R['update'], EndpointToFunction<R['update']>>,
     R['update']['schema']
   > &
     Readonly<Update>;
   readonly partialUpdate?: RestEndpointOptions<
     unknown extends PartialUpdate
-      ? R['partialUpdate']
+      ? EndpointToFunction<R['partialUpdate']>
       : OptionsToFunction<
           PartialUpdate,
           R['partialUpdate'],
-          Extract<R['partialUpdate'], FetchFunction>
+          EndpointToFunction<R['partialUpdate']>
         >,
     R['partialUpdate']['schema']
   > &
     Readonly<PartialUpdate>;
   readonly create?: RestEndpointOptions<
     unknown extends Create
-      ? R['create']
-      : OptionsToFunction<
-          Create,
-          R['create'],
-          Extract<R['create'], FetchFunction>
-        >,
+      ? EndpointToFunction<R['create']>
+      : OptionsToFunction<Create, R['create'], EndpointToFunction<R['create']>>,
     R['create']['schema']
   > &
     Readonly<Create>;
   readonly delete?: RestEndpointOptions<
     unknown extends Delete
-      ? R['delete']
-      : OptionsToFunction<
-          Delete,
-          R['delete'],
-          Extract<R['delete'], FetchFunction>
-        >,
+      ? EndpointToFunction<R['delete']>
+      : OptionsToFunction<Delete, R['delete'], EndpointToFunction<R['delete']>>,
     R['delete']['schema']
   > &
     Readonly<Delete>;

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest/next.d.ts
@@ -104,172 +104,10 @@ declare class Invalidate<E extends EntityInterface & {
 }
 
 /**
- * Marks entity as deleted.
- * @see https://resthooks.io/rest/api/Delete
- */
-declare class Delete<E extends EntityInterface & {
-    process: any;
-}> extends Invalidate<E> implements SchemaClass$1 {
-    denormalize(id: string, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<E>, found: boolean, suspend: boolean];
-}
-
-type Constructor = abstract new (...args: any[]) => {};
-type IDClass = abstract new (...args: any[]) => {
-    id: string | number | undefined;
-};
-type PKClass = abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
-};
-type ValidSchemas<TInstance> = {
-    [k in keyof TInstance]?: Schema;
-};
-type EntityOptions<TInstance extends {}> = {
-    readonly schema?: ValidSchemas<TInstance>;
-    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
-    readonly key?: string;
-} & {
-    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
-};
-interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
-    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
-}
-interface IEntityClass<TBase extends Constructor = any> {
-    toJSON(): {
-        name: string;
-        schema: {
-            [k: string]: Schema;
-        };
-        key: string;
-    };
-    /** Defines nested entities
-     *
-     * @see https://resthooks.io/rest/api/Entity#schema
-     */
-    schema: {
-        [k: string]: Schema;
-    };
-    /** Returns the globally unique identifier for the static Entity
-     *
-     * @see https://resthooks.io/docs/api/Entity#key
-     */
-    key: string;
-    /** Defines indexes to enable lookup by
-     *
-     * @see https://resthooks.io/rest/api/Entity#indexes
-     */
-    indexes?: readonly string[] | undefined;
-    /**
-     * A unique identifier for each Entity
-     *
-     * @see https://resthooks.io/docs/api/Entity#pk
-     * @param [value] POJO of the entity or subset used
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     */
-    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | undefined;
-    /** Return true to merge incoming data; false keeps existing entity
-     *
-     * @see https://resthooks.io/docs/api/schema.Entity#useIncoming
-     */
-    useIncoming(existingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, incomingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): boolean;
-    /** Determines the order of incoming entity vs entity already in store\
-     *
-     * @see https://resthooks.io/docs/api/schema.Entity#shouldReorder
-     * @returns true if incoming entity should be first argument of merge()
-     */
-    shouldReorder(existingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, incomingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): boolean;
-    /** Creates new instance copying over defined values of arguments
-     *
-     * @see https://resthooks.io/docs/api/schema.Entity#merge
-     */
-    merge(existing: any, incoming: any): any;
-    /** Run when an existing entity is found in the store
-     *
-     * @see https://resthooks.io/docs/api/schema.Entity#mergeWithStore
-     */
-    mergeWithStore(existingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, incomingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): any;
-    /** Run when an existing entity is found in the store
-     *
-     * @see https://resthooks.io/docs/api/schema.Entity#mergeMetaWithStore
-     */
-    mergeMetaWithStore(existingMeta: {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    }, incomingMeta: {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    };
-    /** Factory method to convert from Plain JS Objects.
-     *
-     * @param [props] Plain Object of properties to assign.
-     */
-    fromJS<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, props?: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T>;
-    /** Called when denormalizing an entity to create an instance when 'valid'
-     *
-     * @param [props] Plain Object of properties to assign.
-     * @see https://resthooks.io/docs/api/Entity#createIfValid
-     */
-    createIfValid<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, props: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T> | undefined;
-    /** Do any transformations when first receiving input
-     *
-     * @see https://resthooks.io/docs/api/Entity#process
-     */
-    process(input: any, parent: any, key: string | undefined): any;
-    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>): any;
-    /** Do any transformations when first receiving input
-     *
-     * @see https://resthooks.io/docs/api/Entity#validate
-     */
-    validate(processedEntity: any): string | undefined;
-    /** Attempts to infer results
-     *
-     * @see https://resthooks.io/docs/api/Entity#infer
-     */
-    infer(args: readonly any[], indexes: NormalizedIndex, recurse: any): any;
-    denormalize<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
-    denormalizeOnly<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, input: any, unvisit: (input: any, schema: any) => any): AbstractInstanceType<T>;
-    /** All instance defaults set */
-    readonly defaults: any;
-}
-interface IEntityInstance {
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     */
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
-}
-
-/**
  * Represents arrays
  * @see https://resthooks.io/rest/api/Array
  */
-declare class Array$1<S extends Schema = Schema> implements SchemaClass$1 {
+declare class Array$1<S extends Schema = Schema> implements SchemaClass {
   constructor(
     definition: S,
     schemaAttribute?: S extends EntityMap<infer T>
@@ -321,70 +159,6 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass$1 {
     args: readonly any[],
     indexes: NormalizedIndex,
     recurse: (...args: any) => any,
-  ): any;
-}
-
-/**
- * Retrieves all entities in cache
- *
- * @see https://resthooks.io/rest/api/AllSchema
- */
-declare class All<
-  S extends EntityMap | EntityInterface = EntityMap | EntityInterface,
-> implements SchemaClass$1
-{
-  constructor(
-    definition: S,
-    schemaAttribute?: S extends EntityMap<infer T>
-      ? keyof T | SchemaFunction<keyof S>
-      : undefined,
-  );
-
-  define(definition: Schema): void;
-  readonly isSingleSchema: S extends EntityMap ? false : true;
-  readonly schema: S;
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: (...args: any) => any,
-    addEntity: (...args: any) => any,
-    visitedEntities: Record<string, any>,
-    storeEntities: any,
-    args?: any[],
-  ): (S extends EntityMap ? UnionResult<S> : Normalize<S>)[];
-
-  _normalizeNullable():
-    | (S extends EntityMap ? UnionResult<S> : Normalize<S>)[]
-    | undefined;
-
-  denormalize(
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {},
-    unvisit: UnvisitFunction,
-  ): [
-    denormalized: (S extends EntityMap<infer T> ? T : Denormalize<S>)[],
-    found: boolean,
-    suspend: boolean,
-  ];
-
-  _denormalizeNullable(): [
-    (S extends EntityMap<infer T> ? T : Denormalize<S>)[] | undefined,
-    false,
-    boolean,
-  ];
-
-  denormalizeOnly(
-    input: {},
-    args: readonly any[],
-    unvisit: (input: any, schema: any) => any,
-  ): (S extends EntityMap<infer T> ? T : Denormalize<S>)[];
-
-  infer(
-    args: readonly any[],
-    indexes: NormalizedIndex,
-    recurse: (...args: any) => any,
-    entities: EntityTable,
   ): any;
 }
 
@@ -393,7 +167,7 @@ declare class All<
  * @see https://resthooks.io/rest/api/Object
  */
 declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
-  implements SchemaClass$1
+  implements SchemaClass
 {
   constructor(definition: O);
   define(definition: Schema): void;
@@ -424,150 +198,6 @@ declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
     args: readonly any[],
     unvisit: (input: any, schema: any) => any,
   ): DenormalizeObject<O>;
-
-  infer(
-    args: readonly any[],
-    indexes: NormalizedIndex,
-    recurse: (...args: any) => any,
-  ): any;
-}
-
-/**
- * Represents polymorphic values.
- * @see https://resthooks.io/rest/api/Union
- */
-declare class Union<Choices extends EntityMap = any> implements SchemaClass$1 {
-  constructor(
-    definition: Choices,
-    schemaAttribute:
-      | keyof AbstractInstanceType<Choices[keyof Choices]>
-      | SchemaFunction<keyof Choices>,
-  );
-
-  define(definition: Schema): void;
-  inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
-  getSchemaAttribute: SchemaFunction<keyof Choices>;
-  readonly schema: Choices;
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: (...args: any) => any,
-    addEntity: (...args: any) => any,
-    visitedEntities: Record<string, any>,
-    storeEntities: any,
-    args?: any[],
-  ): UnionResult<Choices>;
-
-  _normalizeNullable(): UnionResult<Choices> | undefined;
-
-  denormalize(
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {},
-    unvisit: UnvisitFunction,
-  ): [
-    denormalized: AbstractInstanceType<Choices[keyof Choices]>,
-    found: boolean,
-    suspend: boolean,
-  ];
-
-  _denormalizeNullable(): [
-    AbstractInstanceType<Choices[keyof Choices]> | undefined,
-    false,
-    boolean,
-  ];
-
-  denormalizeOnly(
-    input: {},
-    args: readonly any[],
-    unvisit: (input: any, schema: any) => any,
-  ): AbstractInstanceType<Choices[keyof Choices]>;
-
-  infer(
-    args: readonly any[],
-    indexes: NormalizedIndex,
-    recurse: (...args: any) => any,
-  ): any;
-}
-
-/**
- * Represents variably sized objects
- * @see https://resthooks.io/rest/api/Values
- */
-declare class Values<Choices extends Schema = any> implements SchemaClass$1 {
-  constructor(
-    definition: Choices,
-    schemaAttribute?: Choices extends EntityMap<infer T>
-      ? keyof T | SchemaFunction<keyof Choices>
-      : undefined,
-  );
-
-  define(definition: Schema): void;
-  readonly isSingleSchema: Choices extends EntityMap ? false : true;
-  inferSchema: SchemaAttributeFunction<
-    Choices extends EntityMap ? Choices[keyof Choices] : Choices
-  >;
-
-  getSchemaAttribute: Choices extends EntityMap
-    ? SchemaFunction<keyof Choices>
-    : false;
-
-  readonly schema: Choices;
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: (...args: any) => any,
-    addEntity: (...args: any) => any,
-    visitedEntities: Record<string, any>,
-    storeEntities: any,
-    args?: any[],
-  ): Record<
-    string,
-    Choices extends EntityMap ? UnionResult<Choices> : Normalize<Choices>
-  >;
-
-  _normalizeNullable():
-    | Record<
-        string,
-        Choices extends EntityMap
-          ? UnionResult<Choices>
-          : NormalizeNullable<Choices>
-      >
-    | undefined;
-
-  denormalize(
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {},
-    unvisit: UnvisitFunction,
-  ): [
-    denormalized: Record<
-      string,
-      Choices extends EntityMap<infer T> ? T : Denormalize<Choices>
-    >,
-    found: boolean,
-    suspend: boolean,
-  ];
-
-  _denormalizeNullable(): [
-    Record<
-      string,
-      Choices extends EntityMap<infer T>
-        ? T | undefined
-        : DenormalizeNullable<Choices>
-    >,
-    false,
-    boolean,
-  ];
-
-  denormalizeOnly(
-    input: {},
-    args: readonly any[],
-    unvisit: (input: any, schema: any) => any,
-  ): Record<
-    string,
-    Choices extends EntityMap<infer T> ? T : Denormalize<Choices>
-  >;
 
   infer(
     args: readonly any[],
@@ -712,25 +342,16 @@ declare class Collection<
     body?: Record<string, any>,
   ],
 > extends CollectionRoot<S, Parent> {}
-
-type StrategyFunction<T> = (value: any, parent: any, key: string) => T;
 type SchemaFunction<K = string> = (
   value: any,
   parent: any,
   key: string,
 ) => K;
-type MergeFunction = (entityA: any, entityB: any) => any;
-type SchemaAttributeFunction<S extends Schema> = (
-  value: any,
-  parent: any,
-  key: string,
-) => S;
-
 type UnionResult<Choices extends EntityMap> = {
   id: string;
   schema: keyof Choices;
 };
-interface SchemaClass$1<T = any, N = T | undefined>
+interface SchemaClass<T = any, N = T | undefined>
   extends SchemaSimple<T> {
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
   _normalizeNullable(): any;
@@ -738,91 +359,7 @@ interface SchemaClass$1<T = any, N = T | undefined>
   _denormalizeNullable(): [N, boolean, boolean];
 }
 
-// id is in Instance, so we default to that as pk
-/**
- * Represents data that should be deduped by specifying a primary key.
- * @see https://resthooks.io/docs/api/schema.Entity
- */
-declare function Entity$1<TBase extends PKClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase;
-
-// id is in Instance, so we default to that as pk
-declare function Entity$1<TBase extends IDClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-// pk was specified in options, so we don't need to redefine
-declare function Entity$1<TBase extends Constructor>(
-  Base: TBase,
-  opt: RequiredPKOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-type schema_d_Delete<E extends EntityInterface & {
-    process: any;
-}> = Delete<E>;
-declare const schema_d_Delete: typeof Delete;
-type schema_d_EntityMap<T = any> = EntityMap<T>;
-type schema_d_Invalidate<E extends EntityInterface & {
-    process: any;
-}> = Invalidate<E>;
-declare const schema_d_Invalidate: typeof Invalidate;
-type schema_d_UnvisitFunction = UnvisitFunction;
-type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
-declare const schema_d_All: typeof All;
-type schema_d_Union<Choices extends EntityMap = any> = Union<Choices>;
-declare const schema_d_Union: typeof Union;
-type schema_d_Values<Choices extends Schema = any> = Values<Choices>;
-declare const schema_d_Values: typeof Values;
-type schema_d_CollectionInterface<S extends PolymorphicInterface = any, Parent extends any[] = any> = CollectionInterface<S, Parent>;
-declare const schema_d_CollectionInterface: typeof CollectionInterface;
-type schema_d_CollectionFromSchema<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
-    urlParams: Record<string, any>,
-    body?: Record<string, any>,
-  ]> = CollectionFromSchema<S, Parent>;
-type schema_d_CollectionConstructor = CollectionConstructor;
-declare const schema_d_CollectionRoot: typeof CollectionRoot;
-type schema_d_Collection<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
-    urlParams: Record<string, any>,
-    body?: Record<string, any>,
-  ]> = Collection<S, Parent>;
-declare const schema_d_Collection: typeof Collection;
-type schema_d_StrategyFunction<T> = StrategyFunction<T>;
-type schema_d_SchemaFunction<K = string> = SchemaFunction<K>;
-type schema_d_MergeFunction = MergeFunction;
-type schema_d_SchemaAttributeFunction<S extends Schema> = SchemaAttributeFunction<S>;
-type schema_d_UnionResult<Choices extends EntityMap> = UnionResult<Choices>;
-type schema_d_EntityInterface<T = any> = EntityInterface<T>;
-declare namespace schema_d {
-  export {
-    schema_d_Delete as Delete,
-    schema_d_EntityMap as EntityMap,
-    schema_d_Invalidate as Invalidate,
-    schema_d_UnvisitFunction as UnvisitFunction,
-    Array$1 as Array,
-    schema_d_All as All,
-    Object$1 as Object,
-    schema_d_Union as Union,
-    schema_d_Values as Values,
-    schema_d_CollectionInterface as CollectionInterface,
-    schema_d_CollectionFromSchema as CollectionFromSchema,
-    schema_d_CollectionConstructor as CollectionConstructor,
-    schema_d_CollectionRoot as CollectionRoot,
-    schema_d_Collection as Collection,
-    schema_d_StrategyFunction as StrategyFunction,
-    schema_d_SchemaFunction as SchemaFunction,
-    schema_d_MergeFunction as MergeFunction,
-    schema_d_SchemaAttributeFunction as SchemaAttributeFunction,
-    schema_d_UnionResult as UnionResult,
-    SchemaClass$1 as SchemaClass,
-    Entity$1 as Entity,
-    schema_d_EntityInterface as EntityInterface,
-  };
-}
-
-interface NetworkError$1 extends Error {
+interface NetworkError extends Error {
     status: number;
     response?: Response;
 }
@@ -830,7 +367,7 @@ interface UnknownError extends Error {
     status?: unknown;
     response?: unknown;
 }
-type ErrorTypes = NetworkError$1 | UnknownError;
+type ErrorTypes = NetworkError | UnknownError;
 
 interface SnapshotInterface {
     getResponse: <E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>]>(endpoint: E, ...args: Args) => {
@@ -843,23 +380,11 @@ interface SnapshotInterface {
 }
 type ExpiryStatusInterface = 1 | 2 | 3;
 
-/** Get the Params type for a given Shape */
-type EndpointParam<E> = E extends (first: infer A, ...rest: any) => any ? A : E extends {
-    key: (first: infer A, ...rest: any) => any;
-} ? A : never;
 /** What the function's promise resolves to */
 type ResolveType<E extends (...args: any) => any> = ReturnType<E> extends Promise<infer R> ? R : never;
 type PartialParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? Partial<P> : never;
 
 type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Promise<R>;
-/** @deprecated */
-type SchemaDetail<T> = EntityInterface<T> | {
-    [K: string]: any;
-} | SchemaClass$1;
-/** @deprecated */
-type SchemaList<T> = EntityInterface<T>[] | {
-    [K: string]: any;
-} | Schema[] | SchemaClass$1;
 interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
     /** Default data expiry length, will fall back to NetworkManager default if not defined */
     readonly dataExpiryLength?: number;
@@ -901,10 +426,6 @@ interface SchemaSimpleNew<T = any> {
     normalize(input: any, parent: any, key: any, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: any, args?: any[]): any;
     denormalizeOnly(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): T;
     infer(args: readonly any[], indexes: NormalizedIndex, recurse: (...args: any) => any, entities: EntityTable): any;
-}
-interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
-    _normalizeNullable(): any;
-    _denormalizeNullable(): [N, boolean, boolean];
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid?(props: any): any;
@@ -949,8 +470,6 @@ interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends S
     readonly sideEffect?: M;
     readonly schema?: S;
 }
-/** For retrieval requests */
-type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined>;
 
 /* eslint-disable @typescript-eslint/ban-types */
 
@@ -1116,26 +635,6 @@ interface EndpointConstructor {
   ): EndpointInstance<F, S, M> & E;
   readonly prototype: Function;
 }
-declare let Endpoint: EndpointConstructor;
-
-
-interface ExtendableEndpointConstructor {
-  new <
-    F extends (
-      this: EndpointInstanceInterface<FetchFunction> & E,
-      params?: any,
-      body?: any,
-    ) => Promise<any>,
-    S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
-    E extends Record<string, any> = {},
-  >(
-    RestFetch: F,
-    options?: Readonly<EndpointOptions<F, S, M>> & E,
-  ): EndpointInstanceInterface<F, S, M> & E;
-  readonly prototype: Function;
-}
-declare let ExtendableEndpoint: ExtendableEndpointConstructor;
 
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 type IfTypeScriptLooseNull$1<Y, N> = 1 | undefined extends 1 ? Y : N;
@@ -1151,138 +650,6 @@ type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [
     : never
   : Orig;
 
-declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
-}> & (abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
-});
-/**
- * Represents data that should be deduped by specifying a primary key.
- * @see https://resthooks.io/docs/api/Entity
- */
-declare abstract class Entity extends Entity_base {
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
-    /** Control how automatic schema validation is handled
-     *
-     * `undefined`: Defaults - throw error in worst offense
-     * 'warn': only ever warn
-     * 'silent': Don't bother with processing at all
-     *
-     * Note: this only applies to non-nested members.
-     */
-    protected static automaticValidation?: 'warn' | 'silent';
-    /** Return true to merge incoming data; false keeps existing entity
-     *
-     * @see https://resthooks.io/docs/api/schema.Entity#useIncoming
-     */
-    static useIncoming(existingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, incomingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): boolean;
-    /** Run when an existing entity is found in the store */
-    static mergeWithStore(existingMeta: {
-        date: number;
-        fetchedAt: number;
-    } | undefined, incomingMeta: {
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): any;
-    static mergeMetaWithStore(existingMeta: {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    }, incomingMeta: {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    }, existing: any, incoming: any): {
-        expiresAt: number;
-        date: number;
-        fetchedAt: number;
-    };
-    /** Factory method to convert from Plain JS Objects.
-     *
-     * @param [props] Plain Object of properties to assign.
-     */
-    static fromJS: <T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>) => AbstractInstanceType<T>;
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [value] POJO of the entity or subset used
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     */
-    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | undefined;
-    /** Do any transformations when first receiving input */
-    static process(input: any, parent: any, key: string | undefined): any;
-    static validate(processedEntity: any): string | undefined;
-    static denormalize<T extends typeof Entity>(this: T, input: any, unvisit: UnvisitFunction): [denormalized: AbstractInstanceType<T>, found: boolean, suspend: boolean];
-    /** Used by denormalize to set nested members */
-    protected static set?(entity: any, key: string, value: any): void;
-}
-
-declare function validateRequired(processedEntity: any, requiredDefaults: Record<string, unknown>): string | undefined;
-
-declare const DELETED: unique symbol;
-declare const INVALID: symbol;
-
-/**
- * Performant lookups by secondary indexes
- * @see https://resthooks.io/docs/api/Index
- */
-declare class Index<S extends Schema, P = Readonly<IndexParams<S>>> {
-    schema: S;
-    constructor(schema: S, key?: (params: P) => string);
-    key(params?: P): string;
-    /** The following is for compatibility with FetchShape */
-    getFetchKey: (params: P) => string;
-}
-type ArrayElement<ArrayType extends unknown[] | readonly unknown[]> = ArrayType[number];
-type IndexParams<S extends Schema> = S extends {
-    indexes: readonly string[];
-} ? {
-    [K in Extract<ArrayElement<S['indexes']>, keyof AbstractInstanceType<S>>]?: AbstractInstanceType<S>[K];
-} : Readonly<object>;
-
-/**
- * Programmatic cache reading
- * @see https://resthooks.io/rest/api/Query
- */
-declare class Query<S extends SchemaSimple, P extends any[] = [], R = Denormalize<S>> {
-    schema: QuerySchema<S, R>;
-    process: (entries: Denormalize<S>, ...args: P) => R;
-    readonly sideEffect: undefined;
-    constructor(schema: S, process?: (entries: Denormalize<S>, ...args: P) => R);
-    key(...args: P): string;
-    protected createQuerySchema(schema: SchemaSimple): any;
-}
-type QuerySchema<Schema, R> = Exclude<Schema, 'denormalize' | '_denormalizeNullable'> & {
-    denormalize(input: {}, unvisit: UnvisitFunction): [denormalized: R, found: boolean, suspend: boolean];
-    _denormalizeNullable(input: {}, unvisit: UnvisitFunction): [denormalized: R | undefined, found: boolean, suspend: boolean];
-    denormalizeOnly(input: {}, args: readonly any[], unvisit: (input: any, schema: any) => any): R;
-};
-
-declare class AbortOptimistic extends Error {
-}
-
-type ExtractCollection<S extends Schema | undefined> = S extends CollectionInterface ? S : S extends Object$1<infer T> ? ExtractObject<T> : S extends Exclude<Schema, {
-    [K: string]: any;
-}> ? never : S extends {
-    [K: string]: Schema;
-} ? ExtractObject<S> : never;
-type ExtractObject<S extends Record<string, any>> = {
-    [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
-}[keyof S];
-
 type OnlyOptional<S extends string> = S extends `${infer K}?` ? K : never;
 type OnlyRequired<S extends string> = S extends `${string}?` ? never : S;
 /** Computes the union of keys for a path string */
@@ -1295,16 +662,23 @@ type KeysToArgs<Key extends string> = {
 } & (OnlyRequired<Key> extends never ? unknown : {
     [K in Key as OnlyRequired<K>]: string | number;
 });
-type PathArgsAndSearch<S extends string> = OnlyRequired<PathKeys<S>> extends never ? Record<string, number | string | boolean> | undefined : {
-    [K in PathKeys<S> as OnlyRequired<K>]: string | number;
-} & Record<string, number | string>;
 /** Removes the last :token */
 type ShortenPath<S extends string> = string extends S ? string : S extends `${infer B}:${infer R}` ? TrimColon<`${B}:${ShortenPath<R>}`> : '';
 type TrimColon<S extends string> = string extends S ? string : S extends `${infer R}:` ? R : S;
 
-type OptionsToFunction<O extends PartialRestGenerics, E extends RestInstanceBase & {
+type OptionsToFunction<O extends PartialRestGenerics, E extends {
     body?: any;
+    path?: string;
 }, F extends FetchFunction> = 'path' extends keyof O ? RestFetch<'searchParams' extends keyof O ? O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, 'body' extends keyof O ? O['body'] : E['body'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : 'body' extends keyof O ? RestFetch<'searchParams' extends keyof O ? O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, O['body'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : 'searchParams' extends keyof O ? RestFetch<O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, E['body'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : (this: ThisParameterType<F>, ...args: Parameters<F>) => Promise<O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>>;
+
+type ExtractCollection<S extends Schema | undefined> = S extends CollectionInterface ? S : S extends Object$1<infer T> ? ExtractObject<T> : S extends Exclude<Schema, {
+    [K: string]: any;
+}> ? never : S extends {
+    [K: string]: Schema;
+} ? ExtractObject<S> : never;
+type ExtractObject<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
+}[keyof S];
 
 type EndpointUpdateFunction<Source extends FetchFunction, Schema, Updaters extends Record<string, any> = Record<string, any>> = (source: ResultEntry<Source & {
     schema: Schema;
@@ -1353,9 +727,9 @@ interface RestInstanceBase<
   getRequestInit(
     this: any,
     body?: RequestInit['body'] | Record<string, unknown>,
-  ): RequestInit;
+  ): Promise<RequestInit> | RequestInit;
   /** @see https://resthooks.io/rest/api/RestEndpoint#getHeaders */
-  getHeaders(headers: HeadersInit): HeadersInit;
+  getHeaders(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
   /* after-fetch */
   /** @see https://resthooks.io/rest/api/RestEndpoint#fetchResponse */
   fetchResponse(input: RequestInfo, init: RequestInit): Promise<Response>;
@@ -1764,6 +1138,10 @@ type IfTypeScriptLooseNull<Y, N> = 1 | undefined extends 1 ? Y : N;
 
 type KeyofRestEndpoint = keyof RestInstance;
 
+type FromFallBack<K extends keyof E, O, E> = K extends keyof O
+  ? O[K]
+  : E[K];
+
 type FetchMutate<
   A extends readonly any[] =  // eslint-disable-next-line @typescript-eslint/ban-types
     | [any, {}]
@@ -1777,148 +1155,184 @@ type FetchGet<A extends readonly any[] = [any], R = any> = (
   ...args: A
 ) => Promise<R>;
 
-type GetEndpoint<
-  UrlParams = any,
-  S extends Schema | undefined = Schema | undefined,
-> = RestTypeNoBody<UrlParams, S, undefined>;
-
-type MutateEndpoint<
-  UrlParams = any,
-  Body extends BodyInit | Record<string, any> = any,
-  S extends Schema | undefined = Schema | undefined,
-> = RestTypeWithBody<UrlParams, S, true, Body>;
-
 type Defaults<O, D> = {
   [K in keyof O | keyof D]: K extends keyof O
     ? Exclude<O[K], undefined>
     : D[Extract<K, keyof D>];
 };
 
-type NewGetEndpoint<
+type GetEndpoint<
   O extends {
+    readonly path: string;
+    readonly schema: Schema;
+    /** Only used for types */
+    readonly searchParams?: any;
+  } = {
     path: string;
-    searchParams?: any;
-  } = { path: string },
-  S extends Schema | undefined = Schema | undefined,
+    schema: Schema;
+  },
 > = RestTypeNoBody<
   'searchParams' extends keyof O
     ? O['searchParams'] & PathArgs<O['path']>
     : PathArgs<O['path']>,
-  S,
+  O['schema'],
   undefined,
   any,
   O & { body: undefined }
 >;
 
-type NewMutateEndpoint<
+type MutateEndpoint<
   O extends {
+    readonly path: string;
+    readonly schema: Schema;
+    /** Only used for types */
+    readonly searchParams?: any;
+    /** Only used for types */
+    readonly body?: any;
+  } = {
     path: string;
-    body?: any;
-    searchParams?: any;
-  } = { path: string; body: any },
-  S extends Schema | undefined = Schema | undefined,
+    body: any;
+    schema: Schema;
+  },
 > = RestTypeWithBody<
   'searchParams' extends keyof O
     ? O['searchParams'] & PathArgs<O['path']>
     : PathArgs<O['path']>,
-  S,
+  O['schema'],
   true,
   O['body'],
   any,
   O
 >;
 
-/** Creates collection of Endpoints for common operations on a given data/schema.
- *
- * @see https://resthooks.io/rest/api/createResource
- */
-declare function createResource<U extends string, S extends Schema>({ path, schema, Endpoint, optimistic, ...extraOptions }: {
-    readonly path: U;
-    readonly schema: S;
-    readonly Endpoint?: typeof RestEndpoint;
+interface ResourceGenerics {
+    readonly path: string;
+    readonly schema: Schema;
+    /** Only used for types */
+    readonly body?: any;
+    /** Only used for types */
+    readonly searchParams?: any;
+}
+interface ResourceOptions {
+    Endpoint?: typeof RestEndpoint;
     urlPrefix?: string;
+    requestInit?: RequestInit;
+    getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
+    getRequestInit?(body: any): Promise<RequestInit> | RequestInit;
+    fetchResponse?(input: RequestInfo, init: RequestInit): Promise<any>;
+    parseResponse?(response: Response): Promise<any>;
+    /** Default data expiry length, will fall back to NetworkManager default if not defined */
+    readonly dataExpiryLength?: number;
+    /** Default error expiry length, will fall back to NetworkManager default if not defined */
+    readonly errorExpiryLength?: number;
+    /** Poll with at least this frequency in miliseconds */
+    readonly pollFrequency?: number;
+    /** Marks cached resources as invalid if they are stale */
+    readonly invalidIfStale?: boolean;
+    /** Determines whether to throw or fallback to */
+    errorPolicy?(error: any): 'hard' | 'soft' | undefined;
     optimistic?: boolean;
-} & EndpointExtraOptions): Resource<U, S>;
-interface Resource<U extends string, S extends Schema> {
+}
+interface ResourceEndpointExtensions<R extends Resource<any>, Get extends PartialRestGenerics = any, GetList extends PartialRestGenerics = any, Update extends PartialRestGenerics = any, PartialUpdate extends PartialRestGenerics = any, Create extends PartialRestGenerics = any, Delete extends PartialRestGenerics = any> {
+    readonly get?: RestEndpointOptions<unknown extends Get ? R['get'] : OptionsToFunction<Get, R['get'], Extract<R['get'], FetchFunction>>, R['get']['schema']> & Readonly<Get>;
+    readonly getList?: RestEndpointOptions<unknown extends GetList ? R['getList'] : OptionsToFunction<GetList, R['getList'], Extract<R['getList'], FetchFunction>>, R['getList']['schema']> & Readonly<GetList>;
+    readonly update?: RestEndpointOptions<unknown extends Update ? R['update'] : OptionsToFunction<Update, R['update'], Extract<R['update'], FetchFunction>>, R['update']['schema']> & Readonly<Update>;
+    readonly partialUpdate?: RestEndpointOptions<unknown extends PartialUpdate ? R['partialUpdate'] : OptionsToFunction<PartialUpdate, R['partialUpdate'], Extract<R['partialUpdate'], FetchFunction>>, R['partialUpdate']['schema']> & Readonly<PartialUpdate>;
+    readonly create?: RestEndpointOptions<unknown extends Create ? R['create'] : OptionsToFunction<Create, R['create'], Extract<R['create'], FetchFunction>>, R['create']['schema']> & Readonly<Create>;
+    readonly delete?: RestEndpointOptions<unknown extends Delete ? R['delete'] : OptionsToFunction<Delete, R['delete'], Extract<R['delete'], FetchFunction>>, R['delete']['schema']> & Readonly<Delete>;
+}
+type ExtendedResource<R extends Resource<any>, Get extends PartialRestGenerics | {} = any, GetList extends PartialRestGenerics | {} = any, Update extends PartialRestGenerics | {} = any, PartialUpdate extends PartialRestGenerics | {} = any, Create extends PartialRestGenerics | {} = any, Delete extends PartialRestGenerics | {} = any, E extends Record<string, PartialRestGenerics> = {}> = {
+    get: unknown extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
+    getList: unknown extends GetList ? R['getList'] : RestExtendedEndpoint<GetList, R['getList']>;
+    update: unknown extends Update ? R['update'] : RestExtendedEndpoint<Update, R['update']>;
+    partialUpdate: unknown extends PartialUpdate ? R['partialUpdate'] : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
+    create: unknown extends Create ? unknown extends GetList ? R['create'] : RestExtendedEndpoint<GetList, R['create']> : unknown extends GetList ? RestExtendedEndpoint<Create, R['create']> : RestExtendedEndpoint<Defaults<Create, GetList>, R['create']>;
+    delete: unknown extends Delete ? R['delete'] : RestExtendedEndpoint<Delete, R['delete']>;
+} & {
+    [K in Exclude<keyof E, keyof Resource>]: RestExtendedEndpoint<E[K], R['get']>;
+};
+interface Resource<O extends ResourceGenerics = {
+    path: string;
+    schema: any;
+}> {
     /** Get a singular item
      *
      * @see https://resthooks.io/rest/api/createResource#get
      */
-    get: NewGetEndpoint<{
-        path: U;
-    }, S>;
+    get: GetEndpoint<{
+        path: O['path'];
+        schema: O['schema'];
+    }>;
     /** Get a list of item
      *
      * @see https://resthooks.io/rest/api/createResource#getlist
      */
-    getList: NewGetEndpoint<{
-        path: ShortenPath<U>;
+    getList: 'searchParams' extends keyof O ? GetEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: Collection<[O['schema']]>;
+        searchParams: O['searchParams'];
+    }> : GetEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: Collection<[O['schema']]>;
         searchParams: Record<string, number | string | boolean> | undefined;
-    }, S[]>;
+    }>;
     /** Create a new item (POST)
      *
      * @see https://resthooks.io/rest/api/createResource#create
      */
-    create: NewMutateEndpoint<{
-        path: ShortenPath<U>;
-        body: Partial<Denormalize<S>>;
-    }, S>;
+    create: 'searchParams' extends keyof O ? MutateEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: Collection<[O['schema']]>['push'];
+        body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
+        searchParams: O['searchParams'];
+    }> : MutateEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: Collection<[O['schema']]>['push'];
+        body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
+    }>;
     /** Update an item (PUT)
      *
      * @see https://resthooks.io/rest/api/createResource#update
      */
-    update: NewMutateEndpoint<{
-        path: U;
-        body: Partial<Denormalize<S>>;
-    }, S>;
+    update: 'body' extends keyof O ? MutateEndpoint<{
+        path: O['path'];
+        body: O['body'];
+        schema: O['schema'];
+    }> : MutateEndpoint<{
+        path: O['path'];
+        body: Partial<Denormalize<O['schema']>>;
+        schema: O['schema'];
+    }>;
     /** Update an item (PATCH)
      *
      * @see https://resthooks.io/rest/api/createResource#partialupdate
      */
-    partialUpdate: NewMutateEndpoint<{
-        path: U;
-        body: Partial<Denormalize<S>>;
-    }, S>;
+    partialUpdate: 'body' extends keyof O ? MutateEndpoint<{
+        path: O['path'];
+        body: Partial<O['body']>;
+        schema: O['schema'];
+    }> : MutateEndpoint<{
+        path: O['path'];
+        body: Partial<Denormalize<O['schema']>>;
+        schema: O['schema'];
+    }>;
     /** Delete an item (DELETE)
      *
      * @see https://resthooks.io/rest/api/createResource#delete
      */
-    delete: RestTypeNoBody<PathArgs<U>, S extends EntityInterface & {
+    delete: RestTypeNoBody<PathArgs<O['path']>, O['schema'] extends EntityInterface & {
         process: any;
-    } ? Delete<S> : S, undefined, Partial<PathArgs<U>>, {
-        path: U;
+    } ? Invalidate<O['schema']> : O['schema'], undefined, Partial<PathArgs<O['path']>>, {
+        path: O['path'];
     }>;
 }
 
-interface HookableEndpointInterface extends EndpointInterface {
-    extend(...args: any): HookableEndpointInterface;
-}
-/** Turns a collection of Endpoints (Resource) into a collection of hooks.
- * This is useful for Endpoints that need hooks to prepare their fetch requests.
+/** Creates collection of Endpoints for common operations on a given data/schema.
  *
- * @see https://resthooks.io/rest/api/hookifyResource
+ * @see https://resthooks.io/rest/api/createResource
  */
-declare function hookifyResource<R extends {}>(resource: R, useRequestInit: () => RequestInit): HookResource<R>;
-type HookResource<R extends {}> = {
-    [K in Extract<keyof R, string> as `use${Capitalize<K>}`]: () => R[K];
-};
+declare function createResource<const O extends ResourceGenerics, const Get extends PartialRestGenerics = any, const GetList extends PartialRestGenerics = any, const Update extends PartialRestGenerics = any, const PartialUpdate extends PartialRestGenerics = any, const Create extends PartialRestGenerics = any, const Delete extends PartialRestGenerics = any, const E extends Record<string, PartialRestGenerics & RestEndpointOptions> = {}>({ path, schema, Endpoint, optimistic, get: getOpt, getList: getListOpt, update: updateOpt, partialUpdate: partialOpt, delete: delOpt, create: createOpt, endpoints, ...extraOptions }: Readonly<O> & ResourceOptions & ResourceEndpointExtensions<Resource<O>, Get, GetList, Update, PartialUpdate, Create, Delete> & {
+    endpoints?: E;
+}): ExtendedResource<Resource<O>, Get, GetList, Update, PartialUpdate, Create, Delete, E>;
 
-/** An error with a Rest Endpoint fetch
- *
- * @see https://resthooks.io/rest/api/NetworkError
- */
-declare class NetworkError extends Error {
-    status: number;
-    response: Response;
-    name: string;
-    constructor(response: Response);
-}
-
-declare function paginationUpdate<E extends {
-    schema: Schema;
-    key: any;
-} & ((...args: any) => Promise<any>), A extends any[]>(endpoint: E, removeCursor: (...args: A) => readonly [...Parameters<typeof endpoint>]): (newPage: any, ...args: A) => {
-    [x: number]: (existing: any) => any;
-};
-
-export { AbortOptimistic, AbstractInstanceType, AddEndpoint, Array$1 as Array, ArrayElement, Collection, DELETED, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, FetchGet, FetchMutate, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MutateEndpoint, NetworkError, NewGetEndpoint, NewMutateEndpoint, Normalize, NormalizeNullable, OptionsToFunction, PaginationFieldEndpoint, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Resource, RestEndpoint, RestEndpointConstructorOptions, RestFetch, RestGenerics, RestInstance, RestType, Schema, SchemaClass, SchemaDetail, SchemaList, SchemaSimple, SchemaSimpleNew, ShortenPath, SnapshotInterface, UnknownError, createResource, hookifyResource, paginationUpdate, schema_d as schema, validateRequired };
+export { AddEndpoint, BodyDefault, Defaults, FetchGet, FetchMutate, FromFallBack, GetEndpoint, KeyofRestEndpoint, MethodToSide, MutateEndpoint, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, PartialRestGenerics, Resource, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, createResource };


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2446 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simpler resource construction

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

```ts
const UserResource = createResource({
  path: 'http\\://test.com/groups/:group/users/:id',
  schema: User,
  getList: {
    searchParams: {} as { isAdmin?: boolean },
  },
  partialUpdate: {
    getOptimisticResponse(snap, params, body) {
      return {
        id: params.id,
        ...body,
      };
    },
  },
  delete: {
    getOptimisticResponse(snap, params) {
      return params;
    },
  },
  endpoints: {
    current: { path: '/user' },
  },
});
```

```ts
UserResource.getList({isAdmin: true});
UserResource.current();
```

To modify existing endpoint options - use its name (like 'get' for 'get' endpoint).

To add additional endpoints - put in the 'endpoints' option. This will extend from the 'get' endpoint, allowing it to inherit the defaults of the resource.