### PR TITLE
enhance: Detect unusable pk when pk is serialized

### DIFF
--- a/.changeset/new-countries-approve.md
+++ b/.changeset/new-countries-approve.md
@@ -1,0 +1,10 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+'@rest-hooks/endpoint': patch
+'@rest-hooks/graphql': patch
+'@rest-hooks/rest': patch
+---
+
+Detect unusable pk when pk is serialized

--- a/docs/rest/api/schema.Entity.md
+++ b/docs/rest/api/schema.Entity.md
@@ -53,7 +53,7 @@ class UserEntity extends schema.Entity(User, {
 
 </TypeScriptEditor>
 
-### pk: string | (value, parent?, key?, args?) => string | undefined = 'id'
+### pk: string | (value, parent?, key?, args?) => string | undefined = 'id' {#pk}
 
 Specifies the [Entity.pk](./Entity.md#pk)
 
@@ -80,11 +80,11 @@ class ThreadEntity extends schema.Entity(Thread, {
 
 </TypeScriptEditor>
 
-### key: string
+### key: string  {#key}
 
 Specifies the [Entity.key](./Entity.md#key)
 
-### schema: \{[k:string]: Schema}
+### schema: \{[k:string]: Schema}  {#schema}
 
 Specifies the [Entity.schema](./Entity.md#schema)
 

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -253,7 +253,7 @@ export default function EntitySchema<TBase extends Constructor>(
     ): any {
       const processedEntity = this.process(input, parent, key);
       const id = this.pk(processedEntity, parent, key, args);
-      if (id === undefined || id === '') {
+      if (id === undefined || id === '' || id === 'undefined') {
         if (process.env.NODE_ENV !== 'production') {
           const error = new Error(
             `Missing usable primary key when normalizing response.
@@ -263,7 +263,7 @@ export default function EntitySchema<TBase extends Constructor>(
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
-  Entity: ${this.name}
+  Entity: ${this.key}
   Value (processed): ${
     processedEntity && JSON.stringify(processedEntity, null, 2)
   }

--- a/packages/endpoint/src/schemas/Invalidate.ts
+++ b/packages/endpoint/src/schemas/Invalidate.ts
@@ -47,7 +47,7 @@ export default class Invalidate<
 
     if (
       process.env.NODE_ENV !== 'production' &&
-      (id === undefined || id === '')
+      (id === undefined || id === '' || id === 'undefined')
     ) {
       const error = new Error(
         `Missing usable primary key when normalizing response.
@@ -57,8 +57,8 @@ export default class Invalidate<
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
 
-  Delete(Entity): Delete(${(this._entity as any).name ?? this._entity})
-  Value: ${input && JSON.stringify(input, null, 2)}
+  Invalidate(Entity): Invalidate(${this._entity.key})
+  Value (processed): ${input && JSON.stringify(input, null, 2)}
   `,
       );
       (error as any).status = 400;

--- a/packages/endpoint/src/schemas/__tests__/Delete.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Delete.test.ts
@@ -62,6 +62,20 @@ describe(`${schema.Delete.name} normalization`, () => {
     }
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
+
+  it('should throw a custom error if data does not include pk (serializes pk)', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return `${this.name}`;
+      }
+    }
+    function normalizeBad() {
+      normalize({ secondthing: 'hi' }, new schema.Delete(MyEntity));
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe(`${schema.Delete.name} denormalization`, () => {

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -125,6 +125,21 @@ describe(`${Entity.name} normalization`, () => {
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
 
+  it('should throw a custom error if data does not include pk (serializes pk)', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return `${this.name}`;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ secondthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
   it('should throw a custom error if schema key is missing from Entity', () => {
     class MyEntity extends Entity {
       readonly name: string = '';

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
@@ -198,6 +198,21 @@ exports[`Delete normalization normalizes an object 1`] = `
 }
 `;
 
+exports[`Delete normalization should throw a custom error if data does not include pk (serializes pk) 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+
+  Invalidate(Entity): Invalidate(MyEntity)
+  Value (processed): {
+  "secondthing": "hi"
+}
+  "
+`;
+
 exports[`Delete normalization should throw a custom error if data does not include pk 1`] = `
 "Missing usable primary key when normalizing response.
 
@@ -206,8 +221,8 @@ exports[`Delete normalization should throw a custom error if data does not inclu
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
 
-  Delete(Entity): Delete(MyEntity)
-  Value: {
+  Invalidate(Entity): Invalidate(MyEntity)
+  Value (processed): {
   "secondthing": "hi"
 }
   "

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
@@ -774,6 +774,21 @@ exports[`Entity normalization should only warn if at least four members are foun
 ]
 `;
 
+exports[`Entity normalization should throw a custom error if data does not include pk (serializes pk) 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
+
+  Entity: MyEntity
+  Value (processed): {
+  "secondthing": "hi"
+}
+  "
+`;
+
 exports[`Entity normalization should throw a custom error if data does not include pk 1`] = `
 "Missing usable primary key when normalizing response.
 

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
@@ -694,7 +694,7 @@ exports[`EntitySchema normalization should throw a custom error if data does not
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
-  Entity: EntityMixin
+  Entity: MyData
   Value (processed): {
   "secondthing": "hi"
 }
@@ -709,7 +709,7 @@ exports[`EntitySchema normalization should throw a custom error if data loads wi
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
-  Entity: EntityMixin
+  Entity: MyData
   Value (processed): {}
   "
 `;
@@ -747,7 +747,7 @@ exports[`EntitySchema normalization should throw a custom error loads with array
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about primary keys: https://resthooks.io/rest/api/Entity#pk
 
-  Entity: EntityMixin
+  Entity: MyData
   Value (processed): {
   "0": {
     "name": "hi",


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Handle case where users use template strings for [pk](https://dataclient.io/rest/api/Entity#pk)

```ts
class MyEntity extends Entity {
  id = 0;
  secondthing = '';
  pk() {
    return `${this.id}`;
  }
}
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Update pk check to `id === undefined || id === '' || id === 'undefined'`