### PR TITLE
fix: Resource.extend() for builtin endpoints with zero typing options

### DIFF
--- a/.changeset/odd-pants-roll.md
+++ b/.changeset/odd-pants-roll.md
@@ -1,0 +1,20 @@
+---
+'@data-client/rest': patch
+'@rest-hooks/rest': patch
+---
+
+Fix Resource.extend() for builtin endpoints with zero typing options
+
+```ts
+const RatingResource = createResource({
+  path: '/ratings/:id',
+  schema: Rating,
+}).extend({
+  getList: {
+    dataExpiryLength: 10 * 60 * 1000, // 10 minutes
+  },
+});
+```
+
+This would previously break the types of RatingResource.getList.
+This would only occur because dataExpiryLength is not a type-influencing option.

--- a/packages/rest/src/__tests__/createResource.test.ts
+++ b/packages/rest/src/__tests__/createResource.test.ts
@@ -355,6 +355,23 @@ describe('createResource()', () => {
     expect(result.current[1][1].username).toBe('newbob');
   });
 
+  it('can override with no generics', async () => {
+    const UserResource = createResource({
+      path: 'http\\://test.com/groups/:group/users/:id',
+      schema: User,
+      paginationField: 'cursor',
+    }).extend({
+      getList: {
+        dataExpiryLength: 10 * 60 * 1000,
+      },
+    });
+
+    const a: undefined = UserResource.getList.sideEffect;
+    // @ts-expect-error
+    const b: true = UserResource.getList.sideEffect;
+    () => useSuspense(UserResource.getList, { group: 'hi' });
+  });
+
   it('can override resource endpoints (function form)', async () => {
     const UserResource = createResource({
       path: 'http\\://test.com/groups/:group/users/:id',

--- a/packages/rest/src/resourceExtensionTypes.ts
+++ b/packages/rest/src/resourceExtensionTypes.ts
@@ -35,17 +35,29 @@ export interface CustomResource<
   Delete extends PartialRestGenerics | {} = any,
 > extends Extendable<O> {
   // unknown only extends any. this allows us to match exclusively on members not set
-  get: unknown extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
+  get: unknown extends Get
+    ? R['get']
+    : PartialRestGenerics extends Get
+    ? R['get']
+    : RestExtendedEndpoint<Get, R['get']>;
   getList: unknown extends GetList
+    ? R['getList']
+    : PartialRestGenerics extends GetList
     ? R['getList']
     : RestExtendedEndpoint<GetList, R['getList']>;
   update: unknown extends Update
     ? R['update']
+    : PartialRestGenerics extends Update
+    ? R['update']
     : RestExtendedEndpoint<Update, R['update']>;
   partialUpdate: unknown extends PartialUpdate
     ? R['partialUpdate']
+    : PartialRestGenerics extends PartialUpdate
+    ? R['partialUpdate']
     : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
   delete: unknown extends Delete
+    ? R['delete']
+    : PartialRestGenerics extends Delete
     ? R['delete']
     : RestExtendedEndpoint<Delete, R['delete']>;
 }

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -1991,11 +1991,11 @@ interface CustomResource<R extends ResourceInterface, O extends ResourceGenerics
     path: ResourcePath;
     schema: any;
 }, Get extends PartialRestGenerics | {} = any, GetList extends PartialRestGenerics | {} = any, Update extends PartialRestGenerics | {} = any, PartialUpdate extends PartialRestGenerics | {} = any, Delete extends PartialRestGenerics | {} = any> extends Extendable<O> {
-    get: unknown extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
-    getList: unknown extends GetList ? R['getList'] : RestExtendedEndpoint<GetList, R['getList']>;
-    update: unknown extends Update ? R['update'] : RestExtendedEndpoint<Update, R['update']>;
-    partialUpdate: unknown extends PartialUpdate ? R['partialUpdate'] : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
-    delete: unknown extends Delete ? R['delete'] : RestExtendedEndpoint<Delete, R['delete']>;
+    get: unknown extends Get ? R['get'] : PartialRestGenerics extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
+    getList: unknown extends GetList ? R['getList'] : PartialRestGenerics extends GetList ? R['getList'] : RestExtendedEndpoint<GetList, R['getList']>;
+    update: unknown extends Update ? R['update'] : PartialRestGenerics extends Update ? R['update'] : RestExtendedEndpoint<Update, R['update']>;
+    partialUpdate: unknown extends PartialUpdate ? R['partialUpdate'] : PartialRestGenerics extends PartialUpdate ? R['partialUpdate'] : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
+    delete: unknown extends Delete ? R['delete'] : PartialRestGenerics extends Delete ? R['delete'] : RestExtendedEndpoint<Delete, R['delete']>;
 }
 type ExtendedResource<R extends ResourceInterface, T extends Record<string, EndpointInterface>> = Omit<R, keyof T> & T;
 interface ResourceEndpointExtensions<R extends ResourceInterface, Get extends PartialRestGenerics = any, GetList extends PartialRestGenerics = any, Update extends PartialRestGenerics = any, PartialUpdate extends PartialRestGenerics = any, Delete extends PartialRestGenerics = any> {

--- a/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
@@ -1357,11 +1357,11 @@ interface CustomResource<R extends ResourceInterface, O extends ResourceGenerics
     path: ResourcePath;
     schema: any;
 }, Get extends PartialRestGenerics | {} = any, GetList extends PartialRestGenerics | {} = any, Update extends PartialRestGenerics | {} = any, PartialUpdate extends PartialRestGenerics | {} = any, Delete extends PartialRestGenerics | {} = any> extends Extendable<O> {
-    get: unknown extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
-    getList: unknown extends GetList ? R['getList'] : RestExtendedEndpoint<GetList, R['getList']>;
-    update: unknown extends Update ? R['update'] : RestExtendedEndpoint<Update, R['update']>;
-    partialUpdate: unknown extends PartialUpdate ? R['partialUpdate'] : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
-    delete: unknown extends Delete ? R['delete'] : RestExtendedEndpoint<Delete, R['delete']>;
+    get: unknown extends Get ? R['get'] : PartialRestGenerics extends Get ? R['get'] : RestExtendedEndpoint<Get, R['get']>;
+    getList: unknown extends GetList ? R['getList'] : PartialRestGenerics extends GetList ? R['getList'] : RestExtendedEndpoint<GetList, R['getList']>;
+    update: unknown extends Update ? R['update'] : PartialRestGenerics extends Update ? R['update'] : RestExtendedEndpoint<Update, R['update']>;
+    partialUpdate: unknown extends PartialUpdate ? R['partialUpdate'] : PartialRestGenerics extends PartialUpdate ? R['partialUpdate'] : RestExtendedEndpoint<PartialUpdate, R['partialUpdate']>;
+    delete: unknown extends Delete ? R['delete'] : PartialRestGenerics extends Delete ? R['delete'] : RestExtendedEndpoint<Delete, R['delete']>;
 }
 type ExtendedResource<R extends ResourceInterface, T extends Record<string, EndpointInterface>> = Omit<R, keyof T> & T;
 interface ResourceEndpointExtensions<R extends ResourceInterface, Get extends PartialRestGenerics = any, GetList extends PartialRestGenerics = any, Update extends PartialRestGenerics = any, PartialUpdate extends PartialRestGenerics = any, Delete extends PartialRestGenerics = any> {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Fix Resource.extend() for builtin endpoints with zero typing options

```ts
const RatingResource = createResource({
  path: '/ratings/:id',
  schema: Rating,
}).extend({
  getList: {
    dataExpiryLength: 10 * 60 * 1000, // 10 minutes
  },
});
```

This would previously break the types of RatingResource.getList.
This would only occur because dataExpiryLength is not a type-influencing option.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

In the case of an option specified, but not including type-influencing options (PartialRestGenerics) the generic would end up being `PartialRestGenerics` rather than any - therefore we simply add a condition to handle that.