### PR TITLE
enhance: controller.fetchIfStale() resolves to data from store if it does not fetch

### DIFF
--- a/.changeset/tidy-coats-drum.md
+++ b/.changeset/tidy-coats-drum.md
@@ -1,0 +1,8 @@
+---
+'@data-client/core': patch
+'@data-client/react': patch
+'@rest-hooks/react': patch
+'@rest-hooks/rest': patch
+---
+
+controller.fetchIfStale() resolves to data from store if it does not fetch

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -147,7 +147,7 @@ post.pk();
 
 ## fetchIfStale(endpoint, ...args) {#fetchIfStale}
 
-Fetches only if endpoint is considered '[stale](../concepts/expiry-policy.md#stale)'; otherwise returns undefined.
+Fetches only if endpoint is considered '[stale](../concepts/expiry-policy.md#stale)'.
 
 This can be useful when prefetching data, as it avoids overfetching fresh data.
 

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -27,7 +27,7 @@ the latest Reactive Data Client clients.
 
 [Resources](./api/createResource.md) are a collection of `methods` for a given `data model`. [Entities](./api/Entity.md) and [Schemas](./api/schema.md) are the declarative _data model_.
 [RestEndpoint](./api/RestEndpoint.md) are the [_methods_](<https://en.wikipedia.org/wiki/Method_(computer_programming)>) on
-that data. 
+that data.
 
 <Tabs
 defaultValue="Class"
@@ -219,7 +219,9 @@ export default function NewArticleForm() {
   const ctrl = useController();
   return (
     <Form
-      onSubmit={e => ctrl.fetch(ArticleResource.getList.push, new FormData(e.target))}
+      onSubmit={e =>
+        ctrl.fetch(ArticleResource.getList.push, new FormData(e.target))
+      }
     >
       <FormField name="title" />
       <FormField name="content" type="textarea" />

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -127,18 +127,16 @@ export default class Controller<
   >(
     endpoint: E,
     ...args: readonly [...Parameters<E>]
-  ):
-    | (E['schema'] extends undefined | null
-        ? ReturnType<E>
-        : Promise<Denormalize<E['schema']>>)
-    | undefined => {
-    const { expiresAt, expiryStatus } = this.getResponse(
+  ): E['schema'] extends undefined | null
+    ? ReturnType<E> | ResolveType<E>
+    : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']> => {
+    const { data, expiresAt, expiryStatus } = this.getResponse(
       endpoint,
       ...args,
       this.getState(),
     );
     if (expiryStatus !== ExpiryStatus.Invalid && Date.now() <= expiresAt)
-      return;
+      return data as any;
     return this.fetch(endpoint, ...args);
   };
 

--- a/packages/core/src/controller/__tests__/Controller.ts
+++ b/packages/core/src/controller/__tests__/Controller.ts
@@ -30,7 +30,7 @@ describe('Controller', () => {
   });
 
   describe('fetchIfStale', () => {
-    it('should NOT fetch if result is NOT stale', () => {
+    it('should NOT fetch if result is NOT stale', async () => {
       const payload = {
         id: 5,
         title: 'hi ho',
@@ -61,8 +61,11 @@ describe('Controller', () => {
         dispatch: jest.fn(() => Promise.resolve()),
         getState,
       });
-      controller.fetchIfStale(CoolerArticleResource.get, { id: payload.id });
+      const article = await controller.fetchIfStale(CoolerArticleResource.get, {
+        id: payload.id,
+      });
       expect(controller.dispatch.mock.calls.length).toBe(0);
+      expect(article.title).toBe(payload.title);
     });
     it('should fetch if result stale', () => {
       const payload = {
@@ -95,7 +98,9 @@ describe('Controller', () => {
         dispatch: jest.fn(() => Promise.resolve()),
         getState,
       });
-      controller.fetchIfStale(CoolerArticleResource.get, { id: payload.id });
+      controller.fetchIfStale(CoolerArticleResource.get, {
+        id: payload.id,
+      });
 
       expect(controller.dispatch.mock.calls.length).toBe(1);
     });

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -480,12 +480,12 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
         update?: EndpointUpdateFunction<E> | undefined;
     }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>;
     /**
-     * Fetches the endpoint with given args, updating the Rest Hooks cache with the response or error upon completion.
+     * Fetches only if endpoint is considered 'stale'; otherwise returns undefined
      * @see https://dataclient.io/docs/api/Controller#fetchIfStale
      */
     fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<E>) => (E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>) | undefined;
+    }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> | ResolveType<E> : Denormalize<E["schema"]> | Promise<Denormalize<E["schema"]>>;
     /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://resthooks.io/docs/api/Controller#invalidate

--- a/website/src/components/Playground/editor-types/@data-client/core/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core/next.d.ts
@@ -368,12 +368,12 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
         update?: EndpointUpdateFunction<E> | undefined;
     }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>;
     /**
-     * Fetches the endpoint with given args, updating the Rest Hooks cache with the response or error upon completion.
+     * Fetches only if endpoint is considered 'stale'; otherwise returns undefined
      * @see https://dataclient.io/docs/api/Controller#fetchIfStale
      */
     fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<E>) => (E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>) | undefined;
+    }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> | ResolveType<E> : Denormalize<E["schema"]> | Promise<Denormalize<E["schema"]>>;
     /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://resthooks.io/docs/api/Controller#invalidate


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Return value is often used to determine other things. It's more important to use the fetched data than to know if we actually fetched

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Resolve to existing data if it is not fetched.