### PR TITLE
enhance: createResource() throws without at least one path :parameter

### DIFF
--- a/.changeset/afraid-keys-change.md
+++ b/.changeset/afraid-keys-change.md
@@ -1,0 +1,6 @@
+---
+'@data-client/rest': patch
+'@rest-hooks/rest': patch
+---
+
+fix(types): RestEndpoint.push/unshift/assign return type is no longer nested Promises

--- a/.changeset/silent-lies-yell.md
+++ b/.changeset/silent-lies-yell.md
@@ -1,0 +1,6 @@
+---
+'@data-client/rest': patch
+'@rest-hooks/rest': patch
+---
+
+enhance: createResource() throws with path not containing any :path

--- a/packages/rest/src-4.0-types/pathTypes.d.ts
+++ b/packages/rest/src-4.0-types/pathTypes.d.ts
@@ -18,3 +18,5 @@ export declare type PathArgsAndSearch<S extends string> =
 
 /** Removes the last :token */
 export declare type ShortenPath<S extends string> = S;
+
+export declare type ResourcePath = string;

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -262,7 +262,7 @@ export type AddEndpoint<
         : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>>
       : PathArgs<Exclude<O['path'], undefined>>,
     any,
-    ReturnType<F>
+    ResolveType<F>
   >,
   ExtractCollection<S>,
   true,

