### PR TITLE
enhance: Collection based pagination updates entire 'root' response

### DIFF
--- a/.changeset/gentle-rivers-decide.md
+++ b/.changeset/gentle-rivers-decide.md
@@ -1,0 +1,9 @@
+---
+'@data-client/rest': patch
+'@rest-hooks/rest': patch
+---
+
+Collection based pagination now replaces the non-list members on page
+
+This allows members like nextPage or 'cursor' to be updated when
+each page is fetched making it easier to know which page to fetch next.

--- a/.changeset/unlucky-boxes-jog.md
+++ b/.changeset/unlucky-boxes-jog.md
@@ -1,0 +1,8 @@
+---
+'@data-client/endpoint': patch
+'@rest-hooks/endpoint': patch
+---
+
+Collections with arguments in different orders now correctly mean the same Collection
+
+This could sometimes result in different instances of a Collection having different values.

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -81,6 +81,7 @@ export const ArticleResource = createResource({
   path: '/article/:id',
   searchParams: {} as { userId?: string } | undefined,
   schema: Article,
+  paginationField: 'page',
 });
 ```
 

--- a/examples/github-app/src/pages/IssueList.tsx
+++ b/examples/github-app/src/pages/IssueList.tsx
@@ -26,7 +26,7 @@ export default function IssueList({ owner, repo, page, q }: Props) {
       />
       {nextPage ? (
         <div className="center">
-          <NextPage owner={owner} repo={repo} q={q} />
+          <NextPage owner={owner} repo={repo} q={q} page={nextPage} />
         </div>
       ) : null}
     </>

--- a/examples/github-app/src/pages/NextPage.tsx
+++ b/examples/github-app/src/pages/NextPage.tsx
@@ -1,28 +1,27 @@
 import { useLoading } from '@data-client/hooks';
 import { useController } from '@data-client/react';
 import { Button } from 'antd';
-import { useState } from 'react';
 import { IssueResource } from 'resources/Issue';
 
 export default function NextPage({
   repo,
   owner,
   q,
+  page,
 }: {
   repo: string;
   owner: string;
   q: string;
+  page: string;
 }) {
   const ctrl = useController();
-  const [count, setCount] = useState(1);
   const [loadMore, loading] = useLoading(async () => {
     await ctrl.fetch(IssueResource.search.getPage, {
-      page: (count + 1).toString(),
+      page,
       repo,
       owner,
       q,
     });
-    setCount((count) => count + 1);
   });
   return (
     <div style={{ textAlign: 'center' }}>

--- a/examples/github-app/webpack.config.js
+++ b/examples/github-app/webpack.config.js
@@ -4,7 +4,7 @@ const options = {
   basePath: 'src',
   buildDir: 'dist/',
   htmlOptions: {
-    title: 'todo-app',
+    title: 'Github App',
     scriptLoading: 'defer',
     template: 'index.ejs',
   },

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -113,7 +113,7 @@ export default class CollectionSchema<
       if (typeof obj[key] !== 'string' && obj[key] !== undefined)
         obj[key] = `${obj[key]}`;
     }
-    return JSON.stringify(obj);
+    return consistentSerialize(obj);
   }
 
   // >>>>>>>>>>>>>>NORMALIZE<<<<<<<<<<<<<<
@@ -319,4 +319,16 @@ function denormalizeOnly(
   return Array.isArray(input)
     ? (this.schema.denormalizeOnly(input, args, unvisit) as any)
     : (this.schema.denormalizeOnly([input], args, unvisit)[0] as any);
+}
+
+/** This serializes in consistent way even if members are added in differnet orders */
+function consistentSerialize(obj: Record<string, unknown>) {
+  const keys = Object.keys(obj).sort();
+  const sortedObj: Record<string, unknown> = {};
+
+  for (const key of keys) {
+    sortedObj[key] = obj[key];
+  }
+
+  return JSON.stringify(sortedObj);
 }

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -12,6 +12,7 @@ Article {
 
 exports[`CacheProvider RestEndpoint/current pagination should work with cursor field parameters 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -88,6 +89,7 @@ exports[`CacheProvider RestEndpoint/current should update collection on push/uns
 
 exports[`CacheProvider RestEndpoint/current should update on get for a paginated resource 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -123,6 +125,7 @@ exports[`CacheProvider RestEndpoint/current should update on get for a paginated
 
 exports[`CacheProvider RestEndpoint/current should update on get for a paginated resource with searchParams 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -168,6 +171,7 @@ Article {
 
 exports[`CacheProvider RestEndpoint/next pagination should work with cursor field parameters 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -244,6 +248,7 @@ exports[`CacheProvider RestEndpoint/next should update collection on push/unshif
 
 exports[`CacheProvider RestEndpoint/next should update on get for a paginated resource 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -279,6 +284,7 @@ exports[`CacheProvider RestEndpoint/next should update on get for a paginated re
 
 exports[`CacheProvider RestEndpoint/next should update on get for a paginated resource with searchParams 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -455,6 +461,7 @@ Article {
 
 exports[`ExternalCacheProvider RestEndpoint/current pagination should work with cursor field parameters 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -531,6 +538,7 @@ exports[`ExternalCacheProvider RestEndpoint/current should update collection on 
 
 exports[`ExternalCacheProvider RestEndpoint/current should update on get for a paginated resource 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -566,6 +574,7 @@ exports[`ExternalCacheProvider RestEndpoint/current should update on get for a p
 
 exports[`ExternalCacheProvider RestEndpoint/current should update on get for a paginated resource with searchParams 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -611,6 +620,7 @@ Article {
 
 exports[`ExternalCacheProvider RestEndpoint/next pagination should work with cursor field parameters 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -687,6 +697,7 @@ exports[`ExternalCacheProvider RestEndpoint/next should update collection on pus
 
 exports[`ExternalCacheProvider RestEndpoint/next should update on get for a paginated resource 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {
@@ -722,6 +733,7 @@ exports[`ExternalCacheProvider RestEndpoint/next should update on get for a pagi
 
 exports[`ExternalCacheProvider RestEndpoint/next should update on get for a paginated resource with searchParams 1`] = `
 {
+  "nextPage": 2,
   "results": [
     Article {
       "author": User {

--- a/packages/react/src/__tests__/integration-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-endpoint.web.tsx
@@ -201,7 +201,7 @@ describe.each([
       expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.current).toBeInstanceOf(SimpleRecord);
-      expect(result.current.nextPage).toBe('');
+      expect(result.current.nextPage).toBe(2);
       expect(result.current.prevPage).toBe('');
       expect(result.current.results).toMatchSnapshot();
       // @ts-expect-error
@@ -428,7 +428,7 @@ describe.each([
     expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current).toBeInstanceOf(SimpleRecord);
-    expect(result.current.nextPage).toBe('');
+    expect(result.current.nextPage).toBe(2);
     expect(result.current.prevPage).toBe('');
     expect(result.current.results).toMatchSnapshot();
   });

--- a/packages/react/src/test-fixtures.ts
+++ b/packages/react/src/test-fixtures.ts
@@ -147,8 +147,10 @@ export const valuesFixture = {
 
 export const paginatedFirstPage = {
   results: nested,
+  nextPage: 2,
 };
 
 export const paginatedSecondPage = {
   results: moreNested,
+  nextPage: 3,
 };

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2207,32 +2207,32 @@ __metadata:
   linkType: hard
 
 "@data-client/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.3.0
-  resolution: "@data-client/core@file:../packages/core#../packages/core::hash=f65112&locator=root-workspace-0b6124%40workspace%3A."
+  version: 0.4.0
+  resolution: "@data-client/core@file:../packages/core#../packages/core::hash=8dc917&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@data-client/normalizr": ^0.2.2
     flux-standard-action: ^2.1.1
-  checksum: 3a1b328503558fd7bac26b475999f389a3efb955c1f379623edb6b53c03c4ea49d763934db5534641652b85f5ef1ac30bdf797cd57c280d73602e7cc7db08070
+  checksum: 188b4fd32f44fb7ce47b7399348f571345901c237012aaad3688170db48070966f27567ddf52d58ed4a32abdef743451a84ab753d2a89f7b050571e79d7836b6
   languageName: node
   linkType: hard
 
 "@data-client/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.2.3
-  resolution: "@data-client/endpoint@file:../packages/endpoint#../packages/endpoint::hash=be559e&locator=root-workspace-0b6124%40workspace%3A."
+  version: 0.2.4
+  resolution: "@data-client/endpoint@file:../packages/endpoint#../packages/endpoint::hash=63ea73&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 31b4d13f68328b4ace8630d5ba24a4a104a312a07ee2bea8cf6fc64d9860d5074394bfbc45543c81eaec13d1a11760ba34e377ed3682b8e24b17bac100db5f6b
+  checksum: 0efeee96f0f71b55c3d5682a22d00aa13a854c77ac080644495579aa3502cce34cab5c8b2682e312e5c38cde6c5ced5ba997c770cc62f81688de486dbd9d84fe
   languageName: node
   linkType: hard
 
 "@data-client/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.2.1
-  resolution: "@data-client/graphql@file:../packages/graphql#../packages/graphql::hash=5df4b4&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@data-client/graphql@file:../packages/graphql#../packages/graphql::hash=a63c27&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@data-client/endpoint": ^0.2.2
-  checksum: c2b46b71581428e5a5a49ba54fc3b769ccda4bfbc91b7a91dc5921dcefd924c934bb03acfd115d44dda87c0c3ef0358bf21139ee2c3ab17d39f37f9bfe6ecae1
+  checksum: 69a3035faaea886879bd9d52dd76a8971f72c9b81a52cf206ae57840f764e2722e5273a7466a34a4a1fdd81768771a7f762a7ec06bbb90a6ce54651450f2384c
   languageName: node
   linkType: hard
 
@@ -2262,11 +2262,11 @@ __metadata:
   linkType: hard
 
 "@data-client/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.3.0
-  resolution: "@data-client/react@file:../packages/react#../packages/react::hash=07eae3&locator=root-workspace-0b6124%40workspace%3A."
+  version: 0.4.0
+  resolution: "@data-client/react@file:../packages/react#../packages/react::hash=992252&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@data-client/core": ^0.3.0
+    "@data-client/core": ^0.4.0
     "@data-client/use-enhanced-reducer": ^0.1.0
   peerDependencies:
     "@react-navigation/native": ^6.0.0
@@ -2277,31 +2277,31 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: e91f7fb8a40a2adc7b122b3fa04e12d10e6e77338f5d56e6164d5c8e7657c30a8070cf271f647389da7cc5318518353052870300b637e9e63848308f8a9872b7
+  checksum: 94640bb0d1ba8e45c9b4f14549939202c2d78a9fddcd424e56806c72020f8e9aec6b75dff6a1cd4a3f6dfa4f60589a7de70f217472b618570c02adb8fec7b81b
   languageName: node
   linkType: hard
 
 "@data-client/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.6.0
-  resolution: "@data-client/rest@file:../packages/rest#../packages/rest::hash=e79c9d&locator=root-workspace-0b6124%40workspace%3A."
+  version: 0.7.0
+  resolution: "@data-client/rest@file:../packages/rest#../packages/rest::hash=dea583&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@data-client/endpoint": ^0.2.3
+    "@data-client/endpoint": ^0.2.4
     path-to-regexp: ^6.2.1
-  checksum: 3113626a4655df0f1f6875b54250e5b9b717b8e818f679cc29ab4a1341b19310a5d35e5bb98ff2bc031c89ef9433038454ea6a260ce0f1f01723e0b07bdbc7a8
+  checksum: 6813a7023074c0f789dd69645bedc79c8fe557568859242d6f6dacbe13fa0bc8e9b00ab711dda99c3308a46331de4d6e38b3eee3687698cbebaa8b0a786902dd
   languageName: node
   linkType: hard
 
 "@data-client/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.3.0
-  resolution: "@data-client/test@file:../packages/test#../packages/test::hash=467718&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@data-client/test@file:../packages/test#../packages/test::hash=7466a8&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^14.0.0
     "@testing-library/react-native": ^12.0.1
     react-error-boundary: ^4.0.0
   peerDependencies:
-    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0
+    "@data-client/react": ^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0
     "@testing-library/react-hooks": ^8.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
     "@types/react-dom": "*"
@@ -2325,7 +2325,7 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: 835e663567a42b1e69efb8b118128216023c7739ebc23bf310f7f14a1309013b2955be0efcff555c591df80160cd86ac088e50a0e5c6b941eb2b98ff58ca5efa
+  checksum: 919edac2134c1371f795e3180d87e31511348df0af59bffbe59fdf00bedfb1078e76a230e6c90c83223b608264482a7b0c40b10c5133b763a0ce5983f6e09f12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The best way to know what page to get next is by using a value sent from the network request. This is required for cursor based pagination, but even for page-based systems there are problems with attempting to track locally as it easily becomes inconsistent with what has been fetched by the server.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Rather than adding a new result and also merging in the existing response:

Next pages should actually replace the whole response - simply merging the list piece. This way it updates with new values like its cursor or page, etc.

To achieve this we modify [RestEndpoint.paginated()](https://dataclient.io/rest/api/RestEndpoint#paginated-function) (only with Collections as other means are 'legacy' and thus we don't want to change behavior):

We now override the Endpoint's key to ensure we remove the cursor from args. We still override the schema, but the pagination schema only overrides merge, and pk (to remove cursor from args). The rest is the same as the parent collection.