### PR TITLE
feat: Add Resource.extend() to customize endpoints

### DIFF
--- a/.changeset/fresh-doors-change.md
+++ b/.changeset/fresh-doors-change.md
@@ -1,0 +1,6 @@
+---
+'@rest-hooks/rest': patch
+'@data-client/rest': patch
+---
+
+Fix endpoint.push/unshift/assign method type

--- a/.changeset/random-word-things.md
+++ b/.changeset/random-word-things.md
@@ -1,0 +1,6 @@
+---
+'@data-client/rest': minor
+'@rest-hooks/rest': minor
+---
+
+Deprecate Resource.create

--- a/.changeset/shiny-spies-give.md
+++ b/.changeset/shiny-spies-give.md
@@ -1,0 +1,28 @@
+---
+'@data-client/rest': minor
+'@rest-hooks/rest': minor
+---
+
+Add Resource.extend()
+
+This is polymorphic, and has three forms
+
+Set any field based on arguments:
+Resource.extend('fieldName', { path: 'mypath/:id' });
+
+Override any of the provided endpoints with options:
+Resource.extend({
+  getList: {
+    path: 'mypath/:id',
+  },
+  update: {
+    body: {} as Other,
+  },
+});
+
+Function to compute derived endpoints:
+Resource.extend((base) => ({
+  getByComment: base.getList.extend({
+    path: 'repos/:owner/:repo/issues/comments/:comment/reactions',
+  }),
+}));

--- a/.changeset/slow-schools-report.md
+++ b/.changeset/slow-schools-report.md
@@ -1,0 +1,6 @@
+---
+'@data-client/rest': minor
+'@rest-hooks/rest': minor
+---
+
+Remove createResource pagination field in favor of getList.paginated

--- a/docs/core/guides/storybook.md
+++ b/docs/core/guides/storybook.md
@@ -10,7 +10,7 @@ testing, potentially speeding up development time greatly.
 
 [&lt;MockResolver /\>](../api/MockResolver.md) enables easy loading of [fixtures or interceptors](../api/Fixtures.md) to see what
 different network responses might look like. It can be layered, composed, and even used
-for [imperative fetches](../api/Controller.md#fetch) usually used with side-effect endpoints like [create](/rest/api/createResource#create) and [update](/rest/api/createResource#update).
+for [imperative fetches](../api/Controller.md#fetch) usually used with side-effect endpoints like [getList.push](/rest/api/createResource#push) and [update](/rest/api/createResource#update).
 
 ## Setup
 

--- a/docs/core/shared/_VoteDemo.mdx
+++ b/docs/core/shared/_VoteDemo.mdx
@@ -1,11 +1,10 @@
 import { postFixtures } from '@site/src/fixtures/posts';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 
-
 <HooksPlayground fixtures={postFixtures} getInitialInterceptorData={() => ({votes: {}})} row>
 
 ```ts title="Post" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -23,20 +22,19 @@ export class Post extends Entity {
     return `//placekitten.com/96/72?image=${this.id % 16}`;
   }
 }
-export const Base = createResource({
-  path: '/posts/:id',
-  schema: Post,
-});
 ```
 
-```ts title="PostResource" {13-20}
-import { AbortOptimistic, RestEndpoint } from '@data-client/rest';
-import { Base, Post } from './Post';
+```ts title="PostResource" {16-23}
+import { RestEndpoint, createResource } from '@data-client/rest';
+import { AbortOptimistic } from '@data-client/rest';
+import { Post } from './Post';
 
 export { Post };
 
-export const PostResource = {
-  ...Base,
+export const PostResource = createResource({
+  path: '/posts/:id',
+  schema: Post,
+}).extend(Base => ({
   vote: new RestEndpoint({
     path: '/posts/:id/vote',
     method: 'POST',
@@ -51,7 +49,7 @@ export const PostResource = {
       };
     },
   }),
-};
+}));
 ```
 
 ```tsx title="PostItem" {7} collapsed

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -229,7 +229,7 @@ export default function NewArticleForm() {
 }
 ```
 
