### PR TITLE
feat: Add Collection option to createResource

### DIFF
--- a/.changeset/selfish-bananas-serve.md
+++ b/.changeset/selfish-bananas-serve.md
@@ -1,0 +1,5 @@
+---
+'@data-client/rest': patch
+---
+
+Add [Collection](https://dataclient.io/rest/api/createResource#collection) option to [createResource](https://dataclient.io/rest/api/createResource)

--- a/docs/rest/api/Collection.md
+++ b/docs/rest/api/Collection.md
@@ -24,7 +24,7 @@ and [.getPage](./RestEndpoint.md#getpage)/[.paginated()](./RestEndpoint.md#pagin
 
 ## Usage
 
-<HooksPlayground fixtures={[
+<HooksPlayground groupId="schema" defaultOpen="y" fixtures={[
 {
 endpoint: new RestEndpoint({path: '/users'}),
 args: [],

--- a/docs/rest/api/createResource.md
+++ b/docs/rest/api/createResource.md
@@ -61,6 +61,7 @@ controller.fetch(TodoResource.delete, { id: '5' });
   paginationField?: string;
   optimistic?: boolean;
   Endpoint?: typeof RestEndpoint;
+  Collection?: typeof Collection;
 } & EndpointExtraOptions
 ```
 
@@ -96,6 +97,52 @@ If specified, will add [Resource.getList.getPage](#getpage) method on the `Resou
 
 Class used to construct the members.
 
+```ts
+import { RestEndpoint } from '@data-client/rest';
+
+export default class AuthdEndpoint<
+  O extends RestGenerics = any,
+> extends RestEndpoint<O> {
+  getRequestInit(body: any): RequestInit {
+    return {
+      ...super.getRequestInit(body),
+      credentials: 'same-origin',
+    };
+  }
+}
+const TodoResource = createResource({
+  path: '/todos/:id',
+  schema: Todo,
+  // highlight-next-line
+  Endpoint: AuthdEndpoint,
+});
+```
+
+### Collection
+
+Class used to construct [getList](#getlist) schema.
+
+```ts
+import { schema, createResource } from '@data-client/rest';
+
+class MyCollection<
+  S extends any[] | PolymorphicInterface = any,
+  Parent extends any[] = [urlParams: any, body?: any],
+> extends schema.Collection<S, Parent> {
+  // getList.push should add to Collections regardless of its 'sorted' argument
+  nonFilterArgumentKeys(key: string) {
+    return key === 'sorted';
+  }
+}
+const TodoResource = createResource({
+  path: '/todos/:id',
+  searchParams: {} as { userId?: string; sorted?: boolean } | undefined,
+  schema: Todo,
+  // highlight-next-line
+  Collection: MyCollection,
+});
+```
+
 ### [EndpointExtraOptions](./RestEndpoint.md#endpoint-life-cycles)
 
 ## Members
@@ -118,7 +165,7 @@ createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }).get({
   group: 'abc',
   id: 'xyz',
 });
-```
+````
 
 Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidate](/docs/api/Controller#invalidate)
 
@@ -272,7 +319,7 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 
 `createResource` builds a great starting point, but often endpoints need to be [further customized](./RestEndpoint.md#typing).
 
-`extend()` is polymorphic with three forms: 
+`extend()` is polymorphic with three forms:
 
 #### Batch extension of known members
 

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -384,6 +384,33 @@ exports[`CacheProvider pagination should work with cursor field from getList.pag
 ]
 `;
 
+exports[`CacheProvider should use custom Collection class 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": "3",
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
 exports[`CacheProvider should work with unions 1`] = `
 [
   [
@@ -831,6 +858,33 @@ exports[`ExternalCacheProvider pagination should work with cursor field from get
     "title": "the next time",
   },
 ]
+`;
+
+exports[`ExternalCacheProvider should use custom Collection class 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": "3",
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
 `;
 
 exports[`ExternalCacheProvider should work with unions 1`] = `

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -19,7 +19,7 @@ import RestEndpoint, {
 } from './RestEndpoint.js';
 import { shortenPath } from './RestHelpers.js';
 
-const { Invalidate, Collection } = schema;
+const { Invalidate, Collection: BaseCollection } = schema;
 
 /** Creates collection of Endpoints for common operations on a given data/schema.
  *
@@ -29,6 +29,7 @@ export default function createResource<O extends ResourceGenerics>({
   path,
   schema,
   Endpoint = RestEndpoint,
+  Collection = BaseCollection,
   optimistic,
   paginationField,
   ...extraOptions

--- a/packages/rest/src/resourceTypes.ts
+++ b/packages/rest/src/resourceTypes.ts
@@ -1,4 +1,4 @@
-import type { schema } from '@data-client/endpoint';
+import type { Collection, schema } from '@data-client/endpoint';
 import type { Schema } from '@data-client/endpoint';
 import type { Denormalize } from '@data-client/endpoint';
 
@@ -30,6 +30,8 @@ export interface ResourceGenerics {
 export interface ResourceOptions {
   /** @see https://resthooks.io/rest/api/createResource#endpoint */
   Endpoint?: typeof RestEndpoint;
+  /** @see https://dataclient.io/rest/api/createResource#collection */
+  Collection?: typeof Collection;
   /** @see https://resthooks.io/rest/api/createResource#optimistic */
   optimistic?: boolean;
   /** @see https://resthooks.io/rest/api/createResource#urlprefix */

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -2045,6 +2045,8 @@ interface ResourceGenerics {
 interface ResourceOptions {
     /** @see https://resthooks.io/rest/api/createResource#endpoint */
     Endpoint?: typeof RestEndpoint;
+    /** @see https://dataclient.io/rest/api/createResource#collection */
+    Collection?: typeof Collection;
     /** @see https://resthooks.io/rest/api/createResource#optimistic */
     optimistic?: boolean;
     /** @see https://resthooks.io/rest/api/createResource#urlprefix */
@@ -2157,7 +2159,7 @@ interface ResourceInterface {
  *
  * @see https://resthooks.io/rest/api/createResource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
+declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, Collection, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 
 interface HookableEndpointInterface extends EndpointInterface {
     extend(...args: any): HookableEndpointInterface;

--- a/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
@@ -1411,6 +1411,8 @@ interface ResourceGenerics {
 interface ResourceOptions {
     /** @see https://resthooks.io/rest/api/createResource#endpoint */
     Endpoint?: typeof RestEndpoint;
+    /** @see https://dataclient.io/rest/api/createResource#collection */
+    Collection?: typeof Collection;
     /** @see https://resthooks.io/rest/api/createResource#optimistic */
     optimistic?: boolean;
     /** @see https://resthooks.io/rest/api/createResource#urlprefix */
@@ -1523,6 +1525,6 @@ interface ResourceInterface {
  *
  * @see https://resthooks.io/rest/api/createResource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
+declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, Collection, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 
 export { AddEndpoint, Defaults, FetchGet, FetchMutate, FromFallBack, GetEndpoint, KeyofRestEndpoint, MethodToSide, MutateEndpoint, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, PartialRestGenerics, Resource, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, createResource };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Make it easier to customize [Collection](https://dataclient.io/rest/api/Collection) usage with [Resources](https://dataclient.io/rest/api/createResource)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Class used to construct [getList](https://dataclient.io/rest/api/createResource#getlist) schema.

```ts
import { schema, createResource } from '@data-client/rest';

class MyCollection<
  S extends any[] | PolymorphicInterface = any,
  Parent extends any[] = [urlParams: any, body?: any],
> extends schema.Collection<S, Parent> {
  // getList.push should add to Collections regardless of its 'sorted' argument
  nonFilterArgumentKeys(key: string) {
    return key === 'sorted';
  }
}
const TodoResource = createResource({
  path: '/todos/:id',
  searchParams: {} as { userId?: string; sorted?: boolean } | undefined,
  schema: Todo,
  // highlight-next-line
  Collection: MyCollection,
});
```