### PR TITLE
docs: Fix 'last updated' on site

### DIFF
--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -1,0 +1,28 @@
+name: Vercel Preview Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/site-preview.yml'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/site-release.yml
+++ b/.github/workflows/site-release.yml
@@ -1,0 +1,28 @@
+name: Vercel Preview Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/site-release.yml'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 200
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/docs/rest/guides/pagination.md
+++ b/docs/rest/guides/pagination.md
@@ -94,13 +94,13 @@ import PostItem from './PostItem';
 import { PostResource } from './Post';
 
 export default function PostList() {
-  const { results: posts, cursor } = useSuspense(PostResource.getList);
+  const { results, cursor } = useSuspense(PostResource.getList);
   const ctrl = useController();
   const handlePageLoad = () =>
     ctrl.fetch(PostResource.getList.getPage, { cursor });
   return (
     <div>
-      {posts.map(post => (
+      {results.map(post => (
         <PostItem key={post.pk()} post={post} />
       ))}
       {cursor ? (


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We want accurate last updated for docs site

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since vercel's integration doesn't allow much configuration - we move to using our own github actions relying on their CLI instead. This gives us control over fetch depth.