### PR TITLE
enhance: Collections can filter based on FormData arguments

### DIFF
--- a/.changeset/bright-planes-dance.md
+++ b/.changeset/bright-planes-dance.md
@@ -1,0 +1,31 @@
+---
+'@data-client/core': patch
+'@data-client/react': patch
+'@rest-hooks/core': patch
+'@rest-hooks/react': patch
+---
+
+[Collections](https://dataclient.io/rest/api/Collection) can filter based on FormData arguments
+
+```ts
+ctrl.fetch(
+  getPosts.push,
+  { group: 'react' },
+  new FormData(e.currentTarget),
+);
+```
+
+Say our FormData contained an `author` field. Now that newly created
+item will be properly added to the [collection list](https://dataclient.io/rest/api/Collection) for that author.
+
+```ts
+useSuspense(getPosts, {
+  group: 'react',
+  author: 'bob',
+});
+```
+
+In this case if `FormData.get('author') === 'bob'`, it will show
+up in that [useSuspense()](https://dataclient.io/docs/api/useSuspense) call.
+
+See more in the [Collection nonFilterArgumentKeys example](https://dataclient.io/rest/api/Collection#nonfilterargumentkeys)

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -29,6 +29,7 @@ import {
   createUnsubscription,
   createSubscription,
 } from './createSubscription.js';
+import ensurePojo from './ensurePojo.js';
 import type { EndpointUpdateFunction } from './types.js';
 import { initialState } from '../state/reducer/createReducer.js';
 import selectMeta from '../state/selectMeta.js';
@@ -380,7 +381,9 @@ export default class Controller<
   } => {
     const state = rest[rest.length - 1] as State<unknown>;
     // this is typescript generics breaking
-    const args: any = rest.slice(0, rest.length - 1) as Parameters<E['key']>;
+    const args: any = rest
+      .slice(0, rest.length - 1)
+      .map(ensurePojo) as Parameters<E['key']>;
     const isActive = args.length !== 1 || args[0] !== null;
     const key = isActive ? endpoint.key(...args) : '';
     const cacheResults = isActive ? state.results[key] : undefined;

--- a/packages/core/src/controller/createSet.ts
+++ b/packages/core/src/controller/createSet.ts
@@ -1,5 +1,6 @@
 import type { EndpointInterface, ResolveType } from '@data-client/normalizr';
 
+import ensurePojo from './ensurePojo.js';
 import { EndpointUpdateFunction } from './types.js';
 import { SET_TYPE } from '../actionTypes.js';
 import type { SetAction, SetMeta } from '../types.js';
@@ -59,7 +60,7 @@ export default function createSet<
   }
   const now = Date.now();
   const meta: SetMeta = {
-    args,
+    args: args.map(ensurePojo),
     fetchedAt: fetchedAt ?? now,
     date: now,
     expiresAt: now + expiryLength,

--- a/packages/core/src/controller/ensurePojo.ts
+++ b/packages/core/src/controller/ensurePojo.ts
@@ -1,0 +1,11 @@
+export const ensurePojo =
+  // FormData doesn't exist in node
+  /* istanbul ignore else we don't run coverage when we test node*/
+  typeof FormData !== 'undefined'
+    ? (body: any) =>
+        body instanceof FormData
+          ? Object.fromEntries((body as any).entries())
+          : body
+    : /* istanbul ignore next */
+      (body: any) => body;
+export default ensurePojo;

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -46,7 +46,48 @@ exports[`CacheProvider RestEndpoint/current pagination should work with cursor f
 }
 `;
 
-exports[`CacheProvider RestEndpoint/current should update collection on push/unshift 1`] = `
+exports[`CacheProvider RestEndpoint/current should update collection on push/unshift FormData 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": "3",
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": "5",
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/current should update collection on push/unshift pojo 1`] = `
 {
   "todos": [
     Todo {
@@ -205,7 +246,48 @@ exports[`CacheProvider RestEndpoint/next pagination should work with cursor fiel
 }
 `;
 
-exports[`CacheProvider RestEndpoint/next should update collection on push/unshift 1`] = `
+exports[`CacheProvider RestEndpoint/next should update collection on push/unshift FormData 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": "3",
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": "5",
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`CacheProvider RestEndpoint/next should update collection on push/unshift pojo 1`] = `
 {
   "todos": [
     Todo {
@@ -522,7 +604,48 @@ exports[`ExternalCacheProvider RestEndpoint/current pagination should work with 
 }
 `;
 
-exports[`ExternalCacheProvider RestEndpoint/current should update collection on push/unshift 1`] = `
+exports[`ExternalCacheProvider RestEndpoint/current should update collection on push/unshift FormData 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": "3",
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": "5",
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/current should update collection on push/unshift pojo 1`] = `
 {
   "todos": [
     Todo {
@@ -681,7 +804,48 @@ exports[`ExternalCacheProvider RestEndpoint/next pagination should work with cur
 }
 `;
 
-exports[`ExternalCacheProvider RestEndpoint/next should update collection on push/unshift 1`] = `
+exports[`ExternalCacheProvider RestEndpoint/next should update collection on push/unshift FormData 1`] = `
+{
+  "todos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+    Todo {
+      "completed": false,
+      "id": "3",
+      "title": "ssdf",
+      "userId": "2",
+    },
+  ],
+  "user": User {
+    "email": "",
+    "id": "1",
+    "name": "",
+    "todos": [
+      Todo {
+        "completed": false,
+        "id": "5",
+        "title": "do things",
+        "userId": "1",
+      },
+    ],
+    "username": "bob",
+  },
+  "userTodos": [
+    Todo {
+      "completed": false,
+      "id": "5",
+      "title": "do things",
+      "userId": "1",
+    },
+  ],
+}
+`;
+
+exports[`ExternalCacheProvider RestEndpoint/next should update collection on push/unshift pojo 1`] = `
 {
   "todos": [
     Todo {

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -138,7 +138,7 @@ export default function createResource<O extends ResourceGenerics>({
 function optimisticUpdate(snap: SnapshotInterface, params: any, body: any) {
   return {
     ...params,
-    ...ensureBodyPojo(body),
+    ...ensurePojo(body),
   };
 }
 function optimisticPartial(
@@ -151,14 +151,14 @@ function optimisticPartial(
       ...params,
       ...data,
       // even tho we don't always have two arguments, the extra one will simply be undefined which spreads fine
-      ...ensureBodyPojo(body),
+      ...ensurePojo(body),
     };
   };
 }
 function optimisticDelete(snap: SnapshotInterface, params: any) {
   return params;
 }
-function ensureBodyPojo(body: any) {
+function ensurePojo(body: any) {
   return body instanceof FormData
     ? Object.fromEntries((body as any).entries())
     : body;

--- a/website/src/fixtures/posts-collection.ts
+++ b/website/src/fixtures/posts-collection.ts
@@ -69,10 +69,11 @@ export const postFixtures = [
   {
     endpoint: getPosts.push,
     response({ group }, body) {
-      console.log('POST with', group, body);
       const id = randomId();
       this.entities[id] = { id, group };
-      for (const [key, value] of Object.entries(body)) {
+      const entries =
+        body instanceof FormData ? body.entries() : Object.entries(body);
+      for (const [key, value] of entries) {
         this.entities[id][key] = value;
       }
       return this.entities[id];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
It's often easy to prepare data using FormData.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

[Collections](https://dataclient.io/rest/api/Collection) can filter based on FormData arguments

```ts
ctrl.fetch(
  getPosts.push,
  { group: 'react' },
  new FormData(e.currentTarget),
);
```

Say our FormData contained an `author` field. Now that newly created
item will be properly added to the [collection list](https://dataclient.io/rest/api/Collection) for that author.

```ts
useSuspense(getPosts, {
  group: 'react',
  author: 'bob',
});
```

In this case if `FormData.get('author') === 'bob'`, it will show
up in that [useSuspense()](https://dataclient.io/docs/api/useSuspense) call.

See more in the [Collection nonFilterArgumentKeys example](https://dataclient.io/rest/api/Collection#nonfilterargumentkeys)


### Code location

We convert args away from FormData inside the `core` package. This could be done in normalizr, but we don't believe normalizr should be aware of such concepts. `core` is not view library specific, but FormData is beyond that so it's the perfect level to be aware of such things. We also have to be conscious that FormData does not exist in node; so we have a condition for that. Though we do not expect node to have any need for support other than the fact that it's impossible - since mutations are generally not done in SSR