-[create](api/createResource.md#create) then takes any `keyable` body to send as the payload and then returns a promise that
+[getList.push](api/createResource.md#push) then takes any `keyable` body to send as the payload and then returns a promise that
 resolves to the new Resource created by the API. It will automatically be added in the cache for any consumers to display.
 
 </TabItem>

--- a/docs/rest/api/RestEndpoint.md
+++ b/docs/rest/api/RestEndpoint.md
@@ -757,42 +757,6 @@ const createUser = new RestEndpoint({
 });
 ```
 
-This is usage with a [createResource](./createResource.md)
-
-```typescript title="TodoResource.ts"
-import { Entity, createResource } from '@data-client/rest';
-
-export class Todo extends Entity {
-  readonly id: number = 0;
-  readonly userId: number = 0;
-  readonly title: string = '';
-  readonly completed: boolean = false;
-
-  pk() {
-    return `${this.id}`;
-  }
-}
-
-// We declare BaseTodoResource before TodoResource to prevent recursive type definitions
-const BaseTodoResource = createResource({
-  path: 'https://jsonplaceholder.typicode.com/todos/:id',
-  schema: Todo,
-});
-export const TodoResource = {
-  ...BaseTodoResource,
-  create: BaseTodoResource.create.extend({
-    // highlight-start
-    update: (newResourceId: string) => ({
-      [todoList.key({})]: (resourceIds: string[] = []) => [
-        ...resourceIds,
-        newResourceId,
-      ],
-    }),
-    // highlight-end
-  }),
-};
-```
-
 ## key(urlParams): string {#key}
 
 Serializes the parameters. This is used to build a lookup key in global stores.

--- a/docs/rest/guides/mocking-unfinished.md
+++ b/docs/rest/guides/mocking-unfinished.md
@@ -30,14 +30,11 @@ export class Rating extends Entity {
   };
 }
 
-const BaseRatingResource = createResource({
+export const RatingResource = createResource({
   path: '/ratings/:id',
   schema: Rating,
-});
-
-export const RatingResource = {
-  ...BaseRatingResource,
-  getList: BaseRatingResource.getList.extend({
+}).extend({
+  getList: {
     dataExpiryLength: 10 * 60 * 1000, // 10 minutes
     fetch() {
       return Promise.resolve(
@@ -49,8 +46,8 @@ export const RatingResource = {
         })),
       );
     },
-  }),
-};
+  },
+});
 ```
 
 ```tsx title="Demo.tsx" collapsed
@@ -62,8 +59,7 @@ function Demo() {
     <div>
       {ratings.map(rating => (
         <div key={rating.pk()}>
-          {rating.author}:{' '}
-          {rating.rating}{' '}
+          {rating.author}: {rating.rating}{' '}
           <time>
             {Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
               rating.date,

--- a/docs/rest/guides/partial-entities.md
+++ b/docs/rest/guides/partial-entities.md
@@ -96,16 +96,14 @@ export class Article extends ArticleSummary {
   }
 }
 
-const BaseArticleResource = createResource({
+export const ArticleResource = createResource({
   path: '/article/:id',
   schema: Article,
-});
-export const ArticleResource = {
-  ...BaseArticleResource,
-  getList: BaseArticleResource.getList.extend({
+}).extend({
+  getList: {
     schema: new schema.Collection([ArticleSummary]),
-  }),
-};
+  },
+});
 ```
 
 ```tsx title="ArticleDetail" collapsed
@@ -218,12 +216,10 @@ class ArticleMeta extends Entity {
   };
 }
 
-const BaseArticleResource = createResource({
+const ArticleResource = createResource({
   path: '/article/:id',
   schema: Article,
+}).extend({
+  getList: { schema: new schema.Collection([ArticleSummary]) },
 });
-const ArticleResource = {
-  ...BaseArticleResource,
-  getList: BaseArticleResource.getList.extend({ schema: [ArticleSummary] }),
-};
 ```

--- a/docs/rest/guides/rpc.md
+++ b/docs/rest/guides/rpc.md
@@ -40,31 +40,29 @@ To handle this, we just need to update the `schema` to include the custom
 endpoint.
 
 ```typescript title="api/TradeResource.ts"
-import { Resource } from '@data-client/rest';
+import { createResource } from '@data-client/rest';
 
-const BaseTradeResource = createResource({
+export const TradeResource = createResource({
   path: '/trade/:id',
   schema: Trade,
-});
-export const TradeResource = {
-  ...BaseTradeResource,
-  create: BaseTradeResource.create.extend({
+}).extend(Base => ({
+  create: Base.getList.push.extend({
     schema: {
-      trade: this,
-      account: AccountResource,
+      trade: Base.getList.push.schema,
+      account: Account,
     },
   }),
-};
+}));
 ```
 
-Now if when we use the [create](../api/createResource.md#create) Endpoint generator method,
+Now if when we use the [getList.push](../api/createResource.md#push) Endpoint generator method,
 we will be happy knowing both the trade and account information will
 be updated in the cache after the `POST` request is complete.
 
 ```typescript title="CreateTrade.tsx"
 export default function CreateTrade() {
   const ctrl = useController();
-  const create = payload => ctrl.fetch(TradeResource.getList.push, payload);
+  const handleSubmit = payload => ctrl.fetch(TradeResource.create, payload);
   //...
 }
 ```

--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -95,25 +95,18 @@ export function createGithubResource<O extends ResourceGenerics>(
   const baseResource = createResource({
     Endpoint: GithubEndpoint,
     ...options,
-    // this type compensates for a TypeScript bug with exactPropertyTypes
-  } as ResourceGenerics);
+  });
 
-  const getList: GetEndpoint<
-    Omit<O, 'schema' | 'path'> & {
-      readonly path: ShortenPath<O['path']>;
-      readonly schema: {
-        results: schema.Collection<O['schema'][]>;
-        link: string;
-      };
-    }
-  > = baseResource.getList.extend({
-    schema: { results: baseResource.getList.schema, link: '' },
+  return baseResource.extend({
+    getList: {
+      schema: {
+        results: baseResource.getList.schema as schema.Collection<
+          O['schema'][]
+        >,
+        link: '',
+      },
+    },
   }) as any;
-
-  return {
-    ...baseResource,
-    getList,
-  } as any;
 }
 
 export interface GithubResource<
@@ -122,7 +115,7 @@ export interface GithubResource<
     schema: Schema;
     paginationField: 'page';
   },
-> extends Omit<Resource<O>, 'getList' | 'getNextPage'> {
+> extends Omit<Resource<O>, 'getList'> {
   getList: GetEndpoint<
     Omit<O, 'schema' | 'path'> & {
       readonly path: ShortenPath<O['path']>;

--- a/examples/github-app/src/resources/Comment.ts
+++ b/examples/github-app/src/resources/Comment.ts
@@ -26,23 +26,14 @@ export class Comment extends GithubEntity {
     updatedAt: Date,
   };
 }
-const baseResource = createGithubResource({
+export const CommentResource = createGithubResource({
   path: '/repos/:owner/:repo/issues/comments/:id',
   schema: Comment,
+  optimistic: true,
+}).extend({
+  getList: {
+    path: '/repos/:owner/:repo/issues/:number/comments',
+    body: { body: '' },
+  },
 });
-const getList = baseResource.getList.extend({
-  path: '/repos/:owner/:repo/issues/:number/comments',
-  // body is 'comment body' aka the text content
-  body: { body: '' },
-});
-export const CommentResource = {
-  ...baseResource,
-  getList,
-  delete: baseResource.delete.extend({
-    getOptimisticResponse(snap, params) {
-      return params;
-    },
-  }),
-};
-
 export default CommentResource;

--- a/examples/github-app/src/resources/Event.tsx
+++ b/examples/github-app/src/resources/Event.tsx
@@ -79,7 +79,7 @@ export class IssuesEvent extends Event {
   };
 }
 
-const base = createGithubResource({
+export const EventResource = createGithubResource({
   path: '/users/:login/events/public/:id',
   schema: new schema.Union(
     {
@@ -97,13 +97,9 @@ const base = createGithubResource({
     'type',
   ),
   Endpoint: PreviewEndpoint,
+}).extend({
+  getList: { path: '/users/:login/events/public\\?per_page=50' },
 });
-export const EventResource = {
-  ...base,
-  getList: base.getList.extend({
-    path: '/users/:login/events/public\\?per_page=50',
-  }),
-};
 
 export const typeToIcon: Record<Event['type'], JSX.Element> = {
   PullRequestEvent: <PullRequestOutlined />,

--- a/examples/github-app/src/resources/Issue.tsx
+++ b/examples/github-app/src/resources/Issue.tsx
@@ -1,6 +1,4 @@
-import { RestGenerics } from '@data-client/rest';
-
-import { GithubEndpoint, GithubEntity, createGithubResource } from './Base';
+import { GithubEntity, createGithubResource } from './Base';
 import { Label } from './Label';
 import { stateToIcon } from './stateToIcon';
 import { User } from './User';
@@ -51,26 +49,25 @@ export class Issue extends GithubEntity {
   }
 }
 
-export const BaseIssueResource = createGithubResource({
+export const IssueResource = createGithubResource({
   path: '/repos/:owner/:repo/issues/:number',
   schema: Issue,
   pollFrequency: 60000,
   searchParams: {} as IssueFilters | undefined,
-});
-export const IssueResource = {
-  ...BaseIssueResource,
-  search: BaseIssueResource.getList.extend({
+}).extend((Base) => ({
+  search: Base.getList.extend({
     path: '/search/issues\\?q=:q?%20repo\\::owner/:repo&page=:page?',
     schema: {
       results: {
         incompleteResults: false,
-        items: BaseIssueResource.getList.schema.results,
+        items: Base.getList.schema.results,
         totalCount: 0,
       },
       link: '',
     },
   }),
-};
+}));
+
 export default IssueResource;
 
 export interface IssueFilters {

--- a/examples/github-app/src/resources/Reaction.tsx
+++ b/examples/github-app/src/resources/Reaction.tsx
@@ -23,18 +23,16 @@ export class Reaction extends GithubEntity {
   };
 }
 
-const base = createGithubResource({
+export const ReactionResource = createGithubResource({
   path: '/repos/:owner/:repo/issues/:number/reactions/:id',
   schema: Reaction,
   Endpoint: PreviewEndpoint,
   optimistic: true,
-});
-export const ReactionResource = {
-  ...base,
+}).extend((base) => ({
   getByComment: base.getList.extend({
     path: 'repos/:owner/:repo/issues/comments/:comment/reactions',
   }),
-};
+}));
 
 export default ReactionResource;
 

--- a/examples/github-app/src/resources/Repository.tsx
+++ b/examples/github-app/src/resources/Repository.tsx
@@ -61,12 +61,10 @@ export class GqlRepository extends Repository {
   }
 }
 
-const base = createGithubResource({
+export const RepositoryResource = createGithubResource({
   path: '/repos/:owner/:repo',
   schema: Repository,
-});
-export const RepositoryResource = {
-  ...base,
+}).extend((base) => ({
   getByUser: base.getList.extend({
     path: '/users/:login/repos',
   }),
@@ -92,5 +90,6 @@ export const RepositoryResource = {
   }`,
     { user: { pinnedItems: { nodes: [GqlRepository] } } },
   ),
-};
+}));
+
 export default RepositoryResource;

--- a/examples/github-app/src/resources/User.ts
+++ b/examples/github-app/src/resources/User.ts
@@ -45,12 +45,12 @@ export class User extends GithubEntity {
     return this.login;
   }
 }
-export const UserResource = {
-  ...createGithubResource({ path: '/users/:login', schema: User }),
-  current: new GithubEndpoint({
-    path: '/user',
-    schema: User,
-  }),
-};
+export const UserResource = createGithubResource({
+  path: '/users/:login',
+  schema: User,
+}).extend('current', {
+  path: '/user',
+  schema: User,
+});
 
 export default UserResource;

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -1,6 +1,5 @@
 import { Entity } from '@data-client/rest';
 import {
-  RestEndpoint,
   createResource,
   ResourceGenerics,
   ResourceOptions,
@@ -20,39 +19,35 @@ export abstract class PlaceholderEntity extends Entity {
 export function createPlaceholderResource<O extends ResourceGenerics = any>(
   options: Readonly<O> & ResourceOptions,
 ): Resource<O> {
-  const base = createResource({
+  return createResource({
     ...options,
     urlPrefix: 'https://jsonplaceholder.typicode.com',
     // hour expiry time since we want to keep our example mutations and the api itself never actually changes
     dataExpiryLength: 1000 * 60 * 60,
-  } as ResourceGenerics);
-  const partialUpdate = base.partialUpdate.extend({
-    process(response: any, ...args: any[]) {
-      // body only contains what we're changing, but we can find the id in params
-      return {
-        ...response,
-        id: args?.[0]?.id,
-      };
-    },
-  });
-  return {
-    ...base,
+  } as O).extend({
     // Endpoint overrides are to compensate for the jsonplaceholder API not returning
     // the correct ID in certain cases
     //
     // This is sometimes needed when you don't control the server API itself
     // More here: https://resthooks.io/docs/guides/network-transform#case-of-the-missing-id
-    partialUpdate,
-    getList: base.getList.extend({
+    partialUpdate: {
+      process(response: any, ...args: any[]) {
+        // body only contains what we're changing, but we can find the id in params
+        return {
+          ...response,
+          id: args?.[0]?.id,
+        };
+      },
+    },
+    getList: {
       process(response: any, ...args: any[]) {
         if (Array.isArray(response)) return response;
-        // placeholder's are stateless, so we need to replace with our fake id
+        // for POST (push/unshift)
         return {
           ...response,
           id: args?.[args.length - 1]?.id,
         };
       },
-    }),
-    // generics don't match up well
-  } as any;
+    },
+  }) as any;
 }

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -312,7 +312,7 @@ exports[`CacheProvider RestEndpoint/next should update on get for a paginated re
 }
 `;
 
-exports[`CacheProvider pagination should work with cursor field in createResource 1`] = `
+exports[`CacheProvider pagination should work with cursor field from getList.paginated 1`] = `
 [
   Article {
     "author": User {
@@ -722,7 +722,7 @@ exports[`ExternalCacheProvider RestEndpoint/next should update on get for a pagi
 }
 `;
 
-exports[`ExternalCacheProvider pagination should work with cursor field in createResource 1`] = `
+exports[`ExternalCacheProvider pagination should work with cursor field from getList.paginated 1`] = `
 [
   Article {
     "author": User {

--- a/packages/react/src/__tests__/integration-collections.tsx
+++ b/packages/react/src/__tests__/integration-collections.tsx
@@ -78,7 +78,6 @@ const ArticlePaginatedResource = createResource({
   path: '/article/:id',
   searchParams: {} as { userId?: number } | undefined,
   schema: Article,
-  paginationField: 'cursor',
 });
 
 const UnionResource = createResource({
@@ -197,7 +196,7 @@ describe.each([
     global.console.warn = prevWarn;
   });
 
-  it('pagination should work with cursor field in createResource', async () => {
+  it('pagination should work with cursor field from getList.paginated', async () => {
     const mynock = nock(/.*/).defaultReplyHeaders({
       'Access-Control-Allow-Origin': '*',
       'Content-Type': 'application/json',
@@ -224,10 +223,13 @@ describe.each([
     await waitForNextUpdate();
     expect(result.current.userArticles).toMatchSnapshot();
 
-    await controller.fetch(ArticlePaginatedResource.getNextPage, {
-      cursor: 2,
-      userId: 1,
-    });
+    await controller.fetch(
+      ArticlePaginatedResource.getList.paginated('cursor'),
+      {
+        cursor: 2,
+        userId: 1,
+      },
+    );
 
     expect(result.current.userArticles.map(({ id }) => id)).toEqual([
       5, 3, 7, 8,
@@ -239,21 +241,21 @@ describe.each([
     ]);
 
     () =>
-      controller.fetch(ArticlePaginatedResource.getNextPage, {
+      controller.fetch(ArticlePaginatedResource.getList.paginated('cursor'), {
         cursor: 2,
         userId: 1,
         // @ts-expect-error
         sdlkjfsd: 5,
       });
     () =>
-      controller.fetch(ArticlePaginatedResource.getNextPage, {
+      controller.fetch(ArticlePaginatedResource.getList.paginated('cursor'), {
         // @ts-expect-error
         sdf: 2,
         userId: 1,
       });
     () =>
       // @ts-expect-error
-      controller.fetch(ArticlePaginatedResource.getNextPage, {
+      controller.fetch(ArticlePaginatedResource.getList.paginated('cursor'), {
         userId: 1,
       });
 

--- a/packages/rest/src-4.1-types/resourceExtendable.d.ts
+++ b/packages/rest/src-4.1-types/resourceExtendable.d.ts
@@ -1,0 +1,21 @@
+import type { EndpointInterface, EndpointToFunction } from '@data-client/endpoint';
+import type { ResourcePath } from './pathTypes.js';
+import type { ResourceExtension, ResourceEndpointExtensions, CustomResource, ExtendedResource } from './resourceExtensionTypes.js';
+import type { ResourceGenerics, ResourceInterface } from './resourceTypes.js';
+import type { PartialRestGenerics, RestEndpointExtendOptions, RestExtendedEndpoint, RestInstanceBase } from './RestEndpoint.js';
+export interface Extendable<O extends ResourceGenerics = {
+    path: ResourcePath;
+    schema: any;
+}> {
+    extend<R extends {
+        [K in ExtendKey]: RestInstanceBase;
+    }, ExtendKey extends Exclude<Extract<keyof R, string>, 'extend'>, ExtendOptions extends PartialRestGenerics | {}>(this: R, key: ExtendKey, options: Readonly<RestEndpointExtendOptions<ExtendOptions, R[ExtendKey], EndpointToFunction<R[ExtendKey]>> & ExtendOptions>): ResourceExtension<R, ExtendKey, ExtendOptions>;
+    extend<R extends {
+        get: RestInstanceBase;
+    }, ExtendKey extends string, ExtendOptions extends PartialRestGenerics | {}>(this: R, key: ExtendKey, options: Readonly<RestEndpointExtendOptions<ExtendOptions, R['get'], EndpointToFunction<R['get']>> & ExtendOptions>): R & {
+        [key in ExtendKey]: RestExtendedEndpoint<ExtendOptions, R['get']>;
+    };
+    extend<R extends ResourceInterface, Get extends PartialRestGenerics = any, GetList extends PartialRestGenerics = any, Update extends PartialRestGenerics = any, PartialUpdate extends PartialRestGenerics = any, Delete extends PartialRestGenerics = any>(this: R, options: ResourceEndpointExtensions<R, Get, GetList, Update, PartialUpdate, Delete>): CustomResource<R, O, Get, GetList, Update, PartialUpdate, Delete>;
+    extend<R extends ResourceInterface, T extends Record<string, EndpointInterface>>(this: R, extender: (baseResource: R) => T): ExtendedResource<R, T>;
+}
+//# sourceMappingURL=resourceExtendable.d.ts.map

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -326,7 +326,7 @@ export type AddEndpoint<
   >,
   S,
   true,
-  O & { method: 'POST' }
+  Omit<O, 'method'> & { method: 'POST' }
 >;
 
 type OptionsBodyDefault<O extends RestGenerics> = 'body' extends keyof O

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -21,7 +21,7 @@ export type {
   PaginationEndpoint,
 } from './RestEndpoint.js';
 export { default as createResource } from './createResource.js';
-export type { Resource } from './createResource.js';
+export type { Resource } from './resourceTypes.js';
 export type { ResourceOptions, ResourceGenerics } from './resourceTypes.js';
 export { default as hookifyResource } from './hookifyResource.js';
 export type {

--- a/packages/rest/src/next/index.ts
+++ b/packages/rest/src/next/index.ts
@@ -1,5 +1,5 @@
 export * from '../RestEndpoint.js';
 export { default as RestEndpoint } from '../RestEndpoint.js';
 export { default as createResource } from '../createResource.js';
-export type { Resource } from '../createResource.js';
+export type { Resource } from '../resourceTypes.js';
 export type { ResourceOptions, ResourceGenerics } from '../resourceTypes.js';

--- a/packages/rest/src/resourceExtendable.ts
+++ b/packages/rest/src/resourceExtendable.ts
@@ -1,0 +1,95 @@
+import type {
+  EndpointInterface,
+  EndpointToFunction,
+} from '@data-client/endpoint';
+
+import type { ResourcePath } from './pathTypes.js';
+import type {
+  ResourceExtension,
+  ResourceEndpointExtensions,
+  CustomResource,
+  ExtendedResource,
+} from './resourceExtensionTypes.js';
+import type {
+  Resource,
+  ResourceGenerics,
+  ResourceInterface,
+} from './resourceTypes.js';
+import type {
+  PartialRestGenerics,
+  RestEndpointExtendOptions,
+  RestExtendedEndpoint,
+  RestInstanceBase,
+} from './RestEndpoint.js';
+
+export interface Extendable<
+  O extends ResourceGenerics = { path: ResourcePath; schema: any },
+> {
+  /** Allows customizing individual endpoints
+   *
+   * @see https://dataclient.io/rest/api/createResource#extend
+   */
+  extend<
+    R extends {
+      [K in ExtendKey]: RestInstanceBase;
+    },
+    const ExtendKey extends Exclude<Extract<keyof R, string>, 'extend'>,
+    // TODO: see RestEndpoint.extend TODO
+    ExtendOptions extends PartialRestGenerics | {},
+  >(
+    this: R,
+    key: ExtendKey,
+    options: Readonly<
+      RestEndpointExtendOptions<
+        ExtendOptions,
+        R[ExtendKey],
+        EndpointToFunction<R[ExtendKey]>
+      > &
+        ExtendOptions
+    >,
+  ): ResourceExtension<R, ExtendKey, ExtendOptions>;
+  extend<
+    R extends { get: RestInstanceBase },
+    const ExtendKey extends string,
+    // TODO: see RestEndpoint.extend TODO
+    ExtendOptions extends PartialRestGenerics | {},
+  >(
+    this: R,
+    key: ExtendKey,
+    options: Readonly<
+      RestEndpointExtendOptions<
+        ExtendOptions,
+        R['get'],
+        EndpointToFunction<R['get']>
+      > &
+        ExtendOptions
+    >,
+  ): R & {
+    [key in ExtendKey]: RestExtendedEndpoint<ExtendOptions, R['get']>;
+  };
+  extend<
+    R extends ResourceInterface,
+    Get extends PartialRestGenerics = any,
+    GetList extends PartialRestGenerics = any,
+    Update extends PartialRestGenerics = any,
+    PartialUpdate extends PartialRestGenerics = any,
+    Delete extends PartialRestGenerics = any,
+  >(
+    this: R,
+    options: ResourceEndpointExtensions<
+      R,
+      Get,
+      GetList,
+      Update,
+      PartialUpdate,
+      Delete
+    >,
+  ): CustomResource<R, O, Get, GetList, Update, PartialUpdate, Delete>;
+  extend<
+    R extends ResourceInterface,
+    T extends Record<string, EndpointInterface>,
+  >(
+    this: R,
+    extender: (baseResource: R) => T,
+  ): ExtendedResource<R, T>;
+}

--- a/packages/rest/src/resourceExtensionTypes.ts
+++ b/packages/rest/src/resourceExtensionTypes.ts
@@ -1,0 +1,109 @@
+import type {
+  EndpointInterface,
+  EndpointToFunction,
+} from '@data-client/endpoint';
+
+import { OptionsToFunction } from './OptionsToFunction.js';
+import type { ResourcePath } from './pathTypes.js';
+import { Extendable } from './resourceExtendable.js';
+import { ResourceGenerics, ResourceInterface } from './resourceTypes.js';
+import type {
+  PartialRestGenerics,
+  RestExtendedEndpoint,
+  RestInstanceBase,
+  RestEndpointOptions,
+} from './RestEndpoint.js';
+
+export type ResourceExtension<
+  R extends { [K in ExtendKey]: RestInstanceBase },
+  ExtendKey extends Exclude<Extract<keyof R, string>, 'extend'>,
+  O extends PartialRestGenerics | {},
+> = {
+  [K in keyof R]: K extends ExtendKey ? RestExtendedEndpoint<O, R[K]> : R[K];
+};
+
+/** Resource with individual endpoints customized
+ *
+ */
+export interface CustomResource<
+  R extends ResourceInterface,
+  O extends ResourceGenerics = { path: ResourcePath; schema: any },
+  Get extends PartialRestGenerics | {} = any,
+  GetList extends PartialRestGenerics | {} = any,
+  Update extends PartialRestGenerics | {} = any,
+  PartialUpdate extends PartialRestGenerics | {} = any,
+  Delete extends PartialRestGenerics | {} = any,
+> extends Extendable<O> {
+  // unknown only extends any. this allows us to match exclusively on members not set
+  get: unknown extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
+  getList: unknown extends GetList
+    ? R['getList']
+    : RestExtendedEndpoint<GetList, R['getList']>;
+  update: unknown extends Update
+    ? R['update']
+    : RestExtendedEndpoint<Update, R['update']>;
+  partialUpdate: unknown extends PartialUpdate
+    ? R['partialUpdate']
+    : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
+  delete: unknown extends Delete
+    ? R['delete']
+    : RestExtendedEndpoint<Delete, R['delete']>;
+}
+
+export type ExtendedResource<
+  R extends ResourceInterface,
+  T extends Record<string, EndpointInterface>,
+> = Omit<R, keyof T> & T;
+
+export interface ResourceEndpointExtensions<
+  R extends ResourceInterface,
+  Get extends PartialRestGenerics = any,
+  GetList extends PartialRestGenerics = any,
+  Update extends PartialRestGenerics = any,
+  PartialUpdate extends PartialRestGenerics = any,
+  Delete extends PartialRestGenerics = any,
+> {
+  readonly get?: RestEndpointOptions<
+    unknown extends Get
+      ? EndpointToFunction<R['get']>
+      : OptionsToFunction<Get, R['get'], EndpointToFunction<R['get']>>,
+    R['get']['schema']
+  > &
+    Readonly<Get>;
+  readonly getList?: RestEndpointOptions<
+    unknown extends GetList
+      ? EndpointToFunction<R['getList']>
+      : OptionsToFunction<
+          GetList,
+          R['getList'],
+          EndpointToFunction<R['getList']>
+        >,
+    R['getList']['schema']
+  > &
+    Readonly<GetList>;
+  readonly update?: RestEndpointOptions<
+    unknown extends Update
+      ? EndpointToFunction<R['update']>
+      : OptionsToFunction<Update, R['update'], EndpointToFunction<R['update']>>,
+    R['update']['schema']
+  > &
+    Readonly<Update>;
+  readonly partialUpdate?: RestEndpointOptions<
+    unknown extends PartialUpdate
+      ? EndpointToFunction<R['partialUpdate']>
+      : OptionsToFunction<
+          PartialUpdate,
+          R['partialUpdate'],
+          EndpointToFunction<R['partialUpdate']>
+        >,
+    R['partialUpdate']['schema']
+  > &
+    Readonly<PartialUpdate>;
+  readonly delete?: RestEndpointOptions<
+    unknown extends Delete
+      ? EndpointToFunction<R['delete']>
+      : OptionsToFunction<Delete, R['delete'], EndpointToFunction<R['delete']>>,
+    R['delete']['schema']
+  > &
+    Readonly<Delete>;
+}

--- a/packages/rest/src/resourceTypes.ts
+++ b/packages/rest/src/resourceTypes.ts
@@ -1,15 +1,22 @@
+import type { schema } from '@data-client/endpoint';
 import type { Schema } from '@data-client/endpoint';
+import type { Denormalize } from '@data-client/endpoint';
 
-import type { ResourcePath } from './pathTypes.js';
-import RestEndpoint from './RestEndpoint.js';
+import type { PathArgs, ResourcePath, ShortenPath } from './pathTypes.js';
+import { Extendable } from './resourceExtendable.js';
+import RestEndpoint, {
+  GetEndpoint,
+  MutateEndpoint,
+  RestInstanceBase,
+  RestTypeNoBody,
+} from './RestEndpoint.js';
 
+/** The typed (generic) options for a Resource */
 export interface ResourceGenerics {
   /** @see https://resthooks.io/rest/api/createResource#path */
   readonly path: ResourcePath;
   /** @see https://resthooks.io/rest/api/createResource#schema */
   readonly schema: Schema;
-  /** @see https://resthooks.io/rest/api/createResource#paginationfield */
-  readonly paginationField?: string;
   /** Only used for types */
   /** @see https://dataclient.io/rest/api/createResource#body */
   readonly body?: any;
@@ -17,6 +24,7 @@ export interface ResourceGenerics {
   /** @see https://resthooks.io/rest/api/createResource#searchParams */
   readonly searchParams?: any;
 }
+/** The untyped options for createResource() */
 export interface ResourceOptions {
   /** @see https://resthooks.io/rest/api/createResource#endpoint */
   Endpoint?: typeof RestEndpoint;
@@ -39,4 +47,111 @@ export interface ResourceOptions {
   readonly invalidIfStale?: boolean;
   /** Determines whether to throw or fallback to */
   errorPolicy?(error: any): 'hard' | 'soft' | undefined;
+}
+
+/** Resources are a collection of methods for a given data model.
+ * @see https://resthooks.io/rest/api/createResource
+ */
+export interface Resource<
+  O extends ResourceGenerics = { path: ResourcePath; schema: any },
+> extends Extendable<O> {
+  /** Get a singular item
+   *
+   * @see https://resthooks.io/rest/api/createResource#get
+   */
+  get: GetEndpoint<{ path: O['path']; schema: O['schema'] }>;
+  /** Get a list of item
+   *
+   * @see https://resthooks.io/rest/api/createResource#getlist
+   */
+  getList: 'searchParams' extends keyof O
+    ? GetEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: schema.Collection<[O['schema']]>;
+        body: 'body' extends keyof O
+          ? O['body']
+          : Partial<Denormalize<O['schema']>>;
+        searchParams: O['searchParams'];
+      }>
+    : GetEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: schema.Collection<[O['schema']]>;
+        body: 'body' extends keyof O
+          ? O['body']
+          : Partial<Denormalize<O['schema']>>;
+        searchParams: Record<string, number | string | boolean> | undefined;
+      }>;
+  /** Create a new item (POST)
+   *
+   * @deprecated use Resource.getList.push instead
+   */
+  create: 'searchParams' extends keyof O
+    ? MutateEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: schema.Collection<[O['schema']]>['push'];
+        body: 'body' extends keyof O
+          ? O['body']
+          : Partial<Denormalize<O['schema']>>;
+        searchParams: O['searchParams'];
+      }>
+    : MutateEndpoint<{
+        path: ShortenPath<O['path']>;
+        schema: schema.Collection<[O['schema']]>['push'];
+        body: 'body' extends keyof O
+          ? O['body']
+          : Partial<Denormalize<O['schema']>>;
+      }>;
+  /** Update an item (PUT)
+   *
+   * @see https://resthooks.io/rest/api/createResource#update
+   */
+  update: 'body' extends keyof O
+    ? MutateEndpoint<{
+        path: O['path'];
+        body: O['body'];
+        schema: O['schema'];
+      }>
+    : MutateEndpoint<{
+        path: O['path'];
+        body: Partial<Denormalize<O['schema']>>;
+        schema: O['schema'];
+      }>;
+  /** Update an item (PATCH)
+   *
+   * @see https://resthooks.io/rest/api/createResource#partialupdate
+   */
+  partialUpdate: 'body' extends keyof O
+    ? MutateEndpoint<{
+        path: O['path'];
+        body: Partial<O['body']>;
+        schema: O['schema'];
+      }>
+    : MutateEndpoint<{
+        path: O['path'];
+        body: Partial<Denormalize<O['schema']>>;
+        schema: O['schema'];
+      }>;
+  /** Delete an item (DELETE)
+   *
+   * @see https://resthooks.io/rest/api/createResource#delete
+   */
+  delete: RestTypeNoBody<
+    PathArgs<O['path']>,
+    O['schema'] extends schema.EntityInterface & { process: any }
+      ? schema.Invalidate<O['schema']>
+      : O['schema'],
+    undefined,
+    Partial<PathArgs<O['path']>>,
+    {
+      path: O['path'];
+    }
+  >;
+}
+
+export interface ResourceInterface {
+  get: RestInstanceBase;
+  getList: RestInstanceBase;
+  update: RestInstanceBase;
+  partialUpdate: RestInstanceBase;
+  delete: RestInstanceBase;
 }

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -1644,7 +1644,7 @@ type AddEndpoint<
   >,
   S,
   true,
-  O & { method: 'POST' }
+  Omit<O, 'method'> & { method: 'POST' }
 >;
 
 type OptionsToAdderBodyArgument<O extends { body?: any }> =
@@ -1930,13 +1930,59 @@ type MutateEndpoint<
   O & { body: any; method: 'POST' | 'PUT' | 'PATCH' | 'DELETE' }
 >;
 
+type ResourceExtension<R extends {
+    [K in ExtendKey]: RestInstanceBase;
+}, ExtendKey extends Exclude<Extract<keyof R, string>, 'extend'>, O extends PartialRestGenerics | {}> = {
+    [K in keyof R]: K extends ExtendKey ? RestExtendedEndpoint<O, R[K]> : R[K];
+};
+/** Resource with individual endpoints customized
+ *
+ */
+interface CustomResource<R extends ResourceInterface, O extends ResourceGenerics = {
+    path: ResourcePath;
+    schema: any;
+}, Get extends PartialRestGenerics | {} = any, GetList extends PartialRestGenerics | {} = any, Update extends PartialRestGenerics | {} = any, PartialUpdate extends PartialRestGenerics | {} = any, Delete extends PartialRestGenerics | {} = any> extends Extendable<O> {
+    get: unknown extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
+    getList: unknown extends GetList ? R['getList'] : RestExtendedEndpoint<GetList, R['getList']>;
+    update: unknown extends Update ? R['update'] : RestExtendedEndpoint<Update, R['update']>;
+    partialUpdate: unknown extends PartialUpdate ? R['partialUpdate'] : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
+    delete: unknown extends Delete ? R['delete'] : RestExtendedEndpoint<Delete, R['delete']>;
+}
+type ExtendedResource<R extends ResourceInterface, T extends Record<string, EndpointInterface>> = Omit<R, keyof T> & T;
+interface ResourceEndpointExtensions<R extends ResourceInterface, Get extends PartialRestGenerics = any, GetList extends PartialRestGenerics = any, Update extends PartialRestGenerics = any, PartialUpdate extends PartialRestGenerics = any, Delete extends PartialRestGenerics = any> {
+    readonly get?: RestEndpointOptions<unknown extends Get ? EndpointToFunction<R['get']> : OptionsToFunction<Get, R['get'], EndpointToFunction<R['get']>>, R['get']['schema']> & Readonly<Get>;
+    readonly getList?: RestEndpointOptions<unknown extends GetList ? EndpointToFunction<R['getList']> : OptionsToFunction<GetList, R['getList'], EndpointToFunction<R['getList']>>, R['getList']['schema']> & Readonly<GetList>;
+    readonly update?: RestEndpointOptions<unknown extends Update ? EndpointToFunction<R['update']> : OptionsToFunction<Update, R['update'], EndpointToFunction<R['update']>>, R['update']['schema']> & Readonly<Update>;
+    readonly partialUpdate?: RestEndpointOptions<unknown extends PartialUpdate ? EndpointToFunction<R['partialUpdate']> : OptionsToFunction<PartialUpdate, R['partialUpdate'], EndpointToFunction<R['partialUpdate']>>, R['partialUpdate']['schema']> & Readonly<PartialUpdate>;
+    readonly delete?: RestEndpointOptions<unknown extends Delete ? EndpointToFunction<R['delete']> : OptionsToFunction<Delete, R['delete'], EndpointToFunction<R['delete']>>, R['delete']['schema']> & Readonly<Delete>;
+}
+
+interface Extendable<O extends ResourceGenerics = {
+    path: ResourcePath;
+    schema: any;
+}> {
+    /** Allows customizing individual endpoints
+     *
+     * @see https://dataclient.io/rest/api/createResource#extend
+     */
+    extend<R extends {
+        [K in ExtendKey]: RestInstanceBase;
+    }, const ExtendKey extends Exclude<Extract<keyof R, string>, 'extend'>, ExtendOptions extends PartialRestGenerics | {}>(this: R, key: ExtendKey, options: Readonly<RestEndpointExtendOptions<ExtendOptions, R[ExtendKey], EndpointToFunction<R[ExtendKey]>> & ExtendOptions>): ResourceExtension<R, ExtendKey, ExtendOptions>;
+    extend<R extends {
+        get: RestInstanceBase;
+    }, const ExtendKey extends string, ExtendOptions extends PartialRestGenerics | {}>(this: R, key: ExtendKey, options: Readonly<RestEndpointExtendOptions<ExtendOptions, R['get'], EndpointToFunction<R['get']>> & ExtendOptions>): R & {
+        [key in ExtendKey]: RestExtendedEndpoint<ExtendOptions, R['get']>;
+    };
+    extend<R extends ResourceInterface, Get extends PartialRestGenerics = any, GetList extends PartialRestGenerics = any, Update extends PartialRestGenerics = any, PartialUpdate extends PartialRestGenerics = any, Delete extends PartialRestGenerics = any>(this: R, options: ResourceEndpointExtensions<R, Get, GetList, Update, PartialUpdate, Delete>): CustomResource<R, O, Get, GetList, Update, PartialUpdate, Delete>;
+    extend<R extends ResourceInterface, T extends Record<string, EndpointInterface>>(this: R, extender: (baseResource: R) => T): ExtendedResource<R, T>;
+}
+
+/** The typed (generic) options for a Resource */
 interface ResourceGenerics {
     /** @see https://resthooks.io/rest/api/createResource#path */
     readonly path: ResourcePath;
     /** @see https://resthooks.io/rest/api/createResource#schema */
     readonly schema: Schema;
-    /** @see https://resthooks.io/rest/api/createResource#paginationfield */
-    readonly paginationField?: string;
     /** Only used for types */
     /** @see https://dataclient.io/rest/api/createResource#body */
     readonly body?: any;
@@ -1944,6 +1990,7 @@ interface ResourceGenerics {
     /** @see https://resthooks.io/rest/api/createResource#searchParams */
     readonly searchParams?: any;
 }
+/** The untyped options for createResource() */
 interface ResourceOptions {
     /** @see https://resthooks.io/rest/api/createResource#endpoint */
     Endpoint?: typeof RestEndpoint;
@@ -1967,16 +2014,13 @@ interface ResourceOptions {
     /** Determines whether to throw or fallback to */
     errorPolicy?(error: any): 'hard' | 'soft' | undefined;
 }
-
-/** Creates collection of Endpoints for common operations on a given data/schema.
- *
+/** Resources are a collection of methods for a given data model.
  * @see https://resthooks.io/rest/api/createResource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 interface Resource<O extends ResourceGenerics = {
     path: ResourcePath;
     schema: any;
-}> {
+}> extends Extendable<O> {
     /** Get a singular item
      *
      * @see https://resthooks.io/rest/api/createResource#get
@@ -2000,22 +2044,9 @@ interface Resource<O extends ResourceGenerics = {
         body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
         searchParams: Record<string, number | string | boolean> | undefined;
     }>;
-    /** Get a list of item
-     *
-     * @see https://dataclient.io/rest/api/createResource#getNextPage
-     */
-    getNextPage: 'paginationField' extends keyof O ? PaginationFieldEndpoint<'searchParams' extends keyof O ? GetEndpoint<{
-        path: ShortenPath<O['path']>;
-        schema: Collection<[O['schema']]>;
-        searchParams: O['searchParams'];
-    }> : GetEndpoint<{
-        path: ShortenPath<O['path']>;
-        schema: Collection<[O['schema']]>;
-        searchParams: Record<string, number | string | boolean> | undefined;
-    }>, Exclude<O['paginationField'], undefined>> : undefined;
     /** Create a new item (POST)
      *
-     * @see https://resthooks.io/rest/api/createResource#create
+     * @deprecated use Resource.getList.push instead
      */
     create: 'searchParams' extends keyof O ? MutateEndpoint<{
         path: ShortenPath<O['path']>;
@@ -2063,6 +2094,19 @@ interface Resource<O extends ResourceGenerics = {
         path: O['path'];
     }>;
 }
+interface ResourceInterface {
+    get: RestInstanceBase;
+    getList: RestInstanceBase;
+    update: RestInstanceBase;
+    partialUpdate: RestInstanceBase;
+    delete: RestInstanceBase;
+}
+
+/** Creates collection of Endpoints for common operations on a given data/schema.
+ *
+ * @see https://resthooks.io/rest/api/createResource
+ */
+declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 
 interface HookableEndpointInterface extends EndpointInterface {
     extend(...args: any): HookableEndpointInterface;


### PR DESCRIPTION
Fixes https://github.com/data-client/rest-hooks/discussions/2446 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simpler resource construction

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`const` generics only works for one level. Due to this TypeScript cannot correctly infer types for each member of an argument - so we cannot have open-ended `Record<string, StrictlyTypedThing>`. This means the only way to correctly type something like `getOptimisticResponse` for an endpoint would be to add a generic member for each endpoint. This makes it not possible to type for adding. For modifying existing we would need to add one for each known member. This is not ideal for the base type as this forces users customizing to write every single generic type in their extension. However, if we add a member, we can pass this type on without requiring users to customize it. If TypeScripts abilities improve in the future, we can always add additional ways of doing things. For now, we want to focus on methodologies that infer types as effortlessly as possible.

Therefore, we add `Resource.extend()`.


#### Batch extension of known members

```ts
export const CommentResource = createResource({
  path: '/repos/:owner/:repo/issues/comments/:id',
  schema: Comment,
}).extend({
  getList: { path: '/repos/:owner/:repo/issues/:number/comments' },
  create: { body: { body: '' } },
});
```

#### Adding new members

```ts
export const UserResource = createGithubResource({
  path: '/users/:login',
  schema: User,
}).extend('current', {
  path: '/user',
  schema: User,
});
```

#### Function form (to get baseResource/super)

```ts
export const IssueResource= createResource({
  path: '/repos/:owner/:repo/issues/:number',
  schema: Issue,
  pollFrequency: 60000,
  searchParams: {} as IssueFilters | undefined,
}).extend(baseResource => ({
  search: baseResource.getList.extend({
    path: '/search/issues\\?q=:q?%20repo\\::owner/:repo&page=:page?',
    schema: {
      results: {
        incompleteResults: false,
        items: BaseIssueResource.getList.schema.results,
        totalCount: 0,
      },
      link: '',
    },
  })
)});
```

### Elimination of derived endpoints

We have already been working towards encouraging getList.push or getList.unshift to make it more clear what operation is being performed and easier to know how to change if necessary. Creating any derived endpoints like pagination or create, means we start caring about inheritance hierarchies. I did come up with some javascript that worked, I even spent way too much time building [typescript algorithms ](https://www.typescriptlang.org/play?#code/C4TwDgpgBA8mwEsD2A7AzlAvFA3lAThAIYAmqANiFGEcABYD8AXFGsPgigOYA0BxZFJSgAjJCRDMoRFCD6FSFKmgDGdCAFsiUmVQC+AWABQoSFABKENEgCu+FRACSKYBHwAzIg6wWIKpPgkADxsHNx8cIioaAB8UABkuADkAMRg+EjASGpEnEksvv6BIeycvFAAChlZAMJ0uShBkcjoMTF6ANzGptBVmUh1DU1x2DgKgsIA1hAgLKFl8gJKUEjwLWgs48swANoAuoZG3eDQAKIAHq4oJBAkp9dgSJzAQacRUBCXENcYzdEjsASsA0CBebyg0xASHcsBiXRMJygFyuNzuDyeLkGnFe70+KIwWyEVD+6H2AJgHy+PygO047jcUAAYgh8GxKfjYGtontjFA+VAGEiqaj7iRHs8cUyWWwYrz+SwKXjviQMLSUPT8FLWcB2crflz0HwAHQmukMyxspXUklofY8oz8gVClG3UXizH1bHI5Wu9ES8HM7UxPgW4Cyh3yqAoCAANzc8OOZm91wttnsECCcr55l11NTdgczlcHi8EB4WagAGkZrmVaxSuEK4rhfqouhjAD8+mAOqgujJ4IDrsOcxITJBcx8atyWFw4yJs7C4cQUfjnNWuvLotuTwOKc1jcYebhQGHzlt2I+HAVnaVqCcKszPYsAe+sUYl7mW97CLhvRAvBb3vFAhRUcgbBuIJIWhCx9xAGJnwsb8oH-RI8FSdJ+hyPIWC-DDqmyT0UCSPYUITBEzGXXt6AHCdawwLcXB3UsAWvCM+SAh9oJhPC0gI7DiL2RCABEQBQIgQRUWjJyQ-CsKIkjvz-IEYBBT8+G42S+PkhoSLnI4KOgUTxMk2iK3XFtCgCYJj3KG1gwrZFInoyoCKxRp7I7HxXzRd9nncicdic+AdiSSESJ-Z1IlC1YLz08j5wMsCiDQDAABU6DKXAKwQEgfCSJJ4UdMQJHywrjEOYxktSqAMrKAAmbL2PvPLsAKor+UQYByGgNryqMSrDKgABBK8Ky4CBgAAGQQNgWDwGh6BYJIAHobDQNw0BWpguAyGwwCSPhVHULQWDq7gUPLZqJuAAAhEAaiQDQNG+YB5sWuhlpWkQHqel6XG2-xntew7WDUTQiDOzLuD0K7HTkrIBPyJrHUdG77se4GXHmyEmCSG6ZrYUHYvWJgdhwD6vp+zH-uAQG-pBvQDg6vlDkOHooFu7ylysNMHCCYa+HxybCeAUG8GOiGoYalD9Kq6IdTEEQWFG7AAAZpAwXR4SVo10d+rHgCNSWtESjmah8W7Qv1mmQb2UKTaIEigA) that would allow computing this. But this would be an incredibly heavy effort and the computational complexity would also require possibly dropping older TypeScript version support. Again, this is the whole reason we moved to createResource() from a class based approach. We have to conceptually leave behind inheritance and focus on strict static definitions.

This means:

- Resource.create is marked as deprecated
- Use of any extends will remove `create` as this is conceptually unsupported
- We have added the remaining things to make getList.push just as type specific as create was in a previous release - so all docs are updated to use this instead.
  - In general we focus on adding definitions to the root endpoints to be used by derive. For instance, both `body` type and `getOptimisticResponse` from getList are unused for getList and only used in getList.push
- Resource.getNextPage is completely removed as it was only recently added. We might work on making paginationField a hidden part of getList so it can be extended without specifying the field name in each case. Not sure how this should work yet