### PR TITLE
feat: Add 'paginationField' parameter to RestEndpoint and createResource

### DIFF
--- a/.changeset/late-hotels-deliver.md
+++ b/.changeset/late-hotels-deliver.md
@@ -1,0 +1,8 @@
+---
+'@data-client/rest': patch
+'@rest-hooks/rest': patch
+---
+
+Fix case where sometimes paginating would not update a collection
+
+This was due to the comparison not using string serialization (canonical form for collection comparisons)

--- a/.changeset/odd-tables-tease.md
+++ b/.changeset/odd-tables-tease.md
@@ -1,0 +1,8 @@
+---
+'@data-client/endpoint': patch
+'@data-client/react': patch
+'@rest-hooks/endpoint': patch
+'@rest-hooks/rest': patch
+---
+
+Ignore 'undefined' parameters in collection matching

--- a/.changeset/strange-parents-crash.md
+++ b/.changeset/strange-parents-crash.md
@@ -1,0 +1,16 @@
+---
+'@data-client/rest': minor
+'@rest-hooks/rest': minor
+---
+
+Add 'paginationField' parameter to [RestEndpoint](https://dataclient.io/rest/api/RestEndpoint#paginationfield) and [createResource](https://dataclient.io/rest/api/createResource#paginationfield)
+
+This adds a '[getPage](https://dataclient.io/rest/api/RestEndpoint#getPage)' member; similar to getList.push/unshift but for [pagination](https://dataclient.io/rest/guides/pagination).
+
+```ts
+const TodoResource = createResource({
+  path: '/todos/:id',
+  schema: Todo,
+  paginationField: 'page',
+}).getList.getPage({ page: '2' });
+```

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const ArticleResource = createResource({
   schema: Article,
   searchParams: {} as { author?: string },
   optimistic: true,
+  paginationField: 'cursor',
 });
 ```
 

--- a/docs/core/getting-started/resource.md
+++ b/docs/core/getting-started/resource.md
@@ -57,6 +57,7 @@ export const TodoResource = createResource({
   path: '/todos/:id',
   schema: Todo,
   searchParams: {} as { userId?: string | number } | undefined,
+  paginationField: 'page',
 });
 
 
@@ -72,6 +73,8 @@ TodoResource.getList({ userId: 1 });
 TodoResource.getList.push({ title: 'my todo' });
 // POST https://jsonplaceholder.typicode.com/todos?userId=1
 TodoResource.getList.push({ userId: 1 }, { title: 'my todo' });
+// GET https://jsonplaceholder.typicode.com/todos?userId=1&page=2
+TodoResource.getList.getPage({ userId: 1, page: 2 });
 // PUT https://jsonplaceholder.typicode.com/todos/5
 TodoResource.update({ id: 5 }, { title: 'my todo' });
 // PATCH https://jsonplaceholder.typicode.com/todos/5

--- a/docs/rest/api/RestEndpoint.md
+++ b/docs/rest/api/RestEndpoint.md
@@ -444,6 +444,10 @@ updateSite({ slug: 'cool' }, { url: '/' });
 
 </TypeScriptEditor>
 
+### paginationField
+
+If specified, will add [getPage](#getpage) method on the `RestEndpoint`.
+
 ### urlPrefix: string = '' {#urlPrefix}
 
 Prepends this to the compiled [path](#path)
@@ -793,9 +797,56 @@ const UserDetailNormalized = getUser.extend({
 
 ## Specialized extenders
 
-### paginated(cursorField): Endpoint {#paginated}
+### push
 
-Creates a new endpoint with an extra `cursorField` string that will be used to find the specific
+This is a convenience to place newly created Entities at the _end_ of a [Collection](./Collection.md).
+
+When this `RestEndpoint`'s schema contains a [Collection](./Collection.md), this returned a new
+RestEndpoint with its parents properties, but with [method](#method): 'POST' and schema: [Collection.push](./Collection.md#push)
+
+### unshift
+
+This is a convenience to place newly created Entities at the _start_ of a [Collection](./Collection.md).
+
+When this `RestEndpoint`'s schema contains a [Collection](./Collection.md), this returned a new
+RestEndpoint with its parents properties, but with [method](#method): 'POST' and schema: [Collection.push](./Collection.md#unshift)
+
+### assign
+
+This is a convenience to add newly created Entities to a [Values](./Values.md) [Collection](./Collection.md).
+
+When this `RestEndpoint`'s schema contains a [Collection](./Collection.md), this returned a new
+RestEndpoint with its parents properties, but with [method](#method): 'POST' and schema: [Collection.push](./Collection.md#assign)
+
+### getPage
+
+An endpoint to retrieve the next page using [paginationField](#paginationfield) as the searchParameter key. Schema
+must also contain a [Collection](./Collection.md)
+
+```tsx
+const getTodos = new RestEndpoint({
+  path: '/todos',
+  schema: Todo,
+  paginationField: 'page',
+})
+
+const todos = useSuspense(getTodos);
+return (
+  <PaginatedList
+    items={todos}
+    fetchNextPage={() =>
+      // fetches url `/todos?page=${nextPage}`
+      ctrl.fetch(TodoResource.getList.getPage, { page: nextPage })
+    }
+  />
+);
+```
+
+See [Infinite Scrolling Pagination](guides/pagination.md#infinite-scrolling) for more info.
+
+### paginated(paginationfield): Endpoint {#paginated}
+
+Creates a new endpoint with an extra `paginationfield` string that will be used to find the specific
 page, to append to this endpoint. See [Infinite Scrolling Pagination](guides/pagination.md#infinite-scrolling) for more info.
 
 ```ts
@@ -822,27 +873,6 @@ const getNextPage = getList.paginated(
 
 `removeCusor` is a function that takes the arguments sent in fetch of `getNextPage` and returns
 the arguments to update `getList`.
-
-### push
-
-This is a convenience to place newly created Entities at the _end_ of a [Collection](./Collection.md).
-
-When this `RestEndpoint`'s schema contains a [Collection](./Collection.md), this returned a new
-RestEndpoint with its parents properties, but with [method](#method): 'POST' and schema: [Collection.push](./Collection.md#push)
-
-### unshift
-
-This is a convenience to place newly created Entities at the _start_ of a [Collection](./Collection.md).
-
-When this `RestEndpoint`'s schema contains a [Collection](./Collection.md), this returned a new
-RestEndpoint with its parents properties, but with [method](#method): 'POST' and schema: [Collection.push](./Collection.md#unshift)
-
-### assign
-
-This is a convenience to add newly created Entities to a [Values](./Values.md) [Collection](./Collection.md).
-
-When this `RestEndpoint`'s schema contains a [Collection](./Collection.md), this returned a new
-RestEndpoint with its parents properties, but with [method](#method): 'POST' and schema: [Collection.push](./Collection.md#assign)
 
 ## Inheritance
 

--- a/docs/rest/api/createResource.md
+++ b/docs/rest/api/createResource.md
@@ -84,6 +84,10 @@ Passed to [RestEndpoint.searchParams](./RestEndpoint.md#searchParams) for [getLi
 
 Passed to [RestEndpoint.body](./RestEndpoint.md#body) for [getList.push](#push) [update](#update) and [partialUpdate](#partialUpdate)
 
+### paginationField
+
+If specified, will add [Resource.getList.getPage](#getpage) method on the `Resource`.
+
 ### optimistic
 
 `true` makes all mutation endpoints [optimistic](../guides/optimistic-updates.md)
@@ -102,6 +106,8 @@ new endpoints](#customizing-resources) based to match your API.
 
 ### get
 
+Retrieve a singular item.
+
 - method: 'GET'
 - path: `path`
 - schema: [schema](#schema)
@@ -117,6 +123,8 @@ createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }).get({
 Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidate](/docs/api/Controller#invalidate)
 
 ### getList
+
+Retrieve a list of items.
 
 - method: 'GET'
 - path: `shortenPath(path)`
@@ -139,8 +147,10 @@ Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidat
 
 ### getList.push {#push}
 
-- `getList.push`
+Creates a new entity and pushes it to the end of getList.
+
 - method: 'POST'
+- path: `shortenPath(path)`
 - schema: `getList.schema.push`
 
 ```typescript
@@ -154,7 +164,51 @@ createResource({
 
 Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 
+### getList.unshift {#unshift}
+
+Creates a new entity and pushes it to the beginning of getList.
+
+- method: 'POST'
+- path: `shortenPath(path)`
+- schema: `getList.schema.unshift`
+
+```typescript
+// POST //test.com/api/abc
+// BODY { "title": "winning" }
+createResource({
+  urlPrefix: '//test.com',
+  path: '/api/:group/:id',
+}).getList.push({ group: 'abc' }, { title: 'winning' });
+```
+
+Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
+
+### getList.getPage {#getpage}
+
+Retrieves another [page](../guides/pagination.md#infinite-scrolling) appending to getList ensuring there are no duplicates.
+
+- method: 'GET'
+- args: `shortenPath(path) & { [paginationField]: string | number } & searchParams`
+- schema: [new schema.Collection(\[schema\]).addWith(paginatedMerge, paginatedFilter(removeCursor))](./Collection.md)
+
+```typescript
+// GET //test.com/api/abc?isExtra=xyz&page=2
+createResource({
+  urlPrefix: '//test.com',
+  path: '/api/:group/:id',
+  paginationField: 'page',
+}).getList.getPage({
+  group: 'abc',
+  isExtra: 'xyz',
+  page: '2',
+});
+```
+
+Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
+
 ### update
+
+Update an item.
 
 - method: 'PUT'
 - path: `path`
@@ -173,6 +227,8 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 
 ### partialUpdate
 
+Update some subset of fields of an item.
+
 - method: 'PATCH'
 - path: `path`
 - schema: `schema`
@@ -189,6 +245,8 @@ createResource({
 Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 
 ### delete
+
+Deletes an item.
 
 - method: 'DELETE'
 - path: `path`

--- a/docs/rest/guides/pagination.md
+++ b/docs/rest/guides/pagination.md
@@ -2,6 +2,8 @@
 title: Pagination
 ---
 
+import StackBlitz from '@site/src/components/StackBlitz';
+
 <head>
   <title>Paginating REST data</title>
 </head>
@@ -9,7 +11,7 @@ title: Pagination
 ## Infinite Scrolling
 
 In case you want to append results to your existing list, rather than move to another page
-[RestEndpoint.paginated()](api/RestEndpoint.md#paginated) can be used.
+[RestEndpoint.getPage](api/RestEndpoint.md#getPage) can be used.
 
 ```typescript title="api/News.ts"
 import { Entity, createResource } from '@data-client/rest';
@@ -28,15 +30,12 @@ export class News extends Entity {
 export const NewsResource = createResource({
   path: '/news/:id',
   schema: News,
+  paginationField: 'cursor',
 })
   .extend('getList', {
     // custom schema
     schema: { results: new schema.Collection([News]), cursor: '' },
-  })
-  .extend(Base => ({
-    // this creates a pagination endpoint that will extend the getList endpoint
-    getNextPage: getList.paginated('cursor'),
-  }));
+  });
 ```
 
 Since UI behaviors vary widely, and implementations vary from platform (react-native or web),
@@ -53,13 +52,17 @@ function NewsList() {
 
   return (
     <Pagination
-      onPaginate={() => ctrl.fetch(NewsResource.getNextPage, { cursor })}
+      onPaginate={() => ctrl.fetch(NewsResource.getPage, { cursor })}
     >
       <NewsList data={results} />
     </Pagination>
   );
 }
 ```
+
+### Demo
+
+<StackBlitz app="github-app" file="src/resources/Issue.tsx,src/pages/NextPage.tsx" />
 
 ## Tokens in Body
 

--- a/examples/github-app/src/pages/IssueList.tsx
+++ b/examples/github-app/src/pages/IssueList.tsx
@@ -1,9 +1,10 @@
 import { useLive } from '@data-client/react';
 import { List } from 'antd';
+import parseLink from 'parse-link-header';
 import { Issue, IssueResource } from 'resources/Issue';
 
 import IssueListItem from './IssueListItem';
-import LinkPagination from '../navigation/LinkPagination';
+import NextPage from './NextPage';
 
 export default function IssueList({ owner, repo, page, q }: Props) {
   const {
@@ -12,9 +13,9 @@ export default function IssueList({ owner, repo, page, q }: Props) {
   } = useLive(IssueResource.search, {
     owner,
     repo,
-    page,
     q,
   });
+  const nextPage = parseLink(link)?.next?.page;
 
   return (
     <>
@@ -23,9 +24,11 @@ export default function IssueList({ owner, repo, page, q }: Props) {
         dataSource={issues}
         renderItem={(issue) => <IssueListItem key={issue.pk()} issue={issue} />}
       />
-      <div className="center">
-        <LinkPagination link={link} />
-      </div>
+      {nextPage ? (
+        <div className="center">
+          <NextPage owner={owner} repo={repo} q={q} />
+        </div>
+      ) : null}
     </>
   );
 }

--- a/examples/github-app/src/pages/NextPage.tsx
+++ b/examples/github-app/src/pages/NextPage.tsx
@@ -1,29 +1,32 @@
+import { useLoading } from '@data-client/hooks';
 import { useController } from '@data-client/react';
+import { Button } from 'antd';
 import { useState } from 'react';
 import { IssueResource } from 'resources/Issue';
 
 export default function NextPage({
   repo,
   owner,
-  page,
+  q,
 }: {
   repo: string;
   owner: string;
-  page: number;
+  q: string;
 }) {
   const ctrl = useController();
-  const [count, setCount] = useState(0);
-  const loadMore = () => {
-    ctrl.fetch(IssueResource.getList.paginated('page'), {
-      page: page + count + 1,
+  const [count, setCount] = useState(1);
+  const [loadMore, loading] = useLoading(async () => {
+    await ctrl.fetch(IssueResource.search.getPage, {
+      page: (count + 1).toString(),
       repo,
       owner,
+      q,
     });
     setCount((count) => count + 1);
-  };
+  });
   return (
-    <div>
-      <button onClick={loadMore}>Load more</button>
+    <div style={{ textAlign: 'center' }}>
+      {loading ? 'loading...' : <Button onClick={loadMore}>Load more</Button>}
     </div>
   );
 }

--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -94,6 +94,7 @@ export function createGithubResource<O extends ResourceGenerics>(
 ): GithubResource<O> {
   const baseResource = createResource({
     Endpoint: GithubEndpoint,
+    paginationField: 'page',
     ...options,
   });
 
@@ -123,6 +124,7 @@ export interface GithubResource<
         results: schema.Collection<O['schema'][]>;
         link: string;
       };
+      readonly paginationField: 'page';
     }
   >;
 }

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -110,7 +110,8 @@ export default class CollectionSchema<
       ? this.argsKey(...args)
       : this.nestKey(parent, key);
     for (const key in obj) {
-      if (typeof obj[key] !== 'string') obj[key] = `${obj[key]}`;
+      if (typeof obj[key] !== 'string' && obj[key] !== undefined)
+        obj[key] = `${obj[key]}`;
     }
     return JSON.stringify(obj);
   }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -72,6 +72,7 @@ const ArticleResource = createResource({
   schema: Article,
   searchParams: {} as { author?: string },
   optimistic: true,
+  paginationField: 'cursor',
 });
 ```
 

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -312,6 +312,39 @@ exports[`CacheProvider RestEndpoint/next should update on get for a paginated re
 }
 `;
 
+exports[`CacheProvider pagination should ignore undefined values 1`] = `
+[
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": [],
+    "title": "the next time",
+  },
+]
+`;
+
 exports[`CacheProvider pagination should work with cursor field from getList.paginated 1`] = `
 [
   Article {
@@ -720,6 +753,39 @@ exports[`ExternalCacheProvider RestEndpoint/next should update on get for a pagi
     },
   ],
 }
+`;
+
+exports[`ExternalCacheProvider pagination should ignore undefined values 1`] = `
+[
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  Article {
+    "author": User {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": [],
+    "title": "the next time",
+  },
+]
 `;
 
 exports[`ExternalCacheProvider pagination should work with cursor field from getList.paginated 1`] = `

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -231,6 +231,10 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
     return this.extend({ update: paginationUpdate(this, removeCursor) });
   }
 
+  get getPage() {
+    return this.paginated(this.paginationField);
+  }
+
   get push() {
     return this.extend({
       method: 'POST',

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -30,6 +30,7 @@ export default function createResource<O extends ResourceGenerics>({
   schema,
   Endpoint = RestEndpoint,
   optimistic,
+  paginationField,
   ...extraOptions
 }: Readonly<O> & ResourceOptions): Resource<O> {
   const shortenedPath = shortenPath(path);
@@ -50,10 +51,13 @@ export default function createResource<O extends ResourceGenerics>({
     }) as any;
   if (optimistic) {
     (extraMutateOptions as any).getOptimisticResponse = optimisticUpdate;
-    (extraPartialOptions as any).getOptimisticResponse = optimisticPartial(get);
+    (extraPartialOptions as any).getOptimisticResponse = optimisticPartial(
+      get as any,
+    );
   }
   const getList = new Endpoint({
     ...extraMutateOptions,
+    paginationField: paginationField as string,
     path: shortenedPath,
     schema: new Collection([schema as any]),
     name: getName('getList'),

--- a/packages/rest/src/paginatedCollections.ts
+++ b/packages/rest/src/paginatedCollections.ts
@@ -9,9 +9,9 @@ export function paginatedMerge(existing: any[], incoming: any[]) {
 export const paginatedFilter =
   <C extends (...args: readonly any[]) => readonly any[]>(removeCursor: C) =>
   (...args: Parameters<C>) => {
-    const noCursorArgs = removeCursor(...args);
+    const noCursorArgs = removeCursor(...args)[0] ?? {};
     return (collectionKey: Record<string, string>) =>
-      shallowEqual(collectionKey, noCursorArgs[0] ?? {});
+      shallowEqual(collectionKey, noCursorArgs);
   };
 
 function shallowEqual(
@@ -20,13 +20,17 @@ function shallowEqual(
 ) {
   const keys1 = Object.keys(object1);
   const keys2 = Object.keys(object2);
-  if (keys1.length !== keys2.length) {
-    return false;
-  }
-  for (const key of keys1) {
-    if (object1[key] != object2[key]) {
+  let length2 = 0;
+  for (const key of keys2) {
+    // we should ignore any members with value undefined
+    if (object2[key] === undefined) continue;
+    if (object1[key] !== `${object2[key]}`) {
       return false;
     }
+    length2++;
+  }
+  if (keys1.length !== length2) {
+    return false;
   }
   return true;
 }

--- a/packages/rest/src/resourceTypes.ts
+++ b/packages/rest/src/resourceTypes.ts
@@ -23,6 +23,8 @@ export interface ResourceGenerics {
   /** Only used for types */
   /** @see https://resthooks.io/rest/api/createResource#searchParams */
   readonly searchParams?: any;
+  /** @see https://resthooks.io/rest/api/createResource#paginationfield */
+  readonly paginationField?: string;
 }
 /** The untyped options for createResource() */
 export interface ResourceOptions {
@@ -65,22 +67,26 @@ export interface Resource<
    * @see https://resthooks.io/rest/api/createResource#getlist
    */
   getList: 'searchParams' extends keyof O
-    ? GetEndpoint<{
-        path: ShortenPath<O['path']>;
-        schema: schema.Collection<[O['schema']]>;
-        body: 'body' extends keyof O
-          ? O['body']
-          : Partial<Denormalize<O['schema']>>;
-        searchParams: O['searchParams'];
-      }>
-    : GetEndpoint<{
-        path: ShortenPath<O['path']>;
-        schema: schema.Collection<[O['schema']]>;
-        body: 'body' extends keyof O
-          ? O['body']
-          : Partial<Denormalize<O['schema']>>;
-        searchParams: Record<string, number | string | boolean> | undefined;
-      }>;
+    ? GetEndpoint<
+        {
+          path: ShortenPath<O['path']>;
+          schema: schema.Collection<[O['schema']]>;
+          body: 'body' extends keyof O
+            ? O['body']
+            : Partial<Denormalize<O['schema']>>;
+          searchParams: O['searchParams'];
+        } & Pick<O, 'paginationField'>
+      >
+    : GetEndpoint<
+        {
+          path: ShortenPath<O['path']>;
+          schema: schema.Collection<[O['schema']]>;
+          body: 'body' extends keyof O
+            ? O['body']
+            : Partial<Denormalize<O['schema']>>;
+          searchParams: Record<string, number | string | boolean> | undefined;
+        } & Pick<O, 'paginationField'>
+      >;
   /** Create a new item (POST)
    *
    * @deprecated use Resource.getList.push instead

--- a/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
@@ -730,6 +730,7 @@ interface RestInstanceBase<
   /** @see https://resthooks.io/rest/api/RestEndpoint#method */
   readonly method: (O & { method: string })['method'];
   readonly signal: AbortSignal | undefined;
+  readonly paginationField?: string;
 
   /* fetch lifecycles */
   /* before-fetch */
@@ -761,10 +762,15 @@ interface RestInstanceBase<
   /** Creates a child endpoint that inherits from this while overriding provided `options`.
    * @see https://dataclient.io/rest/api/RestEndpoint#extend
    */
-  extend<E extends RestInstanceBase, O extends PartialRestGenerics | {}>(
+  extend<
+    E extends RestInstanceBase,
+    ExtendOptions extends PartialRestGenerics | {},
+  >(
     this: E,
-    options: Readonly<RestEndpointExtendOptions<O, E, F> & O>,
-  ): RestExtendedEndpoint<O, E>;
+    options: Readonly<
+      RestEndpointExtendOptions<ExtendOptions, E, F> & ExtendOptions
+    >,
+  ): RestExtendedEndpoint<ExtendOptions, E>;
 }
 
 interface RestInstance<
@@ -776,9 +782,10 @@ interface RestInstance<
     body?: any;
     searchParams?: any;
     method?: string;
+    paginationField?: string;
   } = { path: string },
 > extends RestInstanceBase<F, S, M, O> {
-  /** Endpoint to append the next page extending a list for pagination
+  /** Creates an Endpoint to append the next page extending a list for pagination
    * @see https://dataclient.io/rest/api/RestEndpoint#paginated
    */
   paginated<
@@ -795,6 +802,17 @@ interface RestInstance<
     this: E,
     cursorField: C,
   ): PaginationFieldEndpoint<E, C>;
+  /** Endpoint to append the next page extending a list for pagination
+   * @see https://dataclient.io/rest/api/RestEndpoint#getPage
+   */
+  getPage: 'paginationField' extends keyof O
+    ? O['paginationField'] extends string
+      ? PaginationFieldEndpoint<
+          F & { schema: S; sideEffect: M } & O,
+          O['paginationField']
+        >
+      : undefined
+    : undefined;
   /** Endpoint that pushes (place at end) a newly created entity to this Collection
    * @see https://dataclient.io/rest/api/RestEndpoint#push
    */
@@ -843,11 +861,16 @@ type RestEndpointExtendOptions<
     ? Extract<O['schema'], Schema | undefined>
     : E['schema']
 > &
-  Partial<Omit<E, KeyofRestEndpoint | keyof PartialRestGenerics>>;
+  Partial<
+    Omit<
+      E,
+      KeyofRestEndpoint | keyof PartialRestGenerics | keyof RestEndpointOptions
+    >
+  >;
 
 type OptionsToRestEndpoint<
   O extends PartialRestGenerics,
-  E extends RestInstanceBase & { body?: any },
+  E extends RestInstanceBase & { body?: any; paginationField?: string },
   F extends FetchFunction,
 > = 'path' extends keyof O
   ? RestType<
@@ -870,6 +893,9 @@ type OptionsToRestEndpoint<
           ? O['searchParams']
           : E['searchParams'];
         method: 'method' extends keyof O ? O['method'] : E['method'];
+        paginationField: 'paginationField' extends keyof O
+          ? O['paginationField']
+          : E['paginationField'];
       }
     >
   : 'body' extends keyof O
@@ -893,6 +919,9 @@ type OptionsToRestEndpoint<
           ? O['searchParams']
           : E['searchParams'];
         method: 'method' extends keyof O ? O['method'] : E['method'];
+        paginationField: 'paginationField' extends keyof O
+          ? O['paginationField']
+          : Extract<E['paginationField'], string>;
       }
     >
   : 'searchParams' extends keyof O
@@ -912,6 +941,9 @@ type OptionsToRestEndpoint<
         body: E['body'];
         searchParams: O['searchParams'];
         method: 'method' extends keyof O ? O['method'] : E['method'];
+        paginationField: 'paginationField' extends keyof O
+          ? O['paginationField']
+          : Extract<E['paginationField'], string>;
       }
     >
   : RestInstance<
@@ -927,15 +959,21 @@ type OptionsToRestEndpoint<
           ? O['searchParams']
           : E['searchParams'];
         method: 'method' extends keyof O ? O['method'] : E['method'];
+        paginationField: 'paginationField' extends keyof O
+          ? O['paginationField']
+          : E['paginationField'];
       }
     >;
 
 type RestExtendedEndpoint<
   O extends PartialRestGenerics,
-  E extends RestInstanceBase,
+  E extends RestInstanceBase & { getPage?: unknown },
 > = OptionsToRestEndpoint<
   O,
-  E,
+  E &
+    (E extends { getPage: { paginationField: string } }
+      ? { paginationField: E['getPage']['paginationField'] }
+      : unknown),
   RestInstance<
     (
       ...args: Parameters<E>
@@ -950,13 +988,20 @@ type RestExtendedEndpoint<
   Omit<E, KeyofRestEndpoint | keyof O>;
 
 interface PartialRestGenerics {
+  /** @see https://resthooks.io/rest/api/RestEndpoint#path */
   readonly path?: string;
+  /** @see https://resthooks.io/rest/api/RestEndpoint#schema */
   readonly schema?: Schema | undefined;
+  /** @see https://resthooks.io/rest/api/RestEndpoint#method */
   readonly method?: string;
   /** Only used for types */
+  /** @see https://dataclient.io/rest/api/RestEndpoint#body */
   body?: any;
   /** Only used for types */
+  /** @see https://dataclient.io/rest/api/RestEndpoint#searchParams */
   searchParams?: any;
+  /** @see https://dataclient.io/rest/api/RestEndpoint#paginationfield */
+  readonly paginationField?: string;
   /** @see https://resthooks.io/rest/api/RestEndpoint#process */
   process?(value: any, ...args: any): any;
 }
@@ -967,7 +1012,7 @@ interface RestGenerics extends PartialRestGenerics {
 type PaginationEndpoint<
   E extends FetchFunction & RestGenerics & { sideEffect?: true | undefined },
   A extends any[],
-> = RestInstance<
+> = RestInstanceBase<
   ParamFetchNoBody<A[0], ResolveType<E>>,
   E['schema'],
   E['sideEffect'],
@@ -978,7 +1023,7 @@ type PaginationEndpoint<
 type PaginationFieldEndpoint<
   E extends FetchFunction & RestGenerics & { sideEffect?: true | undefined },
   C extends string,
-> = RestInstance<
+> = RestInstanceBase<
   ParamFetchNoBody<
     { [K in C]: string | number | boolean } & E['searchParams'] &
       PathArgs<Exclude<E['path'], undefined>>,
@@ -989,7 +1034,7 @@ type PaginationFieldEndpoint<
   Pick<E, 'path' | 'searchParams' | 'body'> & {
     searchParams: { [K in C]: string | number | boolean } & E['searchParams'];
   }
->;
+> & { paginationField: C };
 type AddEndpoint<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = any,
@@ -1121,7 +1166,8 @@ type RestType<
     path: string;
     body?: any;
     searchParams?: any;
-  } = { path: string },
+    paginationField?: string;
+  } = { path: string; paginationField: string },
   // eslint-disable-next-line @typescript-eslint/ban-types
 > = IfTypeScriptLooseNull<
   RestInstance<
@@ -1254,6 +1300,7 @@ type GetEndpoint<
     readonly schema: Schema;
     /** Only used for types */
     readonly searchParams?: any;
+    readonly paginationField?: string;
   } = {
     path: string;
     schema: Schema;
@@ -1355,6 +1402,8 @@ interface ResourceGenerics {
     /** Only used for types */
     /** @see https://resthooks.io/rest/api/createResource#searchParams */
     readonly searchParams?: any;
+    /** @see https://resthooks.io/rest/api/createResource#paginationfield */
+    readonly paginationField?: string;
 }
 /** The untyped options for createResource() */
 interface ResourceOptions {
@@ -1404,12 +1453,12 @@ interface Resource<O extends ResourceGenerics = {
         schema: Collection<[O['schema']]>;
         body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
         searchParams: O['searchParams'];
-    }> : GetEndpoint<{
+    } & Pick<O, 'paginationField'>> : GetEndpoint<{
         path: ShortenPath<O['path']>;
         schema: Collection<[O['schema']]>;
         body: 'body' extends keyof O ? O['body'] : Partial<Denormalize<O['schema']>>;
         searchParams: Record<string, number | string | boolean> | undefined;
-    }>;
+    } & Pick<O, 'paginationField'>>;
     /** Create a new item (POST)
      *
      * @deprecated use Resource.getList.push instead
@@ -1472,6 +1521,6 @@ interface ResourceInterface {
  *
  * @see https://resthooks.io/rest/api/createResource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
+declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 
 export { AddEndpoint, Defaults, FetchGet, FetchMutate, FromFallBack, GetEndpoint, KeyofRestEndpoint, MethodToSide, MutateEndpoint, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, PartialRestGenerics, Resource, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, createResource };

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2219,20 +2219,20 @@ __metadata:
 
 "@data-client/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.2.3
-  resolution: "@data-client/endpoint@file:../packages/endpoint#../packages/endpoint::hash=4a5d1f&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@data-client/endpoint@file:../packages/endpoint#../packages/endpoint::hash=be559e&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 671b7029d27178461161fd1bb66ebd40ea9e82794a009abcce7c4507160ff8c7b5e23a3b74830eabfe16a839c5538471be57935a255c58eab22efbd7ba0d1132
+  checksum: 31b4d13f68328b4ace8630d5ba24a4a104a312a07ee2bea8cf6fc64d9860d5074394bfbc45543c81eaec13d1a11760ba34e377ed3682b8e24b17bac100db5f6b
   languageName: node
   linkType: hard
 
 "@data-client/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.2.1
-  resolution: "@data-client/graphql@file:../packages/graphql#../packages/graphql::hash=a63c27&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@data-client/graphql@file:../packages/graphql#../packages/graphql::hash=5df4b4&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@data-client/endpoint": ^0.2.2
-  checksum: 69a3035faaea886879bd9d52dd76a8971f72c9b81a52cf206ae57840f764e2722e5273a7466a34a4a1fdd81768771a7f762a7ec06bbb90a6ce54651450f2384c
+  checksum: c2b46b71581428e5a5a49ba54fc3b769ccda4bfbc91b7a91dc5921dcefd924c934bb03acfd115d44dda87c0c3ef0358bf21139ee2c3ab17d39f37f9bfe6ecae1
   languageName: node
   linkType: hard
 
@@ -2263,7 +2263,7 @@ __metadata:
 
 "@data-client/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.3.0
-  resolution: "@data-client/react@file:../packages/react#../packages/react::hash=72902e&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@data-client/react@file:../packages/react#../packages/react::hash=07eae3&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@data-client/core": ^0.3.0
@@ -2277,18 +2277,18 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 8a12bdccffe1bb88dd7c872b2729d89ae1650c5fb4df92ce1c05d7f194c4d09e12022fed0a3ee042c74bab6531692e82073a44e86af09b071f7a21845e0ee407
+  checksum: e91f7fb8a40a2adc7b122b3fa04e12d10e6e77338f5d56e6164d5c8e7657c30a8070cf271f647389da7cc5318518353052870300b637e9e63848308f8a9872b7
   languageName: node
   linkType: hard
 
 "@data-client/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.6.0
-  resolution: "@data-client/rest@file:../packages/rest#../packages/rest::hash=87f092&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@data-client/rest@file:../packages/rest#../packages/rest::hash=e79c9d&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@data-client/endpoint": ^0.2.3
     path-to-regexp: ^6.2.1
-  checksum: 38706b67282564ce9a058669ad16406276b8d9aeef4b2402de325b88881d8d94ca186244a4ce6e27e69d71637ad1dd9fa8bb9a929f6f1109947e735418495ce5
+  checksum: 3113626a4655df0f1f6875b54250e5b9b717b8e818f679cc29ab4a1341b19310a5d35e5bb98ff2bc031c89ef9433038454ea6a260ce0f1f01723e0b07bdbc7a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
DRY

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

`paginationField` is added to both [createResource](https://dataclient.io/rest/api/createResource) and [RestEndpoint](https://dataclient.io/rest/api/RestEndpoint)

When provided, adds a specialized extender (like push/unshift/assign) to the list. This also only works with [collections](https://dataclient.io/rest/api/Collection).

```ts
const TodoResource = createResource({
  path: '/todos/:id',
  schema: Todo,
  paginationField: 'page',
}).getList.getPage({ page: '2' });
```