### PR TITLE
fix: Commonjs rollup build for test

### DIFF
--- a/.changeset/shiny-spies-give.md
+++ b/.changeset/shiny-spies-give.md
@@ -8,9 +8,14 @@ Add Resource.extend()
 This is polymorphic, and has three forms
 
 Set any field based on arguments:
+
+```ts
 Resource.extend('fieldName', { path: 'mypath/:id' });
+```
 
 Override any of the provided endpoints with options:
+
+```ts
 Resource.extend({
   getList: {
     path: 'mypath/:id',
@@ -19,12 +24,16 @@ Resource.extend({
     body: {} as Other,
   },
 });
+```
 
 Function to compute derived endpoints:
+
+```ts
 Resource.extend((base) => ({
   getByComment: base.getList.extend({
     path: 'repos/:owner/:repo/issues/comments/:comment/reactions',
   }),
 }));
+```
 
 Idea credits: @Dav3rs

--- a/.changeset/violet-donkeys-tell.md
+++ b/.changeset/violet-donkeys-tell.md
@@ -1,0 +1,5 @@
+---
+'@data-client/test': patch
+---
+
+Fix commonjs rollup build

--- a/packages/test/rollup.config.js
+++ b/packages/test/rollup.config.js
@@ -43,7 +43,10 @@ export default [
         runtimeHelpers: true,
       }),
       resolve({ extensions }),
-      commonjs({ extensions }),
+      commonjs({
+        extensions,
+        ignore: ['@testing-library/react-hooks', './render18HookWrapped.js'],
+      }),
     ],
   },
   {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
'./render18HookWrapped.js' and '@testing-library/react-hooks' need to be dynamically required

'@testing-library/react-hooks' is an optional dependency, and render18HookWrapped needs to be in a distinct file for RN

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add `ignore` configure to [commonjs rollup plugin](https://github.com/rollup/rollup-plugin-commonjs)