### PR TITLE
internal: Do not fail on vercel deploys

### DIFF
--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Build Project Artifacts
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
+        continue-on-error: true
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/site-release.yml
+++ b/.github/workflows/site-release.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Build Project Artifacts
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
+        continue-on-error: true
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In case we hit limits https://vercel.com/docs/limits/overview#username-update we don't want a red mark on our history

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`continue-on-error` should ensure the action doesn't fail