### PR TITLE
enhance: Improve push/unshift/assign types

### DIFF
--- a/.changeset/eighty-ants-behave.md
+++ b/.changeset/eighty-ants-behave.md
@@ -1,0 +1,5 @@
+---
+'@data-client/endpoint': patch
+---
+
+Add EndpointToFunction type

--- a/.changeset/fair-countries-tell.md
+++ b/.changeset/fair-countries-tell.md
@@ -1,0 +1,6 @@
+---
+'@data-client/endpoint': patch
+'@data-client/rest': patch
+---
+
+scheam.push/unshift type denormalize to singular item (for now)

--- a/.changeset/kind-roses-join.md
+++ b/.changeset/kind-roses-join.md
@@ -1,0 +1,8 @@
+---
+'@data-client/endpoint': patch
+'@data-client/rest': patch
+'@rest-hooks/endpoint': patch
+'@rest-hooks/rest': patch
+---
+
+fix: Support Collections with boolean parameters

--- a/.changeset/lazy-queens-tan.md
+++ b/.changeset/lazy-queens-tan.md
@@ -1,0 +1,5 @@
+---
+'@data-client/rest': minor
+---
+
+push/unshift/assign inherit body type

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -417,6 +417,7 @@ export const TypedArticleResource = {
   }),
   anybody: TypedArticleResourceBase.get.extend({
     path: '/:id',
+    method: 'POST',
     body: 0 as any,
   }),
   noparams: TypedArticleResourceBase.getList,

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -375,7 +375,7 @@ const todos = useSuspense(TodoResource.getList);
 // mutate
 // POST https://jsonplaceholder.typicode.com/todos
 const ctrl = useController();
