### PR TITLE
feat: Add paginationField to createResource

### DIFF
--- a/.changeset/sharp-islands-pull.md
+++ b/.changeset/sharp-islands-pull.md
@@ -1,0 +1,7 @@
+---
+'@data-client/rest': minor
+'@rest-hooks/rest': minor
+---
+
+Add createResource() paginationField argument
+  When supplied, will enable Resource.getNextPage

--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -92,7 +92,11 @@ export class GithubEndpoint<
 export function createGithubResource<O extends ResourceGenerics>(
   options: Readonly<O> & ResourceOptions,
 ): GithubResource<O> {
-  const baseResource = createResource({ Endpoint: GithubEndpoint, ...options });
+  const baseResource = createResource({
+    Endpoint: GithubEndpoint,
+    ...options,
+    // this type compensates for a TypeScript bug with exactPropertyTypes
+  } as ResourceGenerics);
 
   const getList: GetEndpoint<
     Omit<O, 'schema' | 'body' | 'path'> & {
@@ -115,8 +119,12 @@ export function createGithubResource<O extends ResourceGenerics>(
 }
 
 export interface GithubResource<
-  O extends ResourceGenerics = { path: string; schema: Schema },
-> extends Omit<Resource<O>, 'getList'> {
+  O extends ResourceGenerics = {
+    path: string;
+    schema: Schema;
+    paginationField: 'page';
+  },
+> extends Omit<Resource<O>, 'getList' | 'getNextPage'> {
   getList: GetEndpoint<
     Omit<O, 'schema' | 'body' | 'path'> & {
       readonly path: ShortenPath<O['path']>;

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -25,7 +25,7 @@ export function createPlaceholderResource<O extends ResourceGenerics = any>(
     urlPrefix: 'https://jsonplaceholder.typicode.com',
     // hour expiry time since we want to keep our example mutations and the api itself never actually changes
     dataExpiryLength: 1000 * 60 * 60,
-  });
+  } as ResourceGenerics);
   const partialUpdate = base.partialUpdate.extend({
     process(response: any, ...args: any[]) {
       // body only contains what we're changing, but we can find the id in params

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -312,6 +312,39 @@ exports[`CacheProvider RestEndpoint/next should update on get for a paginated re
 }
 `;
 
+exports[`CacheProvider pagination should work with cursor field in createResource 1`] = `
+[
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": [],
+    "title": "the next time",
+  },
+]
+`;
+
 exports[`CacheProvider should work with unions 1`] = `
 [
   [
@@ -687,6 +720,39 @@ exports[`ExternalCacheProvider RestEndpoint/next should update on get for a pagi
     },
   ],
 }
+`;
+
+exports[`ExternalCacheProvider pagination should work with cursor field in createResource 1`] = `
+[
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": [],
+    "title": "the next time",
+  },
+]
 `;
 
 exports[`ExternalCacheProvider should work with unions 1`] = `

--- a/packages/rest/src/resourceTypes.ts
+++ b/packages/rest/src/resourceTypes.ts
@@ -4,15 +4,25 @@ import type { ResourcePath } from './pathTypes.js';
 import RestEndpoint from './RestEndpoint.js';
 
 export interface ResourceGenerics {
+  /** @see https://resthooks.io/rest/api/createResource#path */
   readonly path: ResourcePath;
+  /** @see https://resthooks.io/rest/api/createResource#schema */
   readonly schema: Schema;
+  /** @see https://resthooks.io/rest/api/createResource#paginationfield */
+  readonly paginationField?: string;
   /** Only used for types */
+  /** @see https://dataclient.io/rest/api/createResource#body */
   readonly body?: any;
   /** Only used for types */
+  /** @see https://resthooks.io/rest/api/createResource#searchParams */
   readonly searchParams?: any;
 }
 export interface ResourceOptions {
+  /** @see https://resthooks.io/rest/api/createResource#endpoint */
   Endpoint?: typeof RestEndpoint;
+  /** @see https://resthooks.io/rest/api/createResource#optimistic */
+  optimistic?: boolean;
+  /** @see https://resthooks.io/rest/api/createResource#urlprefix */
   urlPrefix?: string;
   requestInit?: RequestInit;
   getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
@@ -29,5 +39,4 @@ export interface ResourceOptions {
   readonly invalidIfStale?: boolean;
   /** Determines whether to throw or fallback to */
   errorPolicy?(error: any): 'hard' | 'soft' | undefined;
-  optimistic?: boolean;
 }

--- a/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
@@ -654,6 +654,7 @@ type KeysToArgs<Key extends string> = {
 /** Removes the last :token */
 type ShortenPath<S extends string> = string extends S ? string : S extends `${infer B}:${infer R}` ? TrimColon<`${B}:${ShortenPath<R>}`> : '';
 type TrimColon<S extends string> = string extends S ? string : S extends `${infer R}:` ? R : S;
+type ResourcePath = string;
 
 type OptionsToFunction<O extends PartialRestGenerics, E extends RestInstanceBase & {
     body?: any;
@@ -921,7 +922,7 @@ type AddEndpoint<
         : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>>
       : PathArgs<Exclude<O['path'], undefined>>,
     any,
-    ReturnType<F>
+    ResolveType<F>
   >,
   ExtractCollection<S>,
   true,
@@ -1201,15 +1202,25 @@ type MutateEndpoint<
 >;
 
 interface ResourceGenerics {
-    readonly path: string;
+    /** @see https://resthooks.io/rest/api/createResource#path */
+    readonly path: ResourcePath;
+    /** @see https://resthooks.io/rest/api/createResource#schema */
     readonly schema: Schema;
+    /** @see https://resthooks.io/rest/api/createResource#paginationfield */
+    readonly paginationField?: string;
     /** Only used for types */
+    /** @see https://dataclient.io/rest/api/createResource#body */
     readonly body?: any;
     /** Only used for types */
+    /** @see https://resthooks.io/rest/api/createResource#searchParams */
     readonly searchParams?: any;
 }
 interface ResourceOptions {
+    /** @see https://resthooks.io/rest/api/createResource#endpoint */
     Endpoint?: typeof RestEndpoint;
+    /** @see https://resthooks.io/rest/api/createResource#optimistic */
+    optimistic?: boolean;
+    /** @see https://resthooks.io/rest/api/createResource#urlprefix */
     urlPrefix?: string;
     requestInit?: RequestInit;
     getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
@@ -1226,16 +1237,15 @@ interface ResourceOptions {
     readonly invalidIfStale?: boolean;
     /** Determines whether to throw or fallback to */
     errorPolicy?(error: any): 'hard' | 'soft' | undefined;
-    optimistic?: boolean;
 }
 
 /** Creates collection of Endpoints for common operations on a given data/schema.
  *
  * @see https://resthooks.io/rest/api/createResource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
+declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 interface Resource<O extends ResourceGenerics = {
-    path: string;
+    path: ResourcePath;
     schema: any;
 }> {
     /** Get a singular item
@@ -1259,6 +1269,19 @@ interface Resource<O extends ResourceGenerics = {
         schema: Collection<[O['schema']]>;
         searchParams: Record<string, number | string | boolean> | undefined;
     }>;
+    /** Get a list of item
+     *
+     * @see https://dataclient.io/rest/api/createResource#getNextPage
+     */
+    getNextPage: 'paginationField' extends keyof O ? PaginationFieldEndpoint<'searchParams' extends keyof O ? GetEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: Collection<[O['schema']]>;
+        searchParams: O['searchParams'];
+    }> : GetEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: Collection<[O['schema']]>;
+        searchParams: Record<string, number | string | boolean> | undefined;
+    }>, Exclude<O['paginationField'], undefined>> : undefined;
     /** Create a new item (POST)
      *
      * @see https://resthooks.io/rest/api/createResource#create


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simplify common definitions. (Abstraction specialization)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Before

```ts
const BaseArticleResource = createResource({
  urlPrefix: 'http://test.com',
  path: '/article/:id',
  searchParams: {} as { userId?: number } | undefined,
  schema: Article,
});
const ArticleResource = {
  ...BaseArticleResource,
  getNextPage: BaseArticleResource.paginated('page'),
};
```

After

```ts
const ArticleResource = createResource({
  urlPrefix: 'http://test.com',
  path: '/article/:id',
  searchParams: {} as { userId?: number } | undefined,
  schema: Article,
  paginationField: 'page',
});
```

#### Usage

```tsx
import { useSuspense, useController } from '@data-client/react';
import { NewsResource } from 'api/News';

function NewsList() {
  const articles = useSuspense(ArticleResource.getList);
  const ctrl = useController();

  return (
    <Pagination
      onPaginate={() => ctrl.fetch(ArticleResource.getNextPage, { page: 2 })}
    >
      <NewsList data={articles} />
    </Pagination>
  );
}
```
