### PR TITLE
feat: Add nonFilterArgumentKeys argument to Collection

### DIFF
--- a/.changeset/wet-waves-share.md
+++ b/.changeset/wet-waves-share.md
@@ -1,0 +1,18 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+'@rest-hooks/endpoint': patch
+'@rest-hooks/graphql': patch
+'@rest-hooks/rest': patch
+---
+
+Add nonFilterArgumentKeys argument to Collection
+
+`nonFilterArgumentKeys` defines a test to determine which argument keys
+are not used for filtering the results. For instance, if your API uses
+'orderBy' to choose a sort - this argument would not influence which
+entities are included in the response.
+
+This allows customizing `createCollectionFilter` for the
+most common case

--- a/docs/core/shared/_useLoading.mdx
+++ b/docs/core/shared/_useLoading.mdx
@@ -1,7 +1,7 @@
 import HooksPlayground from '@site/src/components/HooksPlayground';
-import { postFixtures } from '@site/src/fixtures/posts';
+import { postFixtures,getInitialInterceptorData } from '@site/src/fixtures/posts';
 
-<HooksPlayground fixtures={postFixtures} getInitialInterceptorData={() => ({entities:{}})} row>
+<HooksPlayground fixtures={postFixtures} getInitialInterceptorData={getInitialInterceptorData} row>
 
 ```ts title="PostResource" collapsed
 import { Entity, createResource } from '@data-client/rest';

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -317,6 +317,7 @@ export default function EntitySchema<TBase extends Constructor>(
     }
 
     static validate(processedEntity: any): string | undefined {
+      /* istanbul ignore else */
       if (process.env.NODE_ENV !== 'production') {
         for (const key of Object.keys(this.schema)) {
           if (!Object.hasOwn(processedEntity, key)) {

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -360,13 +360,15 @@ type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [
 type CollectionOptions<Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>
-]> = {
-    nestKey: (parent: any, key: string) => Record<string, any>;
+]> = ({
+    nestKey?: (parent: any, key: string) => Record<string, any>;
+} | {
+    argsKey?: (...args: any) => Record<string, any>;
+}) & ({
     createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
-    argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
-};
+    nonFilterArgumentKeys?: ((key: string) => boolean) | string[] | RegExp;
+});
 
 /**
  * Marks entity as Invalid.

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -360,13 +360,15 @@ type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [
 type CollectionOptions<Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>
-]> = {
-    nestKey: (parent: any, key: string) => Record<string, any>;
+]> = ({
+    nestKey?: (parent: any, key: string) => Record<string, any>;
+} | {
+    argsKey?: (...args: any) => Record<string, any>;
+}) & ({
     createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
-    argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
-};
+    nonFilterArgumentKeys?: ((key: string) => boolean) | string[] | RegExp;
+});
 
 /**
  * Marks entity as Invalid.

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -356,13 +356,15 @@ type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [
 type CollectionOptions<Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>
-]> = {
-    nestKey: (parent: any, key: string) => Record<string, any>;
+]> = ({
+    nestKey?: (parent: any, key: string) => Record<string, any>;
+} | {
+    argsKey?: (...args: any) => Record<string, any>;
+}) & ({
     createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
-    argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
-};
+    nonFilterArgumentKeys?: ((key: string) => boolean) | string[] | RegExp;
+});
 
 /**
  * Marks entity as Invalid.

--- a/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
@@ -326,13 +326,15 @@ type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [
 type CollectionOptions<Parent extends any[] = [
     urlParams: Record<string, any>,
     body?: Record<string, any>
-]> = {
-    nestKey: (parent: any, key: string) => Record<string, any>;
+]> = ({
+    nestKey?: (parent: any, key: string) => Record<string, any>;
+} | {
+    argsKey?: (...args: any) => Record<string, any>;
+}) & ({
     createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
 } | {
-    argsKey: (...args: any) => Record<string, any>;
-    createCollectionFilter?: (...args: Parent) => (collectionKey: Record<string, string>) => boolean;
-};
+    nonFilterArgumentKeys?: ((key: string) => boolean) | string[] | RegExp;
+});
 
 /**
  * Marks entity as Invalid.

--- a/website/src/fixtures/posts-collection.ts
+++ b/website/src/fixtures/posts-collection.ts
@@ -1,0 +1,86 @@
+import {
+  Entity,
+  createResource,
+  RestEndpoint,
+  AbortOptimistic,
+  schema,
+} from '@data-client/rest';
+import { v4 as uuid } from 'uuid';
+
+class Post extends Entity {
+  id = '';
+  title = '';
+  group = '';
+  author = '';
+
+  pk() {
+    return this.id;
+  }
+}
+export const getPosts = new RestEndpoint({
+  path: '/:group/posts',
+  searchParams: {} as { orderBy?: string; author?: string },
+  schema: new schema.Collection([Post], {
+    nonFilterArgumentKeys: /orderBy/,
+  }),
+});
+
+const entities = {
+  '1': {
+    id: '1',
+    title: 'Why wait on data we already have?',
+    body: 'The fastest fetch is the one that never happens. With Reactive Data Client, components use the same global data. This means no waiting when navigating from a list to detail view. No overfetching when data is reused in multiple component instances.',
+    author: 'bob',
+    group: 'react',
+  },
+  '2': {
+    id: '2',
+    title: 'Why does user experince matter?',
+    body: 'Slow interactions, confusing inconsistent data, UI flickering great a mental burden on your customers. This reduces their productivity and their frustration can make them lose trust.',
+    author: 'clara',
+    group: 'react',
+  },
+  '3': {
+    id: '3',
+    title: 'What are atomic mutations?',
+    body: 'Atomic means indivisible. Atomic mutations reactively update every usage on or off screen at the same time. This eliminates data tearing while improving performance.',
+    author: 'clara',
+    group: 'react',
+  },
+};
+
+export const getInitialInterceptorData = () => ({ entities: {} });
+
+const delay = 350;
+
+export const postFixtures = [
+  {
+    endpoint: getPosts,
+    response(...args) {
+      if (args[0]?.author) {
+        return Object.values(entities).filter(
+          post => post.author === args[0].author,
+        );
+      }
+      return Object.values(entities);
+    },
+    delay,
+  },
+  {
+    endpoint: getPosts.push,
+    response({ group }, body) {
+      console.log('POST with', group, body);
+      const id = randomId();
+      this.entities[id] = { id, group };
+      for (const [key, value] of Object.entries(body)) {
+        this.entities[id][key] = value;
+      }
+      return this.entities[id];
+    },
+    delay: 500,
+  },
+];
+
+function randomId() {
+  return Number.parseInt(uuid().slice(0, 8), 16);
+}

--- a/website/src/fixtures/posts.ts
+++ b/website/src/fixtures/posts.ts
@@ -93,6 +93,8 @@ const entities = {
   },
 };
 
+export const getInitialInterceptorData = () => ({ entities: {} });
+
 const delay = 350;
 
 export const postFixtures = [


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Specialization to simplify customization

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

`nonFilterArgumentKeys` defines a test to determine which argument keys
are _not_ used for filtering the results. For instance, if your API uses
'orderBy' to choose a sort - this argument would not influence which
entities are included in the response.

```ts
const getPosts = new RestEndpoint({
  path: '/:group/posts',
  searchParams: {} as { orderBy?: string; author?: string },
  schema: new schema.Collection([Post], {
    nonFilterArgumentKeys(key) {
      return key === 'orderBy';
    },
  }),
});
```

For convenience you can also use a RegExp or list of strings:

```ts
const getPosts = new RestEndpoint({
  path: '/:group/posts',
  searchParams: {} as { orderBy?: string; author?: string },
  schema: new schema.Collection([Post], {
    nonFilterArgumentKeys: /orderBy/,
  }),
});
```

```ts
const getPosts = new RestEndpoint({
  path: '/:group/posts',
  searchParams: {} as { orderBy?: string; author?: string },
  schema: new schema.Collection([Post], {
    nonFilterArgumentKeys: ['orderBy'],
  }),
});
```

In this case, `author` and `group` are considered 'filter' argument keys,
which means they will influence whether a newly created should be added
to those lists. On the other hand, `orderBy` does not need to match
when `push` is called.

```ts
const postByBob = useSuspense(getPosts, { author: 'bob' });
const postsSorted = useSuspense(getPosts, { orderBy: 'createdAt' });

// Will be appended to postByBob and postsSorted
() => ctrl.fetch(getPosts.push, { author: 'bob', title: 'new bob post' })
// Will be appended to postsSorted
() => ctrl.fetch(getPosts.push, { author: 'clara', title: 'new clara post' })
```