-ctrl.fetch(TodoResource.create, { title: 'my todo' });
+ctrl.fetch(TodoResource.getList.push, { title: 'my todo' });
 
 // PUT https://jsonplaceholder.typicode.com/todos/5
 const ctrl = useController();

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -56,7 +56,7 @@ function CreatePost() {
 
   return (
     <form
-      onSubmit={e => ctrl.fetch(PostResource.create, new FormData(e.target))}
+      onSubmit={e => ctrl.fetch(PostResource.getList.push, new FormData(e.target))}
     >
       {/* ... */}
     </form>
@@ -119,7 +119,7 @@ When using schemas, the denormalized value is returned
 // highlight-next-line
 import { useController } from '@data-client/react';
 
-const post = await controller.fetch(PostResource.create, createPayload);
+const post = await controller.fetch(PostResource.getList.push, createPayload);
 post.title;
 post.pk();
 ```

--- a/docs/core/api/useController.md
+++ b/docs/core/api/useController.md
@@ -54,7 +54,7 @@ when possible. This allows us to use any class members.
 ```ts
 import { useController } from '@data-client/react';
 
-const post = await controller.fetch(PostResource.create, createPayload);
+const post = await controller.fetch(PostResource.getList.push, createPayload);
 post.title;
 post.computedField
 post.pk();

--- a/docs/core/getting-started/data-dependency.md
+++ b/docs/core/getting-started/data-dependency.md
@@ -176,7 +176,7 @@ width="415" height="184"
 />
 </a>
 
-Do not prop drill. Instead, [useSuspense()](../api/useSuspense.md) in the components that render the data from it. This is
+Do not [prop drill](https://react.dev/learn/passing-data-deeply-with-context#the-problem-with-passing-props). Instead, [useSuspense()](../api/useSuspense.md) in the components that render the data from it. This is
 known as _data co-location_.
 
 Instead of writing complex update functions or invalidations cascades, Reactive Data Client automatically updates

--- a/docs/core/getting-started/mutations.md
+++ b/docs/core/getting-started/mutations.md
@@ -89,7 +89,7 @@ export default function CreateTodo({ userId }: { userId: number }) {
   const ctrl = useController();
   const handleKeyDown = async e => {
     if (e.key === 'Enter') {
-      ctrl.fetch(TodoResource.create, {
+      ctrl.fetch(TodoResource.getList.push, {
         id: randomId(),
         userId,
         title: e.currentTarget.value,
@@ -170,7 +170,7 @@ export default function PostCreate({ setId }) {
   const handleSubmit = data =>
     // highlight-next-line
     startTransition(async () => {
-      const post = await ctrl.fetch(PostResource.create, data);
+      const post = await ctrl.fetch(PostResource.getList.push, data);
       setId(post.id);
     });
   return <PostForm onSubmit={handleSubmit} loading={loading} error={error} />;

--- a/docs/core/shared/_useLoading.mdx
+++ b/docs/core/shared/_useLoading.mdx
@@ -96,7 +96,7 @@ export default function PostCreate({ navigateToPost }) {
   const ctrl = useController();
   const [handleSubmit, loading, error] = useLoading(
     async data => {
-      const post = await ctrl.fetch(PostResource.create, data);
+      const post = await ctrl.fetch(PostResource.getList.push, data);
       // React 17 does not batch updates
       // so we wait for the new post to be commited to the React
       // store to avoid additional fetches

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -219,7 +219,7 @@ export default function NewArticleForm() {
   const ctrl = useController();
   return (
     <Form
-      onSubmit={e => ctrl.fetch(ArticleResource.create, new FormData(e.target))}
+      onSubmit={e => ctrl.fetch(ArticleResource.getList.push, new FormData(e.target))}
     >
       <FormField name="title" />
       <FormField name="content" type="textarea" />

--- a/docs/rest/api/createResource.md
+++ b/docs/rest/api/createResource.md
@@ -37,7 +37,7 @@ const TodoResource = createResource({
 ```ts title="Resources start with 6 Endpoints"
 const todo = useSuspense(TodoResource.get, { id: '5' });
 const todos = useSuspense(TodoResource.getList);
-controller.fetch(TodoResource.create, {
+controller.fetch(TodoResource.getList.push, {
   title: 'finish installing reactive data client',
 });
 controller.fetch(

--- a/docs/rest/guides/optimistic-updates.md
+++ b/docs/rest/guides/optimistic-updates.md
@@ -151,7 +151,7 @@ import { ArticleResource } from 'api/Article';
 export default function CreateArticle() {
   const ctrl = useController();
   const submitHandler = useCallback(
-    data => ctrl.fetch(ArticleResource.create, data),
+    data => ctrl.fetch(ArticleResource.getList.push, data),
     [create],
   );
 

--- a/docs/rest/guides/rpc.md
+++ b/docs/rest/guides/rpc.md
@@ -64,7 +64,7 @@ be updated in the cache after the `POST` request is complete.
 ```typescript title="CreateTrade.tsx"
 export default function CreateTrade() {
   const ctrl = useController();
-  const create = payload => ctrl.fetch(TradeResource.create, payload);
+  const create = payload => ctrl.fetch(TradeResource.getList.push, payload);
   //...
 }
 ```

--- a/examples/github-app/src/pages/IssueDetail/CreateComment.tsx
+++ b/examples/github-app/src/pages/IssueDetail/CreateComment.tsx
@@ -43,7 +43,7 @@ function CreateForm({ issue }: { issue: Issue }) {
   const onFinish = useCallback(
     (data: { body: string }) => {
       return ctrl.fetch(
-        CommentResource.create,
+        CommentResource.getList.push,
         { owner: issue.owner, repo: issue.repo, number: issue.number },
         data,
       );

--- a/examples/github-app/src/pages/IssueDetail/CreateReaction.tsx
+++ b/examples/github-app/src/pages/IssueDetail/CreateReaction.tsx
@@ -17,7 +17,7 @@ export function CreateReaction({ content, reactions = [], issue }: Props) {
   const handleClick = () => {
     if (userReaction || !currentUser) return;
     ctrl.fetch(
-      ReactionResource.create,
+      ReactionResource.getList.push,
       {
         owner: issue.owner,
         number: issue.number,

--- a/examples/github-app/src/pages/IssueDetail/ReactionSpan.tsx
+++ b/examples/github-app/src/pages/IssueDetail/ReactionSpan.tsx
@@ -26,7 +26,7 @@ export function ReactionSpan({
       if (!currentUser) return;
       if (!userReaction) {
         ctrl.fetch(
-          ReactionResource.create,
+          ReactionResource.getList.push,
           {
             owner: issue.owner,
             number: issue.number,

--- a/examples/github-app/src/pages/NextPage.tsx
+++ b/examples/github-app/src/pages/NextPage.tsx
@@ -14,7 +14,7 @@ export default function NextPage({
   const ctrl = useController();
   const [count, setCount] = useState(0);
   const loadMore = () => {
-    ctrl.fetch(IssueResource.getNextPage, {
+    ctrl.fetch(IssueResource.getList.paginated('page'), {
       page: page + count + 1,
       repo,
       owner,

--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -99,7 +99,7 @@ export function createGithubResource<O extends ResourceGenerics>(
   } as ResourceGenerics);
 
   const getList: GetEndpoint<
-    Omit<O, 'schema' | 'body' | 'path'> & {
+    Omit<O, 'schema' | 'path'> & {
       readonly path: ShortenPath<O['path']>;
       readonly schema: {
         results: schema.Collection<O['schema'][]>;
@@ -109,12 +109,10 @@ export function createGithubResource<O extends ResourceGenerics>(
   > = baseResource.getList.extend({
     schema: { results: baseResource.getList.schema, link: '' },
   }) as any;
-  const getNextPage = getList.paginated('page');
 
   return {
     ...baseResource,
     getList,
-    getNextPage,
   } as any;
 }
 
@@ -126,25 +124,13 @@ export interface GithubResource<
   },
 > extends Omit<Resource<O>, 'getList' | 'getNextPage'> {
   getList: GetEndpoint<
-    Omit<O, 'schema' | 'body' | 'path'> & {
+    Omit<O, 'schema' | 'path'> & {
       readonly path: ShortenPath<O['path']>;
       readonly schema: {
         results: schema.Collection<O['schema'][]>;
         link: string;
       };
     }
-  >;
-  getNextPage: PaginationFieldEndpoint<
-    GetEndpoint<
-      Omit<O, 'body' | 'schema' | 'path'> & {
-        readonly path: ShortenPath<O['path']>;
-        readonly schema: {
-          results: schema.Collection<O['schema'][]>;
-          link: string;
-        };
-      }
-    >,
-    'page'
   >;
 }
 

--- a/examples/github-app/src/resources/Comment.ts
+++ b/examples/github-app/src/resources/Comment.ts
@@ -5,7 +5,7 @@ export class Comment extends GithubEntity {
   readonly issueUrl: string = '';
   readonly htmlUrl: string = '';
   readonly body: string = '';
-  readonly user: User = User.fromJS({});
+  readonly user: User = User.fromJS();
   readonly createdAt: Date = new Date(0);
   readonly updatedAt: Date = new Date(0);
   readonly authorAssociation: string = 'NONE';
@@ -32,16 +32,12 @@ const baseResource = createGithubResource({
 });
 const getList = baseResource.getList.extend({
   path: '/repos/:owner/:repo/issues/:number/comments',
-});
-const create = baseResource.create.extend({
-  path: '/repos/:owner/:repo/issues/:number/comments',
   // body is 'comment body' aka the text content
   body: { body: '' },
 });
 export const CommentResource = {
   ...baseResource,
   getList,
-  create,
   delete: baseResource.delete.extend({
     getOptimisticResponse(snap, params) {
       return params;

--- a/examples/github-app/src/resources/Reaction.tsx
+++ b/examples/github-app/src/resources/Reaction.tsx
@@ -5,7 +5,7 @@ import PreviewEndpoint from './PreviewEndpoint';
 import { User } from './User';
 
 export class Reaction extends GithubEntity {
-  readonly user: User = User.fromJS({});
+  readonly user: User = User.fromJS();
   readonly content: ReactionType = '+1';
   readonly createdAt: Date = new Date(0);
 

--- a/examples/github-app/typetest.ts
+++ b/examples/github-app/typetest.ts
@@ -40,7 +40,7 @@ function useTest() {
     );
 
     ctrl.fetch(
-      CommentResource.create,
+      CommentResource.getList.push,
       { owner: issue.owner, repo: issue.repo, number: issue.number },
       { body: 'hi' },
     );
@@ -58,7 +58,7 @@ function useTest() {
     if (!currentUser) return;
     if (!userReaction) {
       ctrl.fetch(
-        ReactionResource.create,
+        ReactionResource.getList.push,
         {
           owner: issue.owner,
           number: issue.number,

--- a/examples/todo-app/src/pages/Home/NewTodo.tsx
+++ b/examples/todo-app/src/pages/Home/NewTodo.tsx
@@ -14,7 +14,7 @@ function NewTodo({ userId }: { userId?: number }) {
   const handlePress = useCallback(
     async (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
-        ctrl.fetch(TodoResource.create, {
+        ctrl.fetch(TodoResource.getList.push, {
           ...payload.current,
           title: e.currentTarget.value,
         });

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -43,8 +43,9 @@ export function createPlaceholderResource<O extends ResourceGenerics = any>(
     // This is sometimes needed when you don't control the server API itself
     // More here: https://resthooks.io/docs/guides/network-transform#case-of-the-missing-id
     partialUpdate,
-    create: base.create.extend({
+    getList: base.getList.extend({
       process(response: any, ...args: any[]) {
+        if (Array.isArray(response)) return response;
         // placeholder's are stateless, so we need to replace with our fake id
         return {
           ...response,

--- a/examples/todo-app/typetest.ts
+++ b/examples/todo-app/typetest.ts
@@ -9,7 +9,7 @@ import { UserResource } from './src/resources/UserResource';
 function useTest() {
   const ctrl = useController();
   const payload = { id: 1, title: '', userId: 1 };
-  ctrl.fetch(TodoResource.create, payload);
+  ctrl.fetch(TodoResource.getList.push, payload);
 
   const todos = useSuspense(TodoResource.getList, { userId: 1 });
   useSuspense(TodoResource.getList);

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -44,6 +44,7 @@ export type {
   NetworkError,
   UnknownError,
   ErrorTypes,
+  EndpointToFunction,
 } from './types.js';
 
 export { default as Endpoint, ExtendableEndpoint } from './endpoint.js';

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -349,6 +349,16 @@ export class Values<Choices extends Schema = any> implements SchemaClass {
   ): any;
 }
 
+export type CollectionArrayAdder<S extends PolymorphicInterface> = S extends {
+  // ensure we are an array type
+  denormalizeOnly(...args: any): any[];
+  // get what we are an array of
+  schema: infer T;
+}
+  ? // TODO: eventually we want to allow singular or list and infer the return based on arguments
+    T
+  : never;
+
 export class CollectionInterface<
   S extends PolymorphicInterface = any,
   Parent extends any[] = any,
@@ -442,16 +452,12 @@ export class CollectionInterface<
   /** Schema to place at the *end* of this Collection
    * @see https://resthooks.io/rest/api/Collection#push
    */
-  push: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? schema.Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  push: CollectionArrayAdder<S>;
 
   /** Schema to place at the *beginning* of this Collection
    * @see https://resthooks.io/rest/api/Collection#unshift
    */
-  unshift: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? schema.Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  unshift: CollectionArrayAdder<S>;
 
   /** Schema to merge with a Values Collection
    * @see https://resthooks.io/rest/api/Collection#assign

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -237,9 +237,9 @@ const defaultFilter =
     Object.entries(collectionKey).every(
       ([key, value]) =>
         key.startsWith('order') ||
-        // double equals lets us compare non-strings and strings
-        urlParams[key] == value ||
-        body?.[key] == value,
+        // strings are canonical form. See pk() above for value transformation
+        `${urlParams[key]}` === value ||
+        `${body?.[key]}` === value,
     );
 
 function CreateAdder<C extends CollectionSchema<any, any>, P extends any[]>(

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -364,7 +364,7 @@ describe(`${schema.Collection.name} denormalization`, () => {
       expect(todos).toBeDefined();
       expect(todos).not.toEqual(expect.any(Symbol));
       if (typeof todos === 'symbol' || !todos) return;
-      expect(todos[0].title).toBe('from the start');
+      //expect(todos[0].title).toBe('from the start'); TODO: once we get types based on parameters sent
       expect(todos).toMatchInlineSnapshot(`
         [
           Todo {
@@ -389,7 +389,7 @@ describe(`${schema.Collection.name} denormalization`, () => {
       expect(todos).toBeDefined();
       expect(todos).not.toEqual(expect.any(Symbol));
       if (typeof todos === 'symbol' || !todos) return;
-      //expect(todos.title).toBe('from the start');
+      expect(todos.title).toBe('from the start');
       expect(todos).toMatchInlineSnapshot(`
         Todo {
           "completed": false,

--- a/packages/endpoint/src/utility.ts
+++ b/packages/endpoint/src/utility.ts
@@ -25,3 +25,8 @@ export type PartialParameters<T extends (...args: any[]) => any> = T extends (
 ) => any
   ? Partial<P>
   : never;
+
+export type EndpointToFunction<E extends (...args: any) => Promise<any>> = (
+  this: E,
+  ...args: Parameters<E>
+) => ReturnType<E>;

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -50,13 +50,13 @@ exports[`CacheProvider RestEndpoint/current should update collection on push/uns
   "todos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
     Todo {
       "completed": false,
-      "id": 3,
+      "id": "3",
       "title": "ssdf",
       "userId": "2",
     },
@@ -68,7 +68,7 @@ exports[`CacheProvider RestEndpoint/current should update collection on push/uns
     "todos": [
       Todo {
         "completed": false,
-        "id": 5,
+        "id": "5",
         "title": "do things",
         "userId": "1",
       },
@@ -78,7 +78,7 @@ exports[`CacheProvider RestEndpoint/current should update collection on push/uns
   "userTodos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
@@ -206,13 +206,13 @@ exports[`CacheProvider RestEndpoint/next should update collection on push/unshif
   "todos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
     Todo {
       "completed": false,
-      "id": 3,
+      "id": "3",
       "title": "ssdf",
       "userId": "2",
     },
@@ -224,7 +224,7 @@ exports[`CacheProvider RestEndpoint/next should update collection on push/unshif
     "todos": [
       Todo {
         "completed": false,
-        "id": 5,
+        "id": "5",
         "title": "do things",
         "userId": "1",
       },
@@ -234,7 +234,7 @@ exports[`CacheProvider RestEndpoint/next should update collection on push/unshif
   "userTodos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
@@ -403,7 +403,7 @@ exports[`CacheProvider should work with unions 2`] = `
   },
   SecondUnion {
     "body": "hi",
-    "id": 100,
+    "id": "100",
     "secondeOnlyField": 10,
     "type": "second",
   },
@@ -460,13 +460,13 @@ exports[`ExternalCacheProvider RestEndpoint/current should update collection on 
   "todos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
     Todo {
       "completed": false,
-      "id": 3,
+      "id": "3",
       "title": "ssdf",
       "userId": "2",
     },
@@ -478,7 +478,7 @@ exports[`ExternalCacheProvider RestEndpoint/current should update collection on 
     "todos": [
       Todo {
         "completed": false,
-        "id": 5,
+        "id": "5",
         "title": "do things",
         "userId": "1",
       },
@@ -488,7 +488,7 @@ exports[`ExternalCacheProvider RestEndpoint/current should update collection on 
   "userTodos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
@@ -616,13 +616,13 @@ exports[`ExternalCacheProvider RestEndpoint/next should update collection on pus
   "todos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
     Todo {
       "completed": false,
-      "id": 3,
+      "id": "3",
       "title": "ssdf",
       "userId": "2",
     },
@@ -634,7 +634,7 @@ exports[`ExternalCacheProvider RestEndpoint/next should update collection on pus
     "todos": [
       Todo {
         "completed": false,
-        "id": 5,
+        "id": "5",
         "title": "do things",
         "userId": "1",
       },
@@ -644,7 +644,7 @@ exports[`ExternalCacheProvider RestEndpoint/next should update collection on pus
   "userTodos": [
     Todo {
       "completed": false,
-      "id": 5,
+      "id": "5",
       "title": "do things",
       "userId": "1",
     },
@@ -813,7 +813,7 @@ exports[`ExternalCacheProvider should work with unions 2`] = `
   },
   SecondUnion {
     "body": "hi",
-    "id": 100,
+    "id": "100",
     "secondeOnlyField": 10,
     "type": "second",
   },

--- a/packages/react/src/__tests__/integration-collections.tsx
+++ b/packages/react/src/__tests__/integration-collections.tsx
@@ -189,7 +189,7 @@ describe.each([
       await controller.fetch(UnionResource.getList.push, {
         body: 'hi',
         type: 'second',
-        id: 100,
+        id: '100',
       });
     });
     expect(result.current[3]).toBeInstanceOf(SecondUnion);
@@ -278,15 +278,15 @@ describe.each([
           .reply(200, {
             id: '1',
             username: 'bob',
-            todos: [{ id: 5, title: 'do things', userId: '1' }],
+            todos: [{ id: '5', title: 'do things', userId: '1' }],
           })
           .get(`/todos`)
           .reply(200, [
-            { id: 5, title: 'do things', userId: '1' },
-            { id: 3, title: 'ssdf', userId: '2' },
+            { id: '5', title: 'do things', userId: '1' },
+            { id: '3', title: 'ssdf', userId: '2' },
           ])
           .get(`/todos?userId=1`)
-          .reply(200, [{ id: 5, title: 'do things', userId: '1' }])
+          .reply(200, [{ id: '5', title: 'do things', userId: '1' }])
           .post(`/todos`)
           .reply(200, (uri, body: any) => ({ ...body }))
           .post(`/todos?userId=5`)
@@ -322,14 +322,18 @@ describe.each([
             TodoResource.getList.push,
             { userId: '5' },
             {
-              id: 1,
+              id: '1',
               title: 'push',
-              userId: '5',
+              userId: 5,
             },
           );
         });
-        expect(result.current.userTodos.map(({ id }) => id)).toEqual([5]);
-        expect(result.current.todos.map(({ id }) => id)).toEqual([5, 3, 1]);
+        expect(result.current.userTodos.map(({ id }) => id)).toEqual(['5']);
+        expect(result.current.todos.map(({ id }) => id)).toEqual([
+          '5',
+          '3',
+          '1',
+        ]);
         expect(result.current.user.todos).toBe(result.current.userTodos);
         // userTodos didn't change so should maintain referential equality
         expect(result.current.userTodos).toBe(firstUserTodos);
@@ -340,14 +344,22 @@ describe.each([
             TodoResource.getList.unshift,
             { userId: '1' },
             {
-              id: 55,
+              id: '55',
               title: 'unshift',
             },
           );
         });
         // this adds to both the base todo list, the one with userId filter, and the nested todo list inside user object
-        expect(result.current.todos.map(({ id }) => id)).toEqual([55, 5, 3, 1]);
-        expect(result.current.userTodos.map(({ id }) => id)).toEqual([55, 5]);
+        expect(result.current.todos.map(({ id }) => id)).toEqual([
+          '55',
+          '5',
+          '3',
+          '1',
+        ]);
+        expect(result.current.userTodos.map(({ id }) => id)).toEqual([
+          '55',
+          '5',
+        ]);
         expect(result.current.user.todos).toBe(result.current.userTodos);
 
         // type checks
@@ -358,7 +370,7 @@ describe.each([
             // @ts-expect-error
             { sdf: '1' },
             {
-              id: 55,
+              id: '55',
               title: 'unshift',
             },
           );
@@ -369,7 +381,7 @@ describe.each([
             // @ts-expect-error
             5,
             {
-              id: 55,
+              id: '55',
               title: 'unshift',
             },
           );

--- a/packages/rest/.gitignore
+++ b/packages/rest/.gitignore
@@ -3,4 +3,5 @@
 /legacy
 /index.d.ts
 /next.d.ts
+/ts4.0
 /ts4.1

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -44,7 +44,7 @@
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
   "typesVersions": {
-    ">=4.1": {
+    ">=5.0": {
       "": [
         "lib/index.d.ts"
       ],
@@ -53,6 +53,17 @@
       ],
       "*": [
         "lib/index.d.ts"
+      ]
+    },
+    ">=4.1": {
+      "": [
+        "ts4.1/index.d.ts"
+      ],
+      "next": [
+        "ts4.1/next/index.d.ts"
+      ],
+      "*": [
+        "ts4.1/index.d.ts"
       ]
     },
     ">=4.0": {
@@ -92,6 +103,7 @@
     "node.mjs",
     "legacy",
     "ts4.0",
+    "ts4.1",
     "LICENSE",
     "README.md"
   ],
@@ -101,8 +113,8 @@
     "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
     "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
     "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "yarn g:clean ts4.0 index.d.ts next.d.ts",
-    "build:legacy-types": "yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0",
+    "build:clean": "yarn g:clean ts4.0 ts4.1 index.d.ts next.d.ts",
+    "build:legacy-types": "yarn g:downtypes lib ts4.0 --to=4.0 && yarn g:downtypes lib ts4.1 --to=4.1 && yarn g:copy --up 1 ./src-4.1-types/**/*.d.ts ./ts4.0/ && yarn g:copy --up 1 ./src-4.1-types/**/*.d.ts ./ts4.1 && yarn g:copy --up 1 ./src-4.0-types/**/*.d.ts ./ts4.0",
     "build": "run build:lib && run build:legacy:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",

--- a/packages/rest/src-4.0-types/OptionsToFunction.d.ts
+++ b/packages/rest/src-4.0-types/OptionsToFunction.d.ts
@@ -1,12 +1,10 @@
 import type { FetchFunction, ResolveType } from '@data-client/endpoint';
 
-import { PartialRestGenerics, RestInstance } from './RestEndpoint.js';
+import { PartialRestGenerics } from './RestEndpoint.js';
 
 export type OptionsToFunction<
   O extends PartialRestGenerics,
-  E extends RestInstance & {
-    body?: any;
-  },
+  E extends { body?: any; path?: string; method?: string },
   F extends FetchFunction,
 > = (
   this: ThisParameterType<F>,
@@ -14,3 +12,8 @@ export type OptionsToFunction<
 ) => Promise<
   O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>
 >;
+
+export type OptionsToBodyArgument<
+  O extends { body?: any },
+  Method extends string | undefined,
+> = any;

--- a/packages/rest/src-4.0-types/extractObject.d.ts
+++ b/packages/rest/src-4.0-types/extractObject.d.ts
@@ -1,0 +1,1 @@
+export type ExtractObject<S extends Record<string, any>> = any;

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -164,6 +164,7 @@ describe('RestEndpoint', () => {
     const epbody = new RestEndpoint({
       path: '/users/:id?/:group?',
       body: { title: '' },
+      method: 'POST',
     });
     () => ep();
     () => ep({ id: 5 });
@@ -483,6 +484,11 @@ describe('RestEndpoint', () => {
         body: 5,
         path: 'http\\://test.com/charmer/:charm',
       });
+      () => {
+        // test type widening
+        const second = updateUser.extend({ body: { body: '' } });
+        second({ charm: 5 }, { body: 'hi' });
+      };
       const response = await updateUser(
         { charm: 5 },
         // @ts-expect-error
@@ -736,6 +742,7 @@ describe('RestEndpoint', () => {
         .extend({
           body: {} as { title: string },
           dataExpiryLength: 0,
+          method: 'POST',
         })
         .extend({ dataExpiryLength: 5 });
       () => newBody({ group: 'hi', id: 'what' }, { title: 'cool' });
@@ -864,10 +871,12 @@ describe('RestEndpoint', () => {
     const endpoint = new RestEndpoint({
       sideEffect: true,
       path: 'http\\://test.com/article-cooler',
-      body: 0 as any,
       schema: CoolerArticle,
     }).extend({ name: 'createarticle' });
+    const a: true = endpoint.sideEffect;
+    const b: 'POST' = endpoint.method;
     expect(endpoint.method).toBe('POST');
+    expect(endpoint.sideEffect).toBe(true);
     const article = await endpoint(payload);
     expect(article).toMatchInlineSnapshot(`
       {

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -436,15 +436,19 @@ it('should handle more open ended type definitions', () => {
     });
 
     unknownParams({ hi: 5 });
+    unknownParams();
+    // @ts-expect-error
+    unknownParams(5);
 
     const explicit: GetEndpoint<{
       path: `${string}:${string}`;
-      schema: typeof User;
+      schema: schema.Collection<[typeof User]>;
     }> = new RestEndpoint({
       path: '' as `${string}:${string}`,
-      schema: User,
+      schema: new schema.Collection([User]),
     });
     explicit({ hi: 5 });
     explicit.push.process({} as any, { hi: 5 });
+    explicit.push();
   };
 });

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -124,11 +124,17 @@ export interface Resource<
     ? GetEndpoint<{
         path: ShortenPath<O['path']>;
         schema: schema.Collection<[O['schema']]>;
+        body: 'body' extends keyof O
+          ? O['body']
+          : Partial<Denormalize<O['schema']>>;
         searchParams: O['searchParams'];
       }>
     : GetEndpoint<{
         path: ShortenPath<O['path']>;
         schema: schema.Collection<[O['schema']]>;
+        body: 'body' extends keyof O
+          ? O['body']
+          : Partial<Denormalize<O['schema']>>;
         searchParams: Record<string, number | string | boolean> | undefined;
       }>;
   /** Get a list of item

--- a/packages/rest/src/extractCollection.ts
+++ b/packages/rest/src/extractCollection.ts
@@ -1,5 +1,7 @@
 import { Schema, schema } from '@data-client/endpoint';
 
+import { ExtractObject } from './extractObject.js';
+
 export default function extractCollection<
   M extends <C extends schema.Collection>(collection: C) => any,
   S extends Schema | undefined,
@@ -18,17 +20,17 @@ export default function extractCollection<
   }
 }
 
-export type ExtractCollection<S extends Schema | undefined> =
-  S extends schema.CollectionInterface
-    ? S
-    : S extends schema.Object<infer T>
-    ? ExtractObject<T>
-    : S extends Exclude<Schema, { [K: string]: any }>
-    ? never
-    : S extends { [K: string]: Schema }
-    ? ExtractObject<S>
-    : never;
-
-export type ExtractObject<S extends Record<string, any>> = {
-  [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
-}[keyof S];
+export type ExtractCollection<S extends Schema | undefined> = S extends {
+  push: any;
+  unshift: any;
+  assign: any;
+  schema: Schema;
+}
+  ? S
+  : S extends schema.Object<infer T>
+  ? ExtractObject<T>
+  : S extends Exclude<Schema, { [K: string]: any }>
+  ? never
+  : S extends { [K: string]: Schema }
+  ? ExtractObject<S>
+  : never;

--- a/packages/rest/src/extractObject.ts
+++ b/packages/rest/src/extractObject.ts
@@ -1,0 +1,7 @@
+import { Schema } from '@data-client/endpoint';
+
+import { ExtractCollection } from './extractCollection.js';
+
+export type ExtractObject<S extends Record<string, any>> = {
+  [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
+}[keyof S];

--- a/website/src/components/Demo/code/posts-app/rest/NewPost.tsx
+++ b/website/src/components/Demo/code/posts-app/rest/NewPost.tsx
@@ -13,7 +13,7 @@ export default function NewPost({ userId }: { userId: number }) {
         type="text"
         onKeyDown={async e => {
           if (e.key === 'Enter') {
-            controller.fetch(PostResource.create, {
+            controller.fetch(PostResource.getList.push, {
               id: randomId(),
               userId,
               title: e.currentTarget.value,

--- a/website/src/components/Demo/code/posts-app/rest/index.ts
+++ b/website/src/components/Demo/code/posts-app/rest/index.ts
@@ -51,10 +51,10 @@ export default {
       },
     },
     {
-      endpoint: PostResource.create,
+      endpoint: PostResource.getList.push,
       async response(...args: any) {
         return {
-          ...(await PostResource.create(...args)),
+          ...(await PostResource.getList.push(...args)),
           id: args?.[args.length - 1]?.id,
         };
       },

--- a/website/src/components/Demo/code/profile-edit/rest/index.ts
+++ b/website/src/components/Demo/code/profile-edit/rest/index.ts
@@ -1,12 +1,9 @@
-import PostContainer from '!!raw-loader!./PostContainer.tsx';
 import PostItem from '!!raw-loader!./PostItem.tsx';
 import PostList from '!!raw-loader!./PostList.tsx';
 import ProfileEdit from '!!raw-loader!./ProfileEdit.tsx';
 import resources from '!!raw-loader!./resources.ts';
 
 import { PostResource } from './resources';
-
-import NewPost from '!!raw-loader!./NewPost.tsx';
 
 export default {
   label: 'REST',
@@ -47,10 +44,10 @@ export default {
       },
     },
     {
-      endpoint: PostResource.create,
+      endpoint: PostResource.getList.push,
       async response(...args: any) {
         return {
-          ...(await PostResource.create(...args)),
+          ...(await PostResource.getList.push(...args)),
           id: args?.[args.length - 1]?.id,
         };
       },

--- a/website/src/components/Demo/code/todo-app/rest/NewTodo.tsx
+++ b/website/src/components/Demo/code/todo-app/rest/NewTodo.tsx
@@ -4,7 +4,7 @@ export default function NewTodo({ userId }: { userId: number }) {
   const controller = useController();
   const handleKeyDown = async e => {
     if (e.key === 'Enter') {
-      controller.fetch(TodoResource.create, {
+      controller.fetch(TodoResource.getList.push, {
         id: randomId(),
         userId,
         title: e.currentTarget.value,

--- a/website/src/components/Demo/code/todo-app/rest/index.ts
+++ b/website/src/components/Demo/code/todo-app/rest/index.ts
@@ -69,10 +69,10 @@ export default {
       },
     },
     {
-      endpoint: TodoResource.create,
+      endpoint: TodoResource.getList.push,
       async response(...args: any) {
         return {
-          ...(await TodoResource.create(...args)),
+          ...(await TodoResource.getList.push(...args)),
           id: args?.[args.length - 1]?.id,
         };
       },

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -79,6 +79,7 @@ type EndpointParam<E> = E extends (first: infer A, ...rest: any) => any ? A : E 
 /** What the function's promise resolves to */
 type ResolveType<E extends (...args: any) => any> = ReturnType<E> extends Promise<infer R> ? R : never;
 type PartialParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? Partial<P> : never;
+type EndpointToFunction<E extends (...args: any) => Promise<any>> = (this: E, ...args: Parameters<E>) => ReturnType<E>;
 
 type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Promise<R>;
 interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
@@ -883,6 +884,16 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
   ): any;
 }
 
+type CollectionArrayAdder<S extends PolymorphicInterface> = S extends {
+  // ensure we are an array type
+  denormalizeOnly(...args: any): any[];
+  // get what we are an array of
+  schema: infer T;
+}
+  ? // TODO: eventually we want to allow singular or list and infer the return based on arguments
+    T
+  : never;
+
 declare class CollectionInterface<
   S extends PolymorphicInterface = any,
   Parent extends any[] = any,
@@ -976,16 +987,12 @@ declare class CollectionInterface<
   /** Schema to place at the *end* of this Collection
    * @see https://resthooks.io/rest/api/Collection#push
    */
-  push: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  push: CollectionArrayAdder<S>;
 
   /** Schema to place at the *beginning* of this Collection
    * @see https://resthooks.io/rest/api/Collection#unshift
    */
-  unshift: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  unshift: CollectionArrayAdder<S>;
 
   /** Schema to merge with a Values Collection
    * @see https://resthooks.io/rest/api/Collection#assign
@@ -1092,6 +1099,7 @@ type schema_d_Union<Choices extends EntityMap = any> = Union<Choices>;
 declare const schema_d_Union: typeof Union;
 type schema_d_Values<Choices extends Schema = any> = Values<Choices>;
 declare const schema_d_Values: typeof Values;
+type schema_d_CollectionArrayAdder<S extends PolymorphicInterface> = CollectionArrayAdder<S>;
 type schema_d_CollectionInterface<S extends PolymorphicInterface = any, Parent extends any[] = any> = CollectionInterface<S, Parent>;
 declare const schema_d_CollectionInterface: typeof CollectionInterface;
 type schema_d_CollectionFromSchema<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
@@ -1123,6 +1131,7 @@ declare namespace schema_d {
     Object$1 as Object,
     schema_d_Union as Union,
     schema_d_Values as Values,
+    schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
     schema_d_CollectionConstructor as CollectionConstructor,
@@ -1272,4 +1281,4 @@ type QuerySchema<Schema, R> = Exclude<Schema, 'denormalize' | '_denormalizeNulla
 declare class AbortOptimistic extends Error {
 }
 
-export { AbortOptimistic, AbstractInstanceType, Array$1 as Array, ArrayElement, Collection, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Schema, SchemaClass$1 as SchemaClass, SchemaSimple, SchemaSimpleNew, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbortOptimistic, AbstractInstanceType, Array$1 as Array, ArrayElement, Collection, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Schema, SchemaClass$1 as SchemaClass, SchemaSimple, SchemaSimpleNew, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -79,6 +79,7 @@ type EndpointParam<E> = E extends (first: infer A, ...rest: any) => any ? A : E 
 /** What the function's promise resolves to */
 type ResolveType<E extends (...args: any) => any> = ReturnType<E> extends Promise<infer R> ? R : never;
 type PartialParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? Partial<P> : never;
+type EndpointToFunction<E extends (...args: any) => Promise<any>> = (this: E, ...args: Parameters<E>) => ReturnType<E>;
 
 type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Promise<R>;
 interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
@@ -883,6 +884,16 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
   ): any;
 }
 
+type CollectionArrayAdder<S extends PolymorphicInterface> = S extends {
+  // ensure we are an array type
+  denormalizeOnly(...args: any): any[];
+  // get what we are an array of
+  schema: infer T;
+}
+  ? // TODO: eventually we want to allow singular or list and infer the return based on arguments
+    T
+  : never;
+
 declare class CollectionInterface<
   S extends PolymorphicInterface = any,
   Parent extends any[] = any,
@@ -976,16 +987,12 @@ declare class CollectionInterface<
   /** Schema to place at the *end* of this Collection
    * @see https://resthooks.io/rest/api/Collection#push
    */
-  push: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  push: CollectionArrayAdder<S>;
 
   /** Schema to place at the *beginning* of this Collection
    * @see https://resthooks.io/rest/api/Collection#unshift
    */
-  unshift: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  unshift: CollectionArrayAdder<S>;
 
   /** Schema to merge with a Values Collection
    * @see https://resthooks.io/rest/api/Collection#assign
@@ -1092,6 +1099,7 @@ type schema_d_Union<Choices extends EntityMap = any> = Union<Choices>;
 declare const schema_d_Union: typeof Union;
 type schema_d_Values<Choices extends Schema = any> = Values<Choices>;
 declare const schema_d_Values: typeof Values;
+type schema_d_CollectionArrayAdder<S extends PolymorphicInterface> = CollectionArrayAdder<S>;
 type schema_d_CollectionInterface<S extends PolymorphicInterface = any, Parent extends any[] = any> = CollectionInterface<S, Parent>;
 declare const schema_d_CollectionInterface: typeof CollectionInterface;
 type schema_d_CollectionFromSchema<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
@@ -1123,6 +1131,7 @@ declare namespace schema_d {
     Object$1 as Object,
     schema_d_Union as Union,
     schema_d_Values as Values,
+    schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
     schema_d_CollectionConstructor as CollectionConstructor,
@@ -1314,4 +1323,4 @@ interface GQLError {
     path: (string | number)[];
 }
 
-export { AbortOptimistic, AbstractInstanceType, Array$1 as Array, ArrayElement, Collection, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Schema, SchemaClass$1 as SchemaClass, SchemaSimple, SchemaSimpleNew, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbortOptimistic, AbstractInstanceType, Array$1 as Array, ArrayElement, Collection, DELETED, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Schema, SchemaClass$1 as SchemaClass, SchemaSimple, SchemaSimpleNew, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -79,6 +79,7 @@ type EndpointParam<E> = E extends (first: infer A, ...rest: any) => any ? A : E 
 /** What the function's promise resolves to */
 type ResolveType<E extends (...args: any) => any> = ReturnType<E> extends Promise<infer R> ? R : never;
 type PartialParameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? Partial<P> : never;
+type EndpointToFunction<E extends (...args: any) => Promise<any>> = (this: E, ...args: Parameters<E>) => ReturnType<E>;
 
 type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Promise<R>;
 interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
@@ -879,6 +880,16 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
   ): any;
 }
 
+type CollectionArrayAdder<S extends PolymorphicInterface> = S extends {
+  // ensure we are an array type
+  denormalizeOnly(...args: any): any[];
+  // get what we are an array of
+  schema: infer T;
+}
+  ? // TODO: eventually we want to allow singular or list and infer the return based on arguments
+    T
+  : never;
+
 declare class CollectionInterface<
   S extends PolymorphicInterface = any,
   Parent extends any[] = any,
@@ -972,16 +983,12 @@ declare class CollectionInterface<
   /** Schema to place at the *end* of this Collection
    * @see https://resthooks.io/rest/api/Collection#push
    */
-  push: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  push: CollectionArrayAdder<S>;
 
   /** Schema to place at the *beginning* of this Collection
    * @see https://resthooks.io/rest/api/Collection#unshift
    */
-  unshift: S extends { denormalizeOnly(...args: any): (infer Return)[] }
-    ? Collection<PolymorphicInterface<Return>, Parent>
-    : never;
+  unshift: CollectionArrayAdder<S>;
 
   /** Schema to merge with a Values Collection
    * @see https://resthooks.io/rest/api/Collection#assign
@@ -1088,6 +1095,7 @@ type schema_d_Union<Choices extends EntityMap = any> = Union<Choices>;
 declare const schema_d_Union: typeof Union;
 type schema_d_Values<Choices extends Schema = any> = Values<Choices>;
 declare const schema_d_Values: typeof Values;
+type schema_d_CollectionArrayAdder<S extends PolymorphicInterface> = CollectionArrayAdder<S>;
 type schema_d_CollectionInterface<S extends PolymorphicInterface = any, Parent extends any[] = any> = CollectionInterface<S, Parent>;
 declare const schema_d_CollectionInterface: typeof CollectionInterface;
 type schema_d_CollectionFromSchema<S extends any[] | PolymorphicInterface = any, Parent extends any[] = [
@@ -1119,6 +1127,7 @@ declare namespace schema_d {
     Object$1 as Object,
     schema_d_Union as Union,
     schema_d_Values as Values,
+    schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
     schema_d_CollectionConstructor as CollectionConstructor,
@@ -1268,14 +1277,20 @@ type QuerySchema<Schema, R> = Exclude<Schema, 'denormalize' | '_denormalizeNulla
 declare class AbortOptimistic extends Error {
 }
 
-type ExtractCollection<S extends Schema | undefined> = S extends CollectionInterface ? S : S extends Object$1<infer T> ? ExtractObject<T> : S extends Exclude<Schema, {
+type ExtractObject<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
+}[keyof S];
+
+type ExtractCollection<S extends Schema | undefined> = S extends {
+    push: any;
+    unshift: any;
+    assign: any;
+    schema: Schema;
+} ? S : S extends Object$1<infer T> ? ExtractObject<T> : S extends Exclude<Schema, {
     [K: string]: any;
 }> ? never : S extends {
     [K: string]: Schema;
 } ? ExtractObject<S> : never;
-type ExtractObject<S extends Record<string, any>> = {
-    [K in keyof S]: S[K] extends Schema ? ExtractCollection<S[K]> : never;
-}[keyof S];
 
 type OnlyOptional<S extends string> = S extends `${infer K}?` ? K : never;
 type OnlyRequired<S extends string> = S extends `${string}?` ? never : S;
@@ -1297,9 +1312,14 @@ type ShortenPath<S extends string> = string extends S ? string : S extends `${in
 type TrimColon<S extends string> = string extends S ? string : S extends `${infer R}:` ? R : S;
 type ResourcePath = string;
 
-type OptionsToFunction<O extends PartialRestGenerics, E extends RestInstanceBase & {
+type OptionsToFunction<O extends PartialRestGenerics, E extends {
     body?: any;
-}, F extends FetchFunction> = 'path' extends keyof O ? RestFetch<'searchParams' extends keyof O ? O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, 'body' extends keyof O ? O['body'] : E['body'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : 'body' extends keyof O ? RestFetch<'searchParams' extends keyof O ? O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, O['body'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : 'searchParams' extends keyof O ? RestFetch<O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, E['body'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : (this: ThisParameterType<F>, ...args: Parameters<F>) => Promise<O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>>;
+    path?: string;
+    method?: string;
+}, F extends FetchFunction> = 'path' extends keyof O ? RestFetch<'searchParams' extends keyof O ? O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, OptionsToBodyArgument<'body' extends keyof O ? O : E, 'method' extends keyof O ? O['method'] : E['method']>, O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : 'body' extends keyof O ? RestFetch<'searchParams' extends keyof O ? O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<O, 'method' extends keyof O ? O['method'] : E['method']>, O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : 'searchParams' extends keyof O ? RestFetch<O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<E, 'method' extends keyof O ? O['method'] : E['method']>, O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>> : (this: ThisParameterType<F>, ...args: Parameters<F>) => Promise<O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>>;
+type OptionsToBodyArgument<O extends {
+    body?: any;
+}, Method extends string | undefined> = Method extends 'POST' | 'PUT' | 'PATCH' ? 'body' extends keyof O ? O['body'] : any : undefined;
 
 type EndpointUpdateFunction<Source extends FetchFunction, Schema, Updaters extends Record<string, any> = Record<string, any>> = (source: ResultEntry<Source & {
     schema: Schema;
@@ -1321,6 +1341,7 @@ interface RestInstanceBase<
     path: string;
     body?: any;
     searchParams?: any;
+    method?: string;
   } = { path: string },
 > extends EndpointInstanceInterface<F, S, M> {
   readonly body?: 'body' extends keyof O ? O['body'] : any;
@@ -1338,7 +1359,7 @@ interface RestInstanceBase<
    */
   readonly urlPrefix: string;
   readonly requestInit: RequestInit;
-  readonly method: string;
+  readonly method: (O & { method: string })['method'];
   readonly signal: AbortSignal | undefined;
 
   /* fetch lifecycles */
@@ -1396,16 +1417,41 @@ interface RestInstance<
     path: string;
     body?: any;
     searchParams?: any;
+    method?: string;
   } = { path: string },
 > extends RestInstanceBase<F, S, M, O> {
-  push: AddEndpoint<F, S, O>;
-  unshift: AddEndpoint<F, S, O>;
-  assign: AddEndpoint<F, S, O>;
+  push: AddEndpoint<
+    F,
+    ExtractCollection<S>['push'],
+    Exclude<O, 'body' | 'method'> & {
+      body:
+        | OptionsToAdderBodyArgument<O>
+        | OptionsToAdderBodyArgument<O>[]
+        | FormData;
+    }
+  >;
+  unshift: AddEndpoint<
+    F,
+    ExtractCollection<S>['unshift'],
+    Exclude<O, 'body' | 'method'> & {
+      body:
+        | OptionsToAdderBodyArgument<O>
+        | OptionsToAdderBodyArgument<O>[]
+        | FormData;
+    }
+  >;
+  assign: AddEndpoint<
+    F,
+    ExtractCollection<S>,
+    Exclude<O, 'body' | 'method'> & {
+      body: Record<string, OptionsToAdderBodyArgument<O>> | FormData;
+    }
+  >;
 }
 
 type RestEndpointExtendOptions<
   O extends PartialRestGenerics,
-  E extends RestInstanceBase,
+  E extends { body?: any; path?: string; schema?: Schema; method?: string },
   F extends FetchFunction,
 > = RestEndpointOptions<
   OptionsToFunction<O, E, F>,
@@ -1426,7 +1472,10 @@ type OptionsToRestEndpoint<
           ? PathArgs<Exclude<O['path'], undefined>>
           : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>>
         : PathArgs<Exclude<O['path'], undefined>>,
-      'body' extends keyof O ? O['body'] : E['body'],
+      OptionsToBodyArgument<
+        'body' extends keyof O ? O : E,
+        'method' extends keyof O ? O['method'] : E['method']
+      >,
       'schema' extends keyof O ? O['schema'] : E['schema'],
       'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>,
@@ -1436,6 +1485,7 @@ type OptionsToRestEndpoint<
         searchParams: 'searchParams' extends keyof O
           ? O['searchParams']
           : E['searchParams'];
+        method: 'method' extends keyof O ? O['method'] : E['method'];
       }
     >
   : 'body' extends keyof O
@@ -1445,7 +1495,10 @@ type OptionsToRestEndpoint<
           ? PathArgs<Exclude<O['path'], undefined>>
           : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>
         : PathArgs<Exclude<E['path'], undefined>>,
-      O['body'],
+      OptionsToBodyArgument<
+        O,
+        'method' extends keyof O ? O['method'] : E['method']
+      >,
       'schema' extends keyof O ? O['schema'] : E['schema'],
       'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>,
@@ -1455,6 +1508,7 @@ type OptionsToRestEndpoint<
         searchParams: 'searchParams' extends keyof O
           ? O['searchParams']
           : E['searchParams'];
+        method: 'method' extends keyof O ? O['method'] : E['method'];
       }
     >
   : 'searchParams' extends keyof O
@@ -1462,7 +1516,10 @@ type OptionsToRestEndpoint<
       O['searchParams'] extends undefined
         ? PathArgs<Exclude<O['path'], undefined>>
         : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>,
-      E['body'],
+      OptionsToBodyArgument<
+        E,
+        'method' extends keyof O ? O['method'] : E['method']
+      >,
       'schema' extends keyof O ? O['schema'] : E['schema'],
       'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>,
@@ -1470,6 +1527,7 @@ type OptionsToRestEndpoint<
         path: E['path'];
         body: E['body'];
         searchParams: O['searchParams'];
+        method: 'method' extends keyof O ? O['method'] : E['method'];
       }
     >
   : RestInstance<
@@ -1484,6 +1542,7 @@ type OptionsToRestEndpoint<
         searchParams: 'searchParams' extends keyof O
           ? O['searchParams']
           : E['searchParams'];
+        method: 'method' extends keyof O ? O['method'] : E['method'];
       }
     >;
 
@@ -1511,9 +1570,9 @@ interface PartialRestGenerics {
   readonly schema?: Schema | undefined;
   readonly method?: string;
   /** Only used for types */
-  readonly body?: any;
+  body?: any;
   /** Only used for types */
-  readonly searchParams?: any;
+  searchParams?: any;
   /** @see https://resthooks.io/rest/api/RestEndpoint#process */
   process?(value: any, ...args: any): any;
 }
@@ -1522,7 +1581,7 @@ interface RestGenerics extends PartialRestGenerics {
 }
 
 type PaginationEndpoint<
-  E extends RestInstanceBase,
+  E extends FetchFunction & RestGenerics & { sideEffect?: true | undefined },
   A extends any[],
 > = RestInstance<
   ParamFetchNoBody<A[0], ResolveType<E>>,
@@ -1533,7 +1592,7 @@ type PaginationEndpoint<
   }
 >;
 type PaginationFieldEndpoint<
-  E extends RestInstanceBase,
+  E extends FetchFunction & RestGenerics & { sideEffect?: true | undefined },
   C extends string,
 > = RestInstance<
   ParamFetchNoBody<
@@ -1552,9 +1611,9 @@ type AddEndpoint<
   S extends Schema | undefined = any,
   O extends {
     path: string;
-    body?: any;
+    body: any;
     searchParams?: any;
-  } = { path: string },
+  } = { path: string; body: any },
 > = RestInstanceBase<
   RestFetch<
     'searchParams' extends keyof O
@@ -1562,25 +1621,16 @@ type AddEndpoint<
         ? PathArgs<Exclude<O['path'], undefined>>
         : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>>
       : PathArgs<Exclude<O['path'], undefined>>,
-    any,
+    O['body'],
     ResolveType<F>
   >,
-  ExtractCollection<S>,
+  S,
   true,
-  Omit<O, 'body'>
-> & { method: 'POST' };
+  O & { method: 'POST' }
+>;
 
-type BodyDefault<O extends RestGenerics> = 'body' extends keyof O
-  ? O['body']
-  : O['method'] extends 'POST' | 'PUT' | 'PATCH'
-  ? Record<string, unknown> | FormData
-  : undefined;
-
-type OptionsBodyDefault<O extends RestGenerics> = 'body' extends keyof O
-  ? O
-  : O['method'] extends 'POST' | 'PUT' | 'PATCH'
-  ? O & { body: any }
-  : O & { body: undefined };
+type OptionsToAdderBodyArgument<O extends { body?: any }> =
+  'body' extends keyof O ? O['body'] : any;
 
 interface RestEndpointOptions<
   F extends FetchFunction = FetchFunction,
@@ -1610,7 +1660,14 @@ type RestEndpointConstructorOptions<O extends RestGenerics = any> =
           ? PathArgs<O['path']>
           : O['searchParams'] & PathArgs<O['path']>
         : PathArgs<O['path']>,
-      BodyDefault<O>,
+      OptionsToBodyArgument<
+        O,
+        'method' extends keyof O
+          ? O['method']
+          : O extends { sideEffect: true }
+          ? 'POST'
+          : 'GET'
+      >,
       O['process'] extends {}
         ? ReturnType<O['process']>
         : any /*Denormalize<O['schema']>*/
@@ -1631,14 +1688,27 @@ interface RestEndpointConstructor {
           ? PathArgs<O['path']>
           : O['searchParams'] & PathArgs<O['path']>
         : PathArgs<O['path']>,
-      BodyDefault<O>,
+      OptionsToBodyArgument<
+        O,
+        'method' extends keyof O
+          ? O['method']
+          : O extends { sideEffect: true }
+          ? 'POST'
+          : 'GET'
+      >,
       O['process'] extends {}
         ? ReturnType<O['process']>
         : any /*Denormalize<O['schema']>*/
     >,
     'schema' extends keyof O ? O['schema'] : undefined,
-    MethodToSide<O['method']>,
-    OptionsBodyDefault<O>
+    'sideEffect' extends keyof O
+      ? Extract<O['sideEffect'], undefined | true>
+      : MethodToSide<O['method']>,
+    'method' extends keyof O
+      ? O
+      : O & {
+          method: O extends { sideEffect: true } ? 'POST' : 'GET';
+        }
   >;
   readonly prototype: RestInstanceBase;
 }
@@ -1813,7 +1883,7 @@ type GetEndpoint<
   O['schema'],
   undefined,
   any,
-  O & { body: undefined }
+  O & { method: 'GET' }
 >;
 
 type MutateEndpoint<
@@ -1839,7 +1909,7 @@ type MutateEndpoint<
   true,
   O['body'],
   any,
-  O
+  O & { body: any; method: 'POST' | 'PUT' | 'PATCH' }
 >;
 
 interface ResourceGenerics {
@@ -1904,10 +1974,12 @@ interface Resource<O extends ResourceGenerics = {
     getList: 'searchParams' extends keyof O ? GetEndpoint<{
         path: ShortenPath<O['path']>;
         schema: Collection<[O['schema']]>;
+        body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
         searchParams: O['searchParams'];
     }> : GetEndpoint<{
         path: ShortenPath<O['path']>;
         schema: Collection<[O['schema']]>;
+        body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
         searchParams: Record<string, number | string | boolean> | undefined;
     }>;
     /** Get a list of item
@@ -2005,4 +2077,4 @@ declare function paginationUpdate<E extends {
     [x: number]: (existing: any) => any;
 };
 
-export { AbortOptimistic, AbstractInstanceType, AddEndpoint, Array$1 as Array, ArrayElement, BodyDefault, Collection, DELETED, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Resource, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaClass$1 as SchemaClass, SchemaSimple, SchemaSimpleNew, ShortenPath, SnapshotInterface, UnknownError, createResource, hookifyResource, paginationUpdate, schema_d as schema, validateRequired };
+export { AbortOptimistic, AbstractInstanceType, AddEndpoint, Array$1 as Array, ArrayElement, Collection, DELETED, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, Index, IndexParams, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Query, ReadEndpoint, ResolveType, Resource, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaClass$1 as SchemaClass, SchemaSimple, SchemaSimpleNew, ShortenPath, SnapshotInterface, UnknownError, createResource, hookifyResource, paginationUpdate, schema_d as schema, validateRequired };

--- a/website/src/fixtures/posts.ts
+++ b/website/src/fixtures/posts.ts
@@ -122,14 +122,13 @@ export const postFixtures = [
     delay: 500,
   },
   {
-    endpoint: PostResource.create,
+    endpoint: PostResource.getList.push,
     response(body) {
       const id = randomId();
       this.entities[id] = { id, userId: 1 };
       for (const [key, value] of body.entries()) {
         this.entities[id][key] = value;
       }
-      console.log('create', id, this.entities[id]);
       return this.entities[id];
     },
     delay: 500,

--- a/website/src/fixtures/todos.ts
+++ b/website/src/fixtures/todos.ts
@@ -75,11 +75,11 @@ export const todoFixtures = [
     },
   },
   {
-    endpoint: TodoResource.create,
+    endpoint: TodoResource.getList.push,
     async response(...args: any) {
       //await new Promise(resolve => setTimeout(resolve, 500));
       return {
-        ...(await TodoResource.create(...args)),
+        ...(await TodoResource.getList.push(...args)),
         id: args?.[args.length - 1]?.id,
       };
     },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Shift to a focus on more explicit create / list interactions; allowing more obvious flexibility in how creations update lists

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- scheam.push/unshift type denormalize to singular item (for now - until we can dynamically determine type)
- improve collections by supporting boolean parameters properly in filter methods
- set `body` type in lists, and ignore it until push/unshift/assign is used. this means we use `method` typing to determine whether to use `body` or not
- Update docs to stop using resource.create and instead use resource.getList.push