### PR TITLE
Add controller.expireAll() that sets all responses to *STALE*

### DIFF
--- a/.changeset/cool-dryers-change.md
+++ b/.changeset/cool-dryers-change.md
@@ -1,0 +1,5 @@
+---
+'@data-client/react': patch
+---
+
+Update README examples to have more options configured

--- a/.changeset/many-pears-explain.md
+++ b/.changeset/many-pears-explain.md
@@ -1,0 +1,18 @@
+---
+'@data-client/react': minor
+'@data-client/core': minor
+'@rest-hooks/core': minor
+'@rest-hooks/react': minor
+---
+
+Add controller.expireAll() that sets all responses to *STALE*
+
+```ts
+controller.expireAll(ArticleResource.getList);
+```
+
+This is like controller.invalidateAll(); but will continue showing
+stale data while it is refetched.
+
+This is sometimes useful to trigger refresh of only data presently shown
+when there are many parameterizations in cache.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,16 @@ class Article extends Entity {
 const UserResource = createResource({
   path: '/users/:id',
   schema: User,
+  optimistic: true,
 });
 
 const ArticleResource = createResource({
   path: '/articles/:id',
   schema: Article,
+  searchParams: {} as
+    | { beginAt?: string; endAt?: string; author?: string }
+    | undefined,
+  optimistic: true,
 });
 ```
 
@@ -86,12 +91,12 @@ const ArticleResource = createResource({
 ```tsx
 const article = useSuspense(ArticleResource.get, { id });
 return (
-  <>
+  <article>
     <h2>
       {article.title} by {article.author.username}
     </h2>
     <p>{article.body}</p>
-  </>
+  </article>
 );
 ```
 

--- a/packages/core/src/actionTypes.ts
+++ b/packages/core/src/actionTypes.ts
@@ -8,4 +8,5 @@ export const SUBSCRIBE_TYPE = 'rest-hooks/subscribe' as const;
 export const UNSUBSCRIBE_TYPE = 'rest-hook/unsubscribe' as const;
 export const INVALIDATE_TYPE = 'rest-hooks/invalidate' as const;
 export const INVALIDATEALL_TYPE = 'rest-hooks/invalidateall' as const;
+export const EXPIREALL_TYPE = 'rest-hooks/expireall' as const;
 export const GC_TYPE = 'rest-hooks/gc' as const;

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@data-client/normalizr';
 import { inferResults, validateInference } from '@data-client/normalizr';
 
+import createExpireAll from './createExpireAll.js';
 import createFetch from './createFetch.js';
 import createInvalidate from './createInvalidate.js';
 import createInvalidateAll from './createInvalidateAll.js';
@@ -136,9 +137,18 @@ export default class Controller<
   /**
    * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
    * @see https://resthooks.io/docs/api/Controller#invalidateAll
+   * @returns Promise that resolves when invalidation is commited.
    */
   invalidateAll = (options: { testKey: (key: string) => boolean }) =>
     this.dispatch(createInvalidateAll((key: string) => options.testKey(key)));
+
+  /**
+   * Sets all matching endpoint result keys to be STALE.
+   * @see https://dataclient.io/docs/api/Controller#expireAll
+   * @returns Promise that resolves when expiry is commited. *NOT* fetch promise
+   */
+  expireAll = (options: { testKey: (key: string) => boolean }) =>
+    this.dispatch(createExpireAll((key: string) => options.testKey(key)));
 
   /**
    * Resets the entire Rest Hooks cache. All inflight requests will not resolve.

--- a/packages/core/src/controller/createExpireAll.ts
+++ b/packages/core/src/controller/createExpireAll.ts
@@ -1,0 +1,11 @@
+import { EXPIREALL_TYPE } from '../actionTypes.js';
+import type { ExpireAllAction } from '../types.js';
+
+export default function createExpireAll(
+  testKey: (key: string) => boolean,
+): ExpireAllAction {
+  return {
+    type: EXPIREALL_TYPE,
+    testKey,
+  };
+}

--- a/packages/core/src/newActions.ts
+++ b/packages/core/src/newActions.ts
@@ -14,6 +14,7 @@ import type {
   GC_TYPE,
   OPTIMISTIC_TYPE,
   INVALIDATEALL_TYPE,
+  EXPIREALL_TYPE,
 } from './actionTypes.js';
 import type { EndpointUpdateFunction } from './controller/types.js';
 
@@ -112,6 +113,12 @@ export interface UnsubscribeAction<
   };
 }
 
+/* EXPIRY */
+export interface ExpireAllAction {
+  type: typeof EXPIREALL_TYPE;
+  testKey: (key: string) => boolean;
+}
+
 /* INVALIDATE */
 export interface InvalidateAllAction {
   type: typeof INVALIDATEALL_TYPE;
@@ -146,5 +153,6 @@ export type ActionTypes =
   | UnsubscribeAction
   | InvalidateAction
   | InvalidateAllAction
+  | ExpireAllAction
   | ResetAction
   | GCAction;

--- a/packages/core/src/state/reducer/createReducer.ts
+++ b/packages/core/src/state/reducer/createReducer.ts
@@ -1,3 +1,4 @@
+import { expireReducer } from './expireReducer.js';
 import { fetchReducer } from './fetchReducer.js';
 import { invalidateReducer } from './invalidateReducer.js';
 import { setReducer } from './setReducer.js';
@@ -9,6 +10,7 @@ import {
   GC_TYPE,
   OPTIMISTIC_TYPE,
   INVALIDATEALL_TYPE,
+  EXPIREALL_TYPE,
 } from '../../actionTypes.js';
 import type Controller from '../../controller/Controller.js';
 import type { ActionTypes, State } from '../../types.js';
@@ -42,6 +44,9 @@ export default function createReducer(controller: Controller): ReducerType {
       case INVALIDATEALL_TYPE:
       case INVALIDATE_TYPE:
         return invalidateReducer(state, action);
+
+      case EXPIREALL_TYPE:
+        return expireReducer(state, action);
 
       case RESET_TYPE:
         return { ...initialState, lastReset: action.date };

--- a/packages/core/src/state/reducer/expireReducer.ts
+++ b/packages/core/src/state/reducer/expireReducer.ts
@@ -1,0 +1,20 @@
+import type { State, ExpireAllAction } from '../../types.js';
+
+export function expireReducer(state: State<unknown>, action: ExpireAllAction) {
+  const meta = { ...state.meta };
+
+  Object.keys(meta).forEach(key => {
+    if (action.testKey(key)) {
+      meta[key] = {
+        ...meta[key],
+        // 1 instead of 0 so we can do 'falsy' checks to see if it is set
+        expiresAt: 1,
+      };
+    }
+  });
+
+  return {
+    ...state,
+    meta,
+  };
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -54,7 +54,7 @@ class Article extends Entity {
   static schema = {
     author: User,
     createdAt: Date,
-  }
+  };
 }
 ```
 
@@ -64,11 +64,16 @@ class Article extends Entity {
 const UserResource = createResource({
   path: '/users/:id',
   schema: User,
+  optimistic: true,
 });
 
 const ArticleResource = createResource({
   path: '/articles/:id',
   schema: Article,
+  searchParams: {} as
+    | { beginAt?: string; endAt?: string; author?: string }
+    | undefined,
+  optimistic: true,
 });
 ```
 
@@ -77,10 +82,12 @@ const ArticleResource = createResource({
 ```tsx
 const article = useSuspense(ArticleResource.get, { id });
 return (
-  <>
-    <h2>{article.title} by {article.author.username}</h2>
+  <article>
+    <h2>
+      {article.title} by {article.author.username}
+    </h2>
     <p>{article.body}</p>
-  </>
+  </article>
 );
 ```
 
@@ -112,7 +119,7 @@ const sortedArticles = new Query(
     const sorted = [...entries].sort((a, b) => a.title.localeCompare(b.title));
     if (asc) return sorted;
     return sorted.reverse();
-  }
+  },
 );
 
 const articlesUnsorted = useCache(sortedArticles);

--- a/packages/react/src/hooks/__tests__/useController/expireAll.tsx
+++ b/packages/react/src/hooks/__tests__/useController/expireAll.tsx
@@ -1,0 +1,218 @@
+import { CacheProvider } from '@data-client/react';
+import { makeRenderRestHook } from '@data-client/test';
+import { FixtureEndpoint } from '@data-client/test/mockState';
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks';
+import { CoolerArticleResource, GetPhoto } from '__tests__/new';
+import nock from 'nock';
+import { useEffect } from 'react';
+
+import { useCache, useController, useSuspense } from '../..';
+
+export const payload = {
+  id: 5,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const createPayload = {
+  id: 1,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const detail: FixtureEndpoint = {
+  endpoint: CoolerArticleResource.get,
+  args: [{ id: 5 }],
+  response: payload,
+};
+
+export const nested: FixtureEndpoint = {
+  endpoint: CoolerArticleResource.getList,
+  args: [],
+  response: [
+    {
+      id: 5,
+      title: 'hi ho',
+      content: 'whatever',
+      tags: ['a', 'best', 'react'],
+      author: {
+        id: 23,
+        username: 'bob',
+      },
+    },
+    {
+      id: 3,
+      title: 'the next time',
+      content: 'whatever',
+      author: {
+        id: 23,
+        username: 'charles',
+        email: 'bob@bob.com',
+      },
+    },
+  ],
+};
+let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+let mynock: nock.Scope;
+
+beforeEach(() => {
+  renderRestHook = makeRenderRestHook(CacheProvider);
+  mynock = nock(/.*/).defaultReplyHeaders({
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'application/json',
+  });
+});
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe('expireAll', () => {
+  // TODO: this test isn't really testing much
+  it('should not expire anything not matching', () => {
+    const { result, controller } = renderRestHook(
+      () => {
+        return {
+          data: useCache(CoolerArticleResource.get, { id: 5 }),
+        };
+      },
+      { initialFixtures: [detail], resolverFixtures: [detail] },
+    );
+    expect(result.current.data).toBeDefined();
+    act(() => {
+      controller.expireAll(CoolerArticleResource.update);
+    });
+    expect(result.current.data).toBeDefined();
+    act(() => {
+      controller.expireAll(CoolerArticleResource.getList);
+    });
+    expect(result.current.data).toBeDefined();
+  });
+
+  it('should suspend when invalidIfStale is used', () => {
+    const throws: Promise<any>[] = [];
+
+    const { result, controller } = renderRestHook(
+      () => {
+        try {
+          return {
+            data: useSuspense(
+              CoolerArticleResource.get.extend({ invalidIfStale: true }),
+              { id: 5 },
+            ),
+          };
+        } catch (e: any) {
+          if (typeof e.then === 'function') {
+            if (e !== throws[throws.length - 1]) {
+              throws.push(e);
+            }
+          }
+          throw e;
+        }
+      },
+      { initialFixtures: [detail], resolverFixtures: [detail] },
+    );
+    expect(throws.length).toBe(0);
+    expect(result.current.data).toBeDefined();
+    act(() => {
+      controller.expireAll(CoolerArticleResource.get);
+    });
+    expect(throws.length).toBe(1);
+  });
+
+  it('should *not* suspend when invalidIfStale is false', () => {
+    const throws: Promise<any>[] = [];
+
+    const { result, controller } = renderRestHook(
+      () => {
+        try {
+          return {
+            data: useSuspense(CoolerArticleResource.get, { id: 5 }),
+          };
+        } catch (e: any) {
+          if (typeof e.then === 'function') {
+            if (e !== throws[throws.length - 1]) {
+              throws.push(e);
+            }
+          }
+          throw e;
+        }
+      },
+      { initialFixtures: [detail], resolverFixtures: [detail] },
+    );
+    expect(throws.length).toBe(0);
+    expect(result.current.data).toBeDefined();
+    act(() => {
+      controller.expireAll(CoolerArticleResource.get);
+    });
+    expect(throws.length).toBe(0);
+    expect(result.current.data).toBeDefined();
+  });
+
+  it('should not change useCache()', () => {
+    const { result, controller } = renderRestHook(
+      () => {
+        return {
+          data: useCache(CoolerArticleResource.get, { id: 5 }),
+        };
+      },
+      { initialFixtures: [detail] },
+    );
+    expect(result.current.data).toBeDefined();
+    act(() => {
+      controller.expireAll(CoolerArticleResource.get);
+    });
+    expect(result.current.data).toBeDefined();
+  });
+
+  it('should return the same === function each time', () => {
+    const track = jest.fn();
+
+    const { rerender } = renderHook(() => {
+      const expireAll = useController().expireAll;
+      useEffect(track, [expireAll]);
+    });
+    expect(track.mock.calls.length).toBe(1);
+    for (let i = 0; i < 4; ++i) {
+      rerender();
+    }
+    expect(track.mock.calls.length).toBe(1);
+  });
+
+  it('should work with ArrayBuffer shapes', () => {
+    const userId = '5';
+    const response = new ArrayBuffer(10);
+    const secondResponse = new ArrayBuffer(20);
+    const { result, controller } = renderRestHook(
+      () => {
+        return {
+          data: useSuspense(GetPhoto, { userId }),
+        };
+      },
+      {
+        initialFixtures: [
+          {
+            endpoint: GetPhoto,
+            response,
+            args: [{ userId }],
+          },
+        ],
+        resolverFixtures: [
+          {
+            endpoint: GetPhoto,
+            response: secondResponse,
+            args: [{ userId }],
+          },
+        ],
+      },
+    );
+    expect(result.current.data).toEqual(response);
+    act(() => {
+      controller.expireAll(GetPhoto);
+    });
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data).toEqual(secondResponse);
+  });
+});

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -227,6 +227,7 @@ declare const SUBSCRIBE_TYPE: "rest-hooks/subscribe";
 declare const UNSUBSCRIBE_TYPE: "rest-hook/unsubscribe";
 declare const INVALIDATE_TYPE: "rest-hooks/invalidate";
 declare const INVALIDATEALL_TYPE: "rest-hooks/invalidateall";
+declare const EXPIREALL_TYPE: "rest-hooks/expireall";
 declare const GC_TYPE: "rest-hooks/gc";
 
 declare const actionTypes_d_FETCH_TYPE: typeof FETCH_TYPE;
@@ -238,6 +239,7 @@ declare const actionTypes_d_SUBSCRIBE_TYPE: typeof SUBSCRIBE_TYPE;
 declare const actionTypes_d_UNSUBSCRIBE_TYPE: typeof UNSUBSCRIBE_TYPE;
 declare const actionTypes_d_INVALIDATE_TYPE: typeof INVALIDATE_TYPE;
 declare const actionTypes_d_INVALIDATEALL_TYPE: typeof INVALIDATEALL_TYPE;
+declare const actionTypes_d_EXPIREALL_TYPE: typeof EXPIREALL_TYPE;
 declare const actionTypes_d_GC_TYPE: typeof GC_TYPE;
 declare namespace actionTypes_d {
   export {
@@ -250,6 +252,7 @@ declare namespace actionTypes_d {
     actionTypes_d_UNSUBSCRIBE_TYPE as UNSUBSCRIBE_TYPE,
     actionTypes_d_INVALIDATE_TYPE as INVALIDATE_TYPE,
     actionTypes_d_INVALIDATEALL_TYPE as INVALIDATEALL_TYPE,
+    actionTypes_d_EXPIREALL_TYPE as EXPIREALL_TYPE,
     actionTypes_d_GC_TYPE as GC_TYPE,
   };
 }
@@ -337,6 +340,10 @@ interface UnsubscribeAction<E extends EndpointAndUpdate<E> = EndpointDefault> {
         key: string;
     };
 }
+interface ExpireAllAction {
+    type: typeof EXPIREALL_TYPE;
+    testKey: (key: string) => boolean;
+}
 interface InvalidateAllAction {
     type: typeof INVALIDATEALL_TYPE;
     testKey: (key: string) => boolean;
@@ -356,7 +363,7 @@ interface GCAction {
     entities: [string, string][];
     results: string[];
 }
-type ActionTypes = FetchAction | OptimisticAction | SetAction | SubscribeAction | UnsubscribeAction | InvalidateAction | InvalidateAllAction | ResetAction | GCAction;
+type ActionTypes = FetchAction | OptimisticAction | SetAction | SubscribeAction | UnsubscribeAction | InvalidateAction | InvalidateAllAction | ExpireAllAction | ResetAction | GCAction;
 
 type newActions_d_SetMeta = SetMeta;
 type newActions_d_SetActionSuccess<E extends EndpointAndUpdate<E> = EndpointDefault> = SetActionSuccess<E>;
@@ -368,6 +375,7 @@ type newActions_d_FetchAction<E extends EndpointAndUpdate<E> = EndpointDefault> 
 type newActions_d_OptimisticAction<E extends EndpointAndUpdate<E> = EndpointDefault> = OptimisticAction<E>;
 type newActions_d_SubscribeAction<E extends EndpointAndUpdate<E> = EndpointDefault> = SubscribeAction<E>;
 type newActions_d_UnsubscribeAction<E extends EndpointAndUpdate<E> = EndpointDefault> = UnsubscribeAction<E>;
+type newActions_d_ExpireAllAction = ExpireAllAction;
 type newActions_d_InvalidateAllAction = InvalidateAllAction;
 type newActions_d_InvalidateAction = InvalidateAction;
 type newActions_d_ResetAction = ResetAction;
@@ -385,6 +393,7 @@ declare namespace newActions_d {
     newActions_d_OptimisticAction as OptimisticAction,
     newActions_d_SubscribeAction as SubscribeAction,
     newActions_d_UnsubscribeAction as UnsubscribeAction,
+    newActions_d_ExpireAllAction as ExpireAllAction,
     newActions_d_InvalidateAllAction as InvalidateAllAction,
     newActions_d_InvalidateAction as InvalidateAction,
     newActions_d_ResetAction as ResetAction,
@@ -478,8 +487,17 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
     /**
      * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
      * @see https://resthooks.io/docs/api/Controller#invalidateAll
+     * @returns Promise that resolves when invalidation is commited.
      */
     invalidateAll: (options: {
+        testKey: (key: string) => boolean;
+    }) => Promise<void>;
+    /**
+     * Sets all matching endpoint result keys to be STALE.
+     * @see https://dataclient.io/docs/api/Controller#expireAll
+     * @returns Promise that resolves when expiry is commited. *NOT* fetch promise
+     */
+    expireAll: (options: {
         testKey: (key: string) => boolean;
     }) => Promise<void>;
     /**
@@ -1039,4 +1057,4 @@ declare class DevToolsManager implements Manager {
     getMiddleware(): Middleware;
 }
 
-export { AbstractInstanceType, ActionTypes, ConnectionListener, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeCache, DenormalizeNullable, DevToolsConfig, DevToolsManager, Dispatch$1 as Dispatch, EndpointExtraOptions, EndpointInterface, EndpointUpdateFunction, EntityInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, FetchMeta, GCAction, GenericDispatch, InvalidateAction, InvalidateAllAction, LogoutManager, Manager, Middleware$2 as Middleware, MiddlewareAPI$1 as MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, OptimisticAction, PK, PollingSubscription, ReceiveAction, ReceiveTypes, ResetAction, ResetError, ResolveType, ResultEntry, Schema, SetAction, SetActionError, SetActionSuccess, SetMeta, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, applyManager, createFetch, createSet as createReceive, createReducer, initialState, newActions_d as newActions };
+export { AbstractInstanceType, ActionTypes, ConnectionListener, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeCache, DenormalizeNullable, DevToolsConfig, DevToolsManager, Dispatch$1 as Dispatch, EndpointExtraOptions, EndpointInterface, EndpointUpdateFunction, EntityInterface, ErrorTypes, ExpireAllAction, ExpiryStatus, FetchAction, FetchFunction, FetchMeta, GCAction, GenericDispatch, InvalidateAction, InvalidateAllAction, LogoutManager, Manager, Middleware$2 as Middleware, MiddlewareAPI$1 as MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, OptimisticAction, PK, PollingSubscription, ReceiveAction, ReceiveTypes, ResetAction, ResetError, ResolveType, ResultEntry, Schema, SetAction, SetActionError, SetActionSuccess, SetMeta, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, applyManager, createFetch, createSet as createReceive, createReducer, initialState, newActions_d as newActions };

--- a/website/src/components/Playground/editor-types/@data-client/core/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core/next.d.ts
@@ -203,6 +203,7 @@ declare const SUBSCRIBE_TYPE: "rest-hooks/subscribe";
 declare const UNSUBSCRIBE_TYPE: "rest-hook/unsubscribe";
 declare const INVALIDATE_TYPE: "rest-hooks/invalidate";
 declare const INVALIDATEALL_TYPE: "rest-hooks/invalidateall";
+declare const EXPIREALL_TYPE: "rest-hooks/expireall";
 declare const GC_TYPE: "rest-hooks/gc";
 
 type EndpointAndUpdate<E extends EndpointInterface> = EndpointInterface & {
@@ -271,6 +272,10 @@ interface UnsubscribeAction<E extends EndpointAndUpdate<E> = EndpointDefault> {
         key: string;
     };
 }
+interface ExpireAllAction {
+    type: typeof EXPIREALL_TYPE;
+    testKey: (key: string) => boolean;
+}
 interface InvalidateAllAction {
     type: typeof INVALIDATEALL_TYPE;
     testKey: (key: string) => boolean;
@@ -290,7 +295,7 @@ interface GCAction {
     entities: [string, string][];
     results: string[];
 }
-type ActionTypes = FetchAction | OptimisticAction | SetAction | SubscribeAction | UnsubscribeAction | InvalidateAction | InvalidateAllAction | ResetAction | GCAction;
+type ActionTypes = FetchAction | OptimisticAction | SetAction | SubscribeAction | UnsubscribeAction | InvalidateAction | InvalidateAllAction | ExpireAllAction | ResetAction | GCAction;
 
 type PK = string;
 interface State<T> {
@@ -370,8 +375,17 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
     /**
      * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
      * @see https://resthooks.io/docs/api/Controller#invalidateAll
+     * @returns Promise that resolves when invalidation is commited.
      */
     invalidateAll: (options: {
+        testKey: (key: string) => boolean;
+    }) => Promise<void>;
+    /**
+     * Sets all matching endpoint result keys to be STALE.
+     * @see https://dataclient.io/docs/api/Controller#expireAll
+     * @returns Promise that resolves when expiry is commited. *NOT* fetch promise
+     */
+    expireAll: (options: {
         testKey: (key: string) => boolean;
     }) => Promise<void>;
     /**

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -2068,7 +2068,7 @@ interface Resource<O extends ResourceGenerics = {
         schema: O['schema'];
     }> : MutateEndpoint<{
         path: O['path'];
-        body: Partial<Denormalize<O['schema']>>;
+        body: Partial<Denormalize<O['schema']>> | FormData;
         schema: O['schema'];
     }>;
     /** Update an item (PATCH)
@@ -2081,7 +2081,7 @@ interface Resource<O extends ResourceGenerics = {
         schema: O['schema'];
     }> : MutateEndpoint<{
         path: O['path'];
-        body: Partial<Denormalize<O['schema']>>;
+        body: Partial<Denormalize<O['schema']>> | FormData;
         schema: O['schema'];
     }>;
     /** Delete an item (DELETE)

--- a/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
@@ -1434,7 +1434,7 @@ interface Resource<O extends ResourceGenerics = {
         schema: O['schema'];
     }> : MutateEndpoint<{
         path: O['path'];
-        body: Partial<Denormalize<O['schema']>>;
+        body: Partial<Denormalize<O['schema']>> | FormData;
         schema: O['schema'];
     }>;
     /** Update an item (PATCH)
@@ -1447,7 +1447,7 @@ interface Resource<O extends ResourceGenerics = {
         schema: O['schema'];
     }> : MutateEndpoint<{
         path: O['path'];
-        body: Partial<Denormalize<O['schema']>>;
+        body: Partial<Denormalize<O['schema']>> | FormData;
         schema: O['schema'];
     }>;
     /** Delete an item (DELETE)


### PR DESCRIPTION
Fixes #1548

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Similar to use case of [invalidateAll()](https://dataclient.io/docs/api/Controller#invalidateAll), but does not result in loading condition.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add controller.expireAll() that sets all responses to *STALE*

```ts
controller.expireAll(ArticleResource.getList);
```

This is like controller.invalidateAll(); but will continue showing
stale data while it is refetched.

This is sometimes useful to trigger refresh of only data presently shown
when there are many parameterizations in cache.