### PR TITLE
fix: Remove false positive Resource.delete with 200 response type but empty text

### DIFF
--- a/.changeset/chilled-news-wink.md
+++ b/.changeset/chilled-news-wink.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/rest': patch
+---
+
+Remove false positive Resource.delete with 200 response type but empty text

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -133,9 +133,11 @@ export default class RestEndpoint extends Endpoint {
     if (!response.headers.get('content-type')?.includes('json')) {
       return response.text().then(text => {
         // string or 'not set' schema, are valid
+        // when overriding process they might handle other cases, so we don't want to block on our logic
         if (
           ['string', 'undefined'].includes(typeof this.schema) ||
-          this.schema === null
+          this.schema === null ||
+          this.process !== RestEndpoint.prototype.process
         )
           return text;
 

--- a/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createResource() UserResource.delete should work with  1`] = `"not found"`;
+
+exports[`createResource() UserResource.delete should work with {"id": 5} 1`] = `"not found"`;

--- a/packages/rest/src/next/RestEndpoint.js
+++ b/packages/rest/src/next/RestEndpoint.js
@@ -133,9 +133,11 @@ export default class RestEndpoint extends Endpoint {
     if (!response.headers.get('content-type')?.includes('json')) {
       return response.text().then(text => {
         // string or 'not set' schema, are valid
+        // when overriding process they might handle other cases, so we don't want to block on our logic
         if (
           ['string', 'undefined'].includes(typeof this.schema) ||
-          this.schema === null
+          this.schema === null ||
+          this.process !== RestEndpoint.prototype.process
         )
           return text;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Since Resource.delete handles empty responses in process(), we cannot be so eager to rule out empty responses in parseResponse for RestEndpoint.

(200 delete with empty response is still valid because process falls back to using parameters to find the element to delete*

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Don't be as strict with response when process is overridden in RestEndpoint.