### PR TITLE
fix: some versions of RN not working with Collections

### DIFF
--- a/.changeset/young-bulldogs-scream.md
+++ b/.changeset/young-bulldogs-scream.md
@@ -1,0 +1,8 @@
+---
+'@data-client/endpoint': patch
+'@rest-hooks/endpoint': patch
+---
+
+Fix some versions of RN not working with Collections
+
+(Array.sort() does not exist in all versions)

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -1,3 +1,4 @@
+import { consistentSerialize } from './consistentSerialize.js';
 import { CREATE } from './special.js';
 import { PolymorphicInterface } from '../interface.js';
 import {
@@ -321,16 +322,4 @@ function denormalizeOnly(
   return Array.isArray(input)
     ? (this.schema.denormalizeOnly(input, args, unvisit) as any)
     : (this.schema.denormalizeOnly([input], args, unvisit)[0] as any);
-}
-
-/** This serializes in consistent way even if members are added in differnet orders */
-function consistentSerialize(obj: Record<string, unknown>) {
-  const keys = Object.keys(obj).sort();
-  const sortedObj: Record<string, unknown> = {};
-
-  for (const key of keys) {
-    sortedObj[key] = obj[key];
-  }
-
-  return JSON.stringify(sortedObj);
 }

--- a/packages/endpoint/src/schemas/consistentSerialize.native.ts
+++ b/packages/endpoint/src/schemas/consistentSerialize.native.ts
@@ -1,0 +1,16 @@
+/** This serializes in consistent way even if members are added in differnet orders */
+export function consistentSerialize(obj: Record<string, unknown>) {
+  let keys = Object.keys(obj);
+  // sort doesn't always work in RN
+  try {
+    keys = keys.sort();
+    // eslint-disable-next-line no-empty
+  } catch {}
+  const sortedObj: Record<string, unknown> = {};
+
+  for (const key of keys) {
+    sortedObj[key] = obj[key];
+  }
+
+  return JSON.stringify(sortedObj);
+}

--- a/packages/endpoint/src/schemas/consistentSerialize.ts
+++ b/packages/endpoint/src/schemas/consistentSerialize.ts
@@ -1,0 +1,11 @@
+/** This serializes in consistent way even if members are added in differnet orders */
+export function consistentSerialize(obj: Record<string, unknown>) {
+  const keys = Object.keys(obj).sort();
+  const sortedObj: Record<string, unknown> = {};
+
+  for (const key of keys) {
+    sortedObj[key] = obj[key];
+  }
+
+  return JSON.stringify(sortedObj);
+}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Work with React Native

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
.native version of any algorithms that need sorting that will fallback in case this fails. So weird that RN doesn't have Array.sort() in all cases. This is the same as paramsToString from @data-client/rest.