### PR TITLE
feat: Add controller.fetchIfStale()

### DIFF
--- a/.changeset/tidy-kiwis-trade.md
+++ b/.changeset/tidy-kiwis-trade.md
@@ -1,0 +1,34 @@
+---
+'@data-client/core': minor
+'@data-client/react': minor
+'@rest-hooks/core': minor
+'@rest-hooks/react': minor
+---
+
+Add controller.fetchIfStale()
+
+Fetches only if endpoint is considered '[stale](../concepts/expiry-policy.md#stale)'; otherwise returns undefined.
+
+This can be useful when prefetching data, as it avoids overfetching fresh data.
+
+An [example](https://stackblitz.com/github/data-client/rest-hooks/tree/master/examples/github-app?file=src%2Frouting%2Froutes.tsx) with a fetch-as-you-render router:
+
+```ts
+{
+  name: 'IssueList',
+  component: lazyPage('IssuesPage'),
+  title: 'issue list',
+  resolveData: async (
+    controller: Controller,
+    { owner, repo }: { owner: string; repo: string },
+    searchParams: URLSearchParams,
+  ) => {
+    const q = searchParams?.get('q') || 'is:issue is:open';
+    await controller.fetchIfStale(IssueResource.search, {
+      owner,
+      repo,
+      q,
+    });
+  },
+},
+```

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -15,6 +15,7 @@ import TabItem from '@theme/TabItem';
 class Controller {
   /*************** Action Dispatchers ***************/
   fetch(endpoint, ...args): ReturnType<E>;
+  fetchIfStale(endpoint, ...args): ReturnType<E> | undefined;
   expireAll({ testKey }): Promise<void>;
   invalidate(endpoint, ...args): Promise<void>;
   invalidateAll({ testKey }): Promise<void>;
@@ -143,6 +144,36 @@ post.pk();
 - Resolves _after_ committing Reactive Data Client cache updates.
 - Identical requests are deduplicated globally; allowing only one inflight request at a time.
   - To ensure a _new_ request is started, make sure to abort any existing inflight requests.
+
+## fetchIfStale(endpoint, ...args) {#fetchIfStale}
+
+Fetches only if endpoint is considered '[stale](../concepts/expiry-policy.md#stale)'; otherwise returns undefined.
+
+This can be useful when prefetching data, as it avoids overfetching fresh data.
+
+An [example](https://stackblitz.com/github/data-client/rest-hooks/tree/master/examples/github-app?file=src%2Frouting%2Froutes.tsx) with a fetch-as-you-render router:
+
+```ts
+{
+  name: 'IssueList',
+  component: lazyPage('IssuesPage'),
+  title: 'issue list',
+  resolveData: async (
+    controller: Controller,
+    { owner, repo }: { owner: string; repo: string },
+    searchParams: URLSearchParams,
+  ) => {
+    const q = searchParams?.get('q') || 'is:issue is:open';
+    // highlight-start
+    await controller.fetchIfStale(IssueResource.search, {
+      owner,
+      repo,
+      q,
+    });
+    // highlight-end
+  },
+},
+```
 
 ## expireAll({ testKey }) {#expireAll}
 

--- a/examples/github-app/src/pages/IssueList.tsx
+++ b/examples/github-app/src/pages/IssueList.tsx
@@ -1,4 +1,4 @@
-import { useLive } from '@data-client/react';
+import { useSuspense } from '@data-client/react';
 import { List } from 'antd';
 import parseLink from 'parse-link-header';
 import { Issue, IssueResource } from 'resources/Issue';
@@ -10,7 +10,7 @@ export default function IssueList({ owner, repo, page, q }: Props) {
   const {
     results: { items: issues },
     link,
-  } = useLive(IssueResource.search, {
+  } = useSuspense(IssueResource.search, {
     owner,
     repo,
     q,

--- a/examples/github-app/src/routing/routes.tsx
+++ b/examples/github-app/src/routing/routes.tsx
@@ -35,7 +35,7 @@ export const routes = [
       controller: Controller,
       { owner, repo }: { owner: string; repo: string },
     ) => {
-      controller.fetch(IssueResource.search, { owner, repo });
+      controller.fetchIfStale(IssueResource.search, { owner, repo });
     },
   },
   {
@@ -47,7 +47,7 @@ export const routes = [
       searchParams: URLSearchParams,
     ) => {
       const q = searchParams?.get('q') || 'is:pr is:open';
-      await controller.fetch(IssueResource.search, {
+      await controller.fetchIfStale(IssueResource.search, {
         owner,
         repo,
         q,
@@ -64,7 +64,7 @@ export const routes = [
       searchParams: URLSearchParams,
     ) => {
       const q = searchParams?.get('q') || 'is:issue is:open';
-      await controller.fetch(IssueResource.search, {
+      await controller.fetchIfStale(IssueResource.search, {
         owner,
         repo,
         q,
@@ -78,9 +78,13 @@ export const routes = [
       controller: Controller,
       { owner, repo, number }: { owner: string; repo: string; number: string },
     ) => {
-      controller.fetch(ReactionResource.getList, { owner, repo, number });
-      controller.fetch(CommentResource.getList, { owner, repo, number });
-      await controller.fetch(IssueResource.get, { owner, repo, number });
+      controller.fetchIfStale(ReactionResource.getList, {
+        owner,
+        repo,
+        number,
+      });
+      controller.fetchIfStale(CommentResource.getList, { owner, repo, number });
+      await controller.fetchIfStale(IssueResource.get, { owner, repo, number });
     },
   },
   {
@@ -90,15 +94,15 @@ export const routes = [
       controller: Controller,
       { login }: { login: string },
     ) => {
-      controller.fetch(UserResource.get, { login });
-      controller.fetch(RepositoryResource.getByUser, { login });
+      controller.fetchIfStale(UserResource.get, { login });
+      controller.fetchIfStale(RepositoryResource.getByUser, { login });
       const { data: currentUser } = controller.getResponse(
         UserResource.current,
         controller.getState(),
       );
       if (currentUser)
-        controller.fetch(RepositoryResource.getByPinned, { login });
-      controller.fetch(EventResource.getList, { login });
+        controller.fetchIfStale(RepositoryResource.getByPinned, { login });
+      controller.fetchIfStale(EventResource.getList, { login });
     },
   },
 ];

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -72,7 +72,7 @@
     "@data-client/endpoint": "^0.2.0"
   },
   "peerDependencies": {
-    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0",
+    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -124,7 +124,7 @@
     "@data-client/core": "^0.3.0"
   },
   "peerDependencies": {
-    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0",
+    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0",
     "redux": "^4.0.0"

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -112,7 +112,7 @@
     "@babel/runtime": "^7.17.0"
   },
   "peerDependencies": {
-    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0",
+    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0",
     "@data-client/redux": "^0.1.0 || ^0.2.0 || ^0.3.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "next": ">=12.0.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -116,7 +116,7 @@
     "react-error-boundary": "^4.0.0"
   },
   "peerDependencies": {
-    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0",
+    "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0",
     "@testing-library/react-hooks": "^8.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0",
     "@types/react-dom": "*",

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -480,6 +480,13 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
         update?: EndpointUpdateFunction<E> | undefined;
     }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>;
     /**
+     * Fetches the endpoint with given args, updating the Rest Hooks cache with the response or error upon completion.
+     * @see https://dataclient.io/docs/api/Controller#fetchIfStale
+     */
+    fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
+        update?: EndpointUpdateFunction<E> | undefined;
+    }>(endpoint: E, ...args_0: Parameters<E>) => (E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>) | undefined;
+    /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://resthooks.io/docs/api/Controller#invalidate
      */

--- a/website/src/components/Playground/editor-types/@data-client/core/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core/next.d.ts
@@ -368,6 +368,13 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
         update?: EndpointUpdateFunction<E> | undefined;
     }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>;
     /**
+     * Fetches the endpoint with given args, updating the Rest Hooks cache with the response or error upon completion.
+     * @see https://dataclient.io/docs/api/Controller#fetchIfStale
+     */
+    fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
+        update?: EndpointUpdateFunction<E> | undefined;
+    }>(endpoint: E, ...args_0: Parameters<E>) => (E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>) | undefined;
+    /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://resthooks.io/docs/api/Controller#invalidate
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,7 +3088,7 @@ __metadata:
     "@types/node": ^20.0.0
     "@types/react": ^18.0.30
   peerDependencies:
-    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0
+    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
@@ -3144,7 +3144,7 @@ __metadata:
     "@types/react": ^18.0.30
     redux: ^4.2.1
   peerDependencies:
-    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0
+    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0
     redux: ^4.0.0
@@ -3182,7 +3182,7 @@ __metadata:
     react-dom: ^18.2.0
     redux: ^4.2.1
   peerDependencies:
-    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0
+    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0
     "@data-client/redux": ^0.1.0 || ^0.2.0 || ^0.3.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     next: ">=12.0.0"
@@ -3213,7 +3213,7 @@ __metadata:
     jest: ^29.5.0
     react-error-boundary: ^4.0.0
   peerDependencies:
-    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0
+    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0
     "@testing-library/react-hooks": ^8.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
     "@types/react-dom": "*"


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes https://github.com/data-client/rest-hooks/discussions/2402

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Avoid overfetching when performing fetch-as-you-render patterns

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Add controller.fetchIfStale()

Fetches only if endpoint is considered '[stale](../concepts/expiry-policy.md#stale)'; otherwise returns undefined.

This can be useful when prefetching data, as it avoids overfetching fresh data.

An [example](https://stackblitz.com/github/data-client/rest-hooks/tree/master/examples/github-app?file=src%2Frouting%2Froutes.tsx) with a fetch-as-you-render router:

```ts
{
  name: 'IssueList',
  component: lazyPage('IssuesPage'),
  title: 'issue list',
  resolveData: async (
    controller: Controller,
    { owner, repo }: { owner: string; repo: string },
    searchParams: URLSearchParams,
  ) => {
    const q = searchParams?.get('q') || 'is:issue is:open';
    await controller.fetchIfStale(IssueResource.search, {
      owner,
      repo,
      q,
    });
  },
},
```

#### Stale

```tsx
Date.now() <= expiresAt && expiryStatus !== ExpiryStatus.Invalid
```
