### PR TITLE
feat: Add 'optimistic' option to createResource

### DIFF
--- a/.changeset/big-radios-speak.md
+++ b/.changeset/big-radios-speak.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/react': patch
+'@rest-hooks/core': patch
+---
+
+Only use optimistic responses for endpoints with sideEffects

--- a/.changeset/six-emus-smoke.md
+++ b/.changeset/six-emus-smoke.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': minor
+---
+
+Add 'optimistic' option to createResource()

--- a/docs/core/getting-started/comparison.md
+++ b/docs/core/getting-started/comparison.md
@@ -105,18 +105,18 @@ but having bluetooth and internet streaming isn't necessarily worse than a car w
 
 How quickly one can get started
 
-|                                         |     Rest Hooks      | SWR | RTK-Query |       Apollo        | Relay |
-| --------------------------------------- | :-----------------: | :-: | :-------: | :-----------------: | :---: |
-| Can use with redux                      |         ✅          | 🛑  |    ✅     |         🛑          |  🛑   |
-| Infinite scrolling                      |         ✅          | ✅  |    🛑     |         ✅          |
-| [401 handling](../api/LogoutManager.md) |         ✅          | 🛑  |    🟡     |                     |  🛑   |
-| Aborts                                  |         ✅          | 🛑  |    🛑     |         🛑          |
-| Arbitrary store queries                 |         ✅          | 🛑  |    ✅     |                     |  🛑   |
-| Debugging inspector                     |         ✅          | 🛑  |    ✅     |         ✅          |  ✅   |
-| Data mocking                            |         ✅          | 🛑  |    🛑     |         🛑          |  ✅   |
-| Storybook                               |         ✅          | 🛑  |    🛑     |         🛑          |
-| Retries                                 | 🟡 user-defined[^1] | 🛑  |    ✅     | 🟡 user-defined[^1] |  🛑   |
-| Declarative data transforms             |         ✅          | 🛑  |    🛑     |         🛑          |  🛑   |
+|                                                                  |     Rest Hooks      | SWR | RTK-Query |       Apollo        | Relay |
+| ---------------------------------------------------------------- | :-----------------: | :-: | :-------: | :-----------------: | :---: |
+| Can use with redux                                               |         ✅          | 🛑  |    ✅     |         🛑          |  🛑   |
+| [Infinite scrolling](/rest/guides/pagination#infinite-scrolling) |         ✅          | ✅  |    🛑     |         ✅          |
+| [401 handling](../api/LogoutManager.md)                          |         ✅          | 🛑  |    🟡     |                     |  🛑   |
+| Aborts                                                           |         ✅          | 🛑  |    🛑     |         🛑          |
+| Arbitrary store queries                                          |         ✅          | 🛑  |    ✅     |                     |  🛑   |
+| Debugging inspector                                              |         ✅          | 🛑  |    ✅     |         ✅          |  ✅   |
+| Data mocking                                                     |         ✅          | 🛑  |    🛑     |         🛑          |  ✅   |
+| [Storybook](../guides/storybook.md)                              |         ✅          | 🛑  |    🛑     |         🛑          |
+| Retries                                                          | 🟡 user-defined[^1] | 🛑  |    ✅     | 🟡 user-defined[^1] |  🛑   |
+| Declarative data transforms                                      |         ✅          | 🛑  |    🛑     |         🛑          |  🛑   |
 
 ### Extensibility
 

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -17,15 +17,11 @@ export abstract class PlaceholderEntity extends Entity {
 }
 
 /** Common patterns in the https://jsonplaceholder.typicode.com API */
-export function createPlaceholderResource<O extends ResourceGenerics = any>({
-  path,
-  schema,
-  Endpoint = RestEndpoint,
-}: Readonly<O> & ResourceOptions): Resource<O> {
+export function createPlaceholderResource<O extends ResourceGenerics = any>(
+  options: Readonly<O> & ResourceOptions,
+): Resource<O> {
   const base = createResource({
-    path,
-    schema,
-    Endpoint,
+    ...options,
     urlPrefix: 'https://jsonplaceholder.typicode.com',
     // hour expiry time since we want to keep our example mutations and the api itself never actually changes
     dataExpiryLength: 1000 * 60 * 60,

--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -66,7 +66,8 @@ export default class NetworkManager implements Manager {
               // render - so we need to stop 'readonly' fetches which can be triggered in render
               if (
                 action.meta.optimisticResponse !== undefined ||
-                action.endpoint?.getOptimisticResponse !== undefined
+                (action.endpoint?.getOptimisticResponse !== undefined &&
+                  action.endpoint.sideEffect)
               ) {
                 return next(action);
               }

--- a/packages/core/src/state/reducer/fetchReducer.ts
+++ b/packages/core/src/state/reducer/fetchReducer.ts
@@ -12,7 +12,7 @@ export function fetchReducer(state: State<unknown>, action: FetchAction) {
   const getOptimisticResponse = action.endpoint?.getOptimisticResponse;
   let receiveAction: ReceiveAction | OptimisticAction;
 
-  if (getOptimisticResponse && action.endpoint) {
+  if (getOptimisticResponse && action.endpoint && action.endpoint.sideEffect) {
     receiveAction = createOptimistic(action.endpoint, {
       args: action.meta.args as readonly any[],
       fetchedAt:

--- a/packages/react/src/hooks/__tests__/useController/__snapshots__/fetch.tsx.snap
+++ b/packages/react/src/hooks/__tests__/useController/__snapshots__/fetch.tsx.snap
@@ -8,11 +8,23 @@ exports[`CacheProvider should log error message when user update method throws 1
   [
     [Error: usererror],
   ],
+  [
+    "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
+  ],
+  [
+    [Error: usererror],
+  ],
 ]
 `;
 
 exports[`ExternalCacheProvider should log error message when user update method throws 1`] = `
 [
+  [
+    "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
+  ],
+  [
+    [Error: usererror],
+  ],
   [
     "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
   ],

--- a/packages/react/src/next/__tests__/__snapshots__/fetch.tsx.snap
+++ b/packages/react/src/next/__tests__/__snapshots__/fetch.tsx.snap
@@ -2,22 +2,12 @@
 
 exports[`CacheProvider should log error message when user update method throws 1`] = `
 [
-  [
-    "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
-  ],
-  [
-    [Error: usererror],
-  ],
+  "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
 ]
 `;
 
 exports[`ExternalCacheProvider should log error message when user update method throws 1`] = `
 [
-  [
-    "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
-  ],
-  [
-    [Error: usererror],
-  ],
+  "The following error occured during Endpoint.update() for POST http://test.com/article-cooler",
 ]
 `;

--- a/packages/react/src/next/__tests__/fetch.tsx
+++ b/packages/react/src/next/__tests__/fetch.tsx
@@ -236,7 +236,7 @@ describe.each([
       // still keeps old list
       expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3]);
 
-    expect(errorspy.mock.calls).toMatchSnapshot();
+    expect(errorspy.mock.calls[0]).toMatchSnapshot();
   });
 
   it('should not suspend once deleted and redirected at same time', async () => {

--- a/packages/rest/src/next/createResource.ts
+++ b/packages/rest/src/next/createResource.ts
@@ -1,10 +1,15 @@
-import { schema } from '@rest-hooks/endpoint';
+import {
+  AbortOptimistic,
+  SnapshotInterface,
+  schema,
+} from '@rest-hooks/endpoint';
 import type { Schema, Denormalize } from '@rest-hooks/endpoint';
 
 import { ResourceGenerics, ResourceOptions } from './resourceTypes.js';
 import RestEndpoint, {
   GetEndpoint,
   MutateEndpoint,
+  RestInstance,
   RestTypeNoBody,
 } from './RestEndpoint.js';
 import { PathArgs, ShortenPath } from '../pathTypes.js';
@@ -20,36 +25,50 @@ export default function createResource<O extends ResourceGenerics>({
   path,
   schema,
   Endpoint = RestEndpoint,
+  optimistic,
   ...extraOptions
 }: Readonly<O> & ResourceOptions): Resource<O> {
   const shortenedPath = shortenPath(path);
   const getName = (name: string) => `${(schema as any)?.name}.${name}`;
+  const extraMutateOptions = { ...extraOptions };
+  const extraPartialOptions = { ...extraOptions };
+  const get: GetEndpoint<{ path: O['path']; schema: O['schema'] }> =
+    new Endpoint({
+      ...extraOptions,
+      path,
+      schema,
+      name: getName('get'),
+    }) as any;
+  if (optimistic) {
+    (extraMutateOptions as any).getOptimisticResponse = optimisticUpdate;
+    (extraPartialOptions as any).getOptimisticResponse = optimisticPartial(get);
+  }
   const getList = new Endpoint({
-    ...extraOptions,
+    ...extraMutateOptions,
     path: shortenedPath,
     schema: new Collection([schema as any]),
     name: getName('getList'),
   });
   return {
-    get: new Endpoint({ ...extraOptions, path, schema, name: getName('get') }),
+    get,
     getList,
     create: getList.push.extend({ name: getName('create') }),
     update: new Endpoint({
-      ...extraOptions,
+      ...extraMutateOptions,
       path,
       schema,
       method: 'PUT',
       name: getName('update'),
     }),
     partialUpdate: new Endpoint({
-      ...extraOptions,
+      ...extraPartialOptions,
       path,
       schema,
       method: 'PATCH',
       name: getName('partialUpdate'),
     }),
     delete: new Endpoint({
-      ...extraOptions,
+      ...extraMutateOptions,
       path,
       schema: (schema as any).process ? new Invalidate(schema as any) : schema,
       method: 'DELETE',
@@ -57,8 +76,31 @@ export default function createResource<O extends ResourceGenerics>({
       process(res: any, params: any) {
         return res && Object.keys(res).length ? res : params;
       },
+      getOptimisticResponse: optimistic ? (optimisticDelete as any) : undefined,
     }),
   } as any;
+}
+
+function optimisticUpdate(snap: SnapshotInterface, params: any, body: any) {
+  return {
+    ...params,
+    ...body,
+  };
+}
+function optimisticPartial(getEndpoint: GetEndpoint) {
+  return function (snap: SnapshotInterface, params: any, body: any) {
+    const { data } = snap.getResponse(getEndpoint, params) as { data: any };
+    if (!data) throw new AbortOptimistic();
+    return {
+      ...params,
+      ...data,
+      // even tho we don't always have two arguments, the extra one will simply be undefined which spreads fine
+      ...body,
+    };
+  };
+}
+function optimisticDelete(snap: SnapshotInterface, params: any) {
+  return params;
 }
 
 export interface Resource<

--- a/packages/rest/src/next/resourceTypes.ts
+++ b/packages/rest/src/next/resourceTypes.ts
@@ -28,4 +28,5 @@ export interface ResourceOptions {
   readonly invalidIfStale?: boolean;
   /** Determines whether to throw or fallback to */
   errorPolicy?(error: any): 'hard' | 'soft' | undefined;
+  optimistic?: boolean;
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Reduce common code.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since RestEndpoints have a fairly common argument structure, we can exploit this to provide sensible optimistic defaults. We add to the resource since we most likely want to share the optimistic nature across different mutation types.

#### Only run optimistic for `sideEffect` endpoints

- Retrieval endpoints this is pointless
- We want to be able to encode our 'create' optimistic in getList so we can use extenders like unshift,assign, etc.