### PR TITLE
enhance: Only warn about name mangling when using SSR and once

### DIFF
--- a/.changeset/tender-turtles-grin.md
+++ b/.changeset/tender-turtles-grin.md
@@ -1,0 +1,6 @@
+---
+'@data-client/endpoint': patch
+'@data-client/ssr': patch
+---
+
+Only warn about name mangling when using SSR and only once per type

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -94,17 +94,14 @@ export default class Endpoint extends Function {
   /* istanbul ignore next */
   static {
     /* istanbul ignore if */
-    if (test.name !== 'test') {
+    if (typeof document !== 'undefined' && document.FUNC_MANGLE) {
+      const baseKey = this.prototype.key;
       this.prototype.key = function (...args) {
-        console.error(
-          'Rest Hooks Error: https://resthooks.io/errors/osid',
-          this,
-        );
-        return `${this.name} ${JSON.stringify(args)}`;
+        document.FUNC_MANGLE?.(this);
+        this.prototype.key = baseKey;
+        return baseKey.call(this, ...args);
       };
     }
   }
 }
 export const ExtendableEndpoint = Endpoint;
-
-function test() {}

--- a/packages/ssr/src/getInitialData.ts
+++ b/packages/ssr/src/getInitialData.ts
@@ -28,5 +28,19 @@ function getDataFromEl(el: HTMLScriptElement, key: string) {
       `#${key} is completely empty. This could be due to CSP issues.`,
     );
   }
+  if (getInitialData.name !== 'getInitialData') {
+    (document as any).FUNC_MANGLE = function () {
+      console.error('Rest Hooks Error: https://resthooks.io/errors/osid', this);
+      delete (document as any).FUNC_MANGLE;
+    };
+  }
+  if (Test.name !== 'Test') {
+    (document as any).CLS_MANGLE = function () {
+      console.error('Rest Hooks Error: https://resthooks.io/errors/dklj', this);
+      delete (document as any).CLS_MANGLE;
+    };
+  }
   return el?.text ? JSON.parse(el?.text) : undefined;
 }
+
+class Test {}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Realistically name mangling only matters when doing hydration where keys are expected to be consistent. So it's just spam for other people.

Furthermore, previous methods would potentially spam the console more than once per type.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We indicate this is an issue to look for in the SSR library.

This will remain back compatible tho not warn if one package is outdated. This is fine because they would have been warned already had they not solved this.