--- a/packages/rest/src/RestHelpers.ts
+++ b/packages/rest/src/RestHelpers.ts
@@ -34,11 +34,11 @@ export function isPojo(obj: unknown): obj is Record<string, any> {
 }
 
 export function shortenPath<S extends string>(path: S): ShortenPath<S> {
+  const lastColonIndex = path.lastIndexOf(':');
+  if (lastColonIndex === -1)
+    throw new Error('Resource path requires at least one :parameter');
   // this is for when not specifying a specific item like create/list
-  let shortUrlRoot: ShortenPath<S> = path.substring(
-    0,
-    path.lastIndexOf(':'),
-  ) as any;
+  let shortUrlRoot: ShortenPath<S> = path.substring(0, lastColonIndex) as any;
   if (shortUrlRoot[shortUrlRoot.length - 1] === '/')
     shortUrlRoot = shortUrlRoot.substring(
       0,

--- a/packages/rest/src/__tests__/Resource.test.ts
+++ b/packages/rest/src/__tests__/Resource.test.ts
@@ -2,11 +2,11 @@ import { Entity, Schema } from '@data-client/endpoint';
 import { useController } from '@data-client/react';
 import { useSuspense } from '@data-client/react';
 import { CacheProvider } from '@data-client/react';
-import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
 
 import { makeRenderRestHook } from '../../../test';
 import createResource from '../createResource';
+import { ResourcePath } from '../pathTypes';
 import RestEndpoint from '../RestEndpoint';
 import {
   payload,
@@ -47,7 +47,7 @@ export class PaginatedArticle extends Entity {
     author: User,
   };
 }
-function createPaginatableResource<U extends string, S extends Schema>({
+function createPaginatableResource<U extends ResourcePath, S extends Schema>({
   path,
   schema,
   Endpoint = RestEndpoint,

--- a/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
@@ -3,3 +3,5 @@
 exports[`createResource() UserResource.delete should work with  1`] = `"not found"`;
 
 exports[`createResource() UserResource.delete should work with {"id": 5} 1`] = `"not found"`;
+
+exports[`createResource() should not allow paths without at least one argument 1`] = `"Resource path requires at least one :parameter"`;

--- a/packages/rest/src/__tests__/createResource.test.ts
+++ b/packages/rest/src/__tests__/createResource.test.ts
@@ -79,6 +79,28 @@ describe('createResource()', () => {
     nock.cleanAll();
   });
 
+  it('should not allow paths without at least one argument', () => {
+    class Todo extends Entity {
+      id = '';
+      userId = 0;
+      title = '';
+      completed = false;
+
+      static key = 'Todo';
+      pk() {
+        return this.id;
+      }
+    }
+
+    expect(() =>
+      createResource({
+        // TODO(see path types): @ts-expect-error
+        path: '/todos/',
+        schema: Todo,
+      }),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
   it('UserResource.get should work', async () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useSuspense(UserResource.get, { group: 'five', id: '5' });

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -4,7 +4,8 @@ import { useSuspense } from '@data-client/react';
 import { User } from '__tests__/new';
 
 import createResource from '../createResource';
-import RestEndpoint, { MutateEndpoint } from '../RestEndpoint';
+import { PathArgs, PathKeys } from '../pathTypes';
+import RestEndpoint, { GetEndpoint, MutateEndpoint } from '../RestEndpoint';
 
 it('RestEndpoint construct and extend with typed options', () => {
   new RestEndpoint({
@@ -425,5 +426,25 @@ it('should precisely type function arguments', () => {
     () => noSearch({ userId: 'hi' });
     // @ts-expect-error
     () => noSearch(5);
+  };
+});
+
+it('should handle more open ended type definitions', () => {
+  () => {
+    const unknownParams = new RestEndpoint({
+      path: '' as `${string}:${string}`,
+    });
+
+    unknownParams({ hi: 5 });
+
+    const explicit: GetEndpoint<{
+      path: `${string}:${string}`;
+      schema: typeof User;
+    }> = new RestEndpoint({
+      path: '' as `${string}:${string}`,
+      schema: User,
+    });
+    explicit({ hi: 5 });
+    explicit.push.process({} as any, { hi: 5 });
   };
 });

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -5,7 +5,7 @@ import {
 } from '@data-client/endpoint';
 import type { Denormalize } from '@data-client/endpoint';
 
-import { PathArgs, ShortenPath } from './pathTypes.js';
+import { PathArgs, ResourcePath, ShortenPath } from './pathTypes.js';
 import { ResourceGenerics, ResourceOptions } from './resourceTypes.js';
 import RestEndpoint, {
   GetEndpoint,
@@ -86,7 +86,9 @@ function optimisticUpdate(snap: SnapshotInterface, params: any, body: any) {
     ...body,
   };
 }
-function optimisticPartial(getEndpoint: GetEndpoint) {
+function optimisticPartial(
+  getEndpoint: GetEndpoint<{ path: ResourcePath; schema: any }>,
+) {
   return function (snap: SnapshotInterface, params: any, body: any) {
     const { data } = snap.getResponse(getEndpoint, params) as { data: any };
     if (!data) throw new AbortOptimistic();
@@ -103,7 +105,7 @@ function optimisticDelete(snap: SnapshotInterface, params: any) {
 }
 
 export interface Resource<
-  O extends ResourceGenerics = { path: string; schema: any },
+  O extends ResourceGenerics = { path: ResourcePath; schema: any },
 > {
   /** Get a singular item
    *

--- a/packages/rest/src/pathTypes.ts
+++ b/packages/rest/src/pathTypes.ts
@@ -56,3 +56,5 @@ type TrimColon<S extends string> = string extends S
   : S extends `${infer R}:`
   ? R
   : S;
+
+export type ResourcePath = string; // `${string}:${string}`; TODO: Maybe do this in the future? Seems to hard to understand for now

--- a/packages/rest/src/resourceTypes.ts
+++ b/packages/rest/src/resourceTypes.ts
@@ -1,9 +1,10 @@
 import type { Schema } from '@data-client/endpoint';
 
+import type { ResourcePath } from './pathTypes.js';
 import RestEndpoint from './RestEndpoint.js';
 
 export interface ResourceGenerics {
-  readonly path: string;
+  readonly path: ResourcePath;
   readonly schema: Schema;
   /** Only used for types */
   readonly body?: any;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

> Can there be better feedback when the path passed to createResource is malformed? Currently, if the path is /todos instead of /todos/:id, rest-hooks will completely ignore the path and send the request to urlPrefix with no path appended
by Firelight on discord

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
createResource() will throw without a path as this is not well defined.

Also: Fixed a type for push/unshift/assign that put double nested Promises as return type rather than only one promise