### PR TITLE
Entity.process() now gets an addition argument of 'args' (sent from endpoint)

### DIFF
--- a/.changeset/purple-hornets-turn.md
+++ b/.changeset/purple-hornets-turn.md
@@ -1,0 +1,30 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+'@rest-hooks/endpoint': patch
+'@rest-hooks/rest': patch
+---
+
+Entity.process() now gets an addition argument of 'args' (sent from endpoint)
+
+```ts
+class Stream extends Entity {
+  username = '';
+  title = '';
+  game = '';
+  currentViewers = 0;
+  live = false;
+
+  pk() {
+    return this.username;
+  }
+  static key = 'Stream';
+
+  process(value, parent, key, args) {
+    const processed = super.process(value, parent, key, args);
+    processed.username = args[0]?.username;
+    return processed;
+  }
+}
+```

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -32,8 +32,8 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 [Entity.key](#key) + [Entity.pk()](#pk) (primary key) enable a [flat lookup table](https://react.dev/learn/choosing-the-state-structure#principles-for-structuring-state) store, enabling high
 performance, data consistency and atomic mutations.
 
-`Entities` enable customizing the data processing lifecycle by defining [static schema](#schema) and [lifecycle method](#data-lifecycle)
-overrides.
+`Entities` enable customizing the data processing lifecycle by defining its static members like [schema](#schema)
+and overriding its [lifecycle methods](#data-lifecycle).
 
 ## Usage
 
@@ -181,7 +181,7 @@ class User extends Entity {
 Factory method that copies props to a new instance. Use this instead of `new MyEntity()`,
 to ensure default props are overridden.
 
-### process(input, parent, key): processedEntity {#process}
+### static process(input, parent, key, args): processedEntity {#process}
 
 Run at the start of normalization for this entity. Return value is saved in store
 and sent to [pk()](#pk).
@@ -189,6 +189,30 @@ and sent to [pk()](#pk).
 **Defaults** to simply copying the response (`{...input}`)
 
 How to override to [build reverse-lookups for relational data](../guides/relational-data.md#reverse-lookups)
+
+#### Case of the missing id
+
+```ts
+class Stream extends Entity {
+  username = '';
+  title = '';
+  game = '';
+  currentViewers = 0;
+  live = false;
+
+  pk() {
+    return this.username;
+  }
+  static key = 'Stream';
+
+  process(value, parent, key, args) {
+    // super.process creates a copy of value
+    const processed = super.process(value, parent, key, args);
+    processed.username = args[0]?.username;
+    return processed;
+  }
+}
+```
 
 ### static merge(existing, incoming): mergedValue {#merge}
 
@@ -282,7 +306,7 @@ class LatestPriceEntity extends Entity {
 }
 ```
 
-### createIfValid(processedEntity): Entity | undefined {#createIfValid}
+### static createIfValid(processedEntity): Entity | undefined {#createIfValid}
 
 Called when denormalizing an entity. This will create an instance of this class
 if it is deemed 'valid'.
@@ -333,7 +357,7 @@ This determines expiry time when entity is part of a result that is inferred.
 
 Overriding can be used to change TTL policy specifically for inferred responses.
 
-## Members
+## Fields
 
 ### static indexes?: (keyof this)[] {#indexes}
 

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -133,7 +133,12 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
    *
    * @see https://resthooks.io/docs/api/Entity#process
    */
-  static process(input: any, parent: any, key: string | undefined): any {
+  static process(
+    input: any,
+    parent: any,
+    key: string | undefined,
+    args: any[],
+  ): any {
     /* istanbul ignore else */
     if (
       process.env.NODE_ENV !== 'production' &&
@@ -160,7 +165,7 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
       }
     }
 
-    return super.process(input, parent, key);
+    return super.process(input, parent, key, args);
   }
 
   /** Returning a string indicates an error (the string is the message)

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -238,7 +238,12 @@ export default function EntitySchema<TBase extends Constructor>(
      *
      * @see https://resthooks.io/docs/api/schema.Entity#process
      */
-    static process(input: any, parent: any, key: string | undefined): any {
+    static process(
+      input: any,
+      parent: any,
+      key: string | undefined,
+      args: any,
+    ): any {
       return { ...input };
     }
 
@@ -252,7 +257,7 @@ export default function EntitySchema<TBase extends Constructor>(
       storeEntities: any,
       args?: readonly any[],
     ): any {
-      const processedEntity = this.process(input, parent, key);
+      const processedEntity = this.process(input, parent, key, args);
       let id = this.pk(processedEntity, parent, key, args);
       if (id === undefined || id === '' || id === 'undefined') {
         // create a random id if a valid one cannot be computed
@@ -669,7 +674,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
    *
    * @see https://resthooks.io/docs/api/Entity#process
    */
-  process(input: any, parent: any, key: string | undefined): any;
+  process(input: any, parent: any, key: string | undefined, args: any[]): any;
   normalize(
     input: any,
     parent: any,

--- a/packages/endpoint/src/schemas/Invalidate.ts
+++ b/packages/endpoint/src/schemas/Invalidate.ts
@@ -42,7 +42,7 @@ export default class Invalidate<
     args?: any[],
   ): string | undefined {
     // TODO: what's store needs to be a differing type from fromJS
-    const processedEntity = this._entity.process(input, parent, key);
+    const processedEntity = this._entity.process(input, parent, key, args);
     const id = this._entity.pk(processedEntity, parent, key, args);
 
     if (

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -428,7 +428,7 @@ interface IEntityClass<TBase extends Constructor = any> {
      *
      * @see https://resthooks.io/docs/api/Entity#process
      */
-    process(input: any, parent: any, key: string | undefined): any;
+    process(input: any, parent: any, key: string | undefined, args: any[]): any;
     normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>): any;
     /** Do any transformations when first receiving input
      *
@@ -1051,7 +1051,7 @@ declare abstract class Entity extends Entity_base {
      *
      * @see https://resthooks.io/docs/api/Entity#process
      */
-    static process(input: any, parent: any, key: string | undefined): any;
+    static process(input: any, parent: any, key: string | undefined, args: any[]): any;
     /** Returning a string indicates an error (the string is the message)
      * @see https://resthooks.io/rest/api/Entity#validate
      */

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -428,7 +428,7 @@ interface IEntityClass<TBase extends Constructor = any> {
      *
      * @see https://resthooks.io/docs/api/Entity#process
      */
-    process(input: any, parent: any, key: string | undefined): any;
+    process(input: any, parent: any, key: string | undefined, args: any[]): any;
     normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>): any;
     /** Do any transformations when first receiving input
      *
@@ -1051,7 +1051,7 @@ declare abstract class Entity extends Entity_base {
      *
      * @see https://resthooks.io/docs/api/Entity#process
      */
-    static process(input: any, parent: any, key: string | undefined): any;
+    static process(input: any, parent: any, key: string | undefined, args: any[]): any;
     /** Returning a string indicates an error (the string is the message)
      * @see https://resthooks.io/rest/api/Entity#validate
      */

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -424,7 +424,7 @@ interface IEntityClass<TBase extends Constructor = any> {
      *
      * @see https://resthooks.io/docs/api/Entity#process
      */
-    process(input: any, parent: any, key: string | undefined): any;
+    process(input: any, parent: any, key: string | undefined, args: any[]): any;
     normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>): any;
     /** Do any transformations when first receiving input
      *
@@ -1047,7 +1047,7 @@ declare abstract class Entity extends Entity_base {
      *
      * @see https://resthooks.io/docs/api/Entity#process
      */
-    static process(input: any, parent: any, key: string | undefined): any;
+    static process(input: any, parent: any, key: string | undefined, args: any[]): any;
     /** Returning a string indicates an error (the string is the message)
      * @see https://resthooks.io/rest/api/Entity#validate
      */

--- a/website/src/components/Playground/editor-types/react.d.ts
+++ b/website/src/components/Playground/editor-types/react.d.ts
@@ -60,7 +60,7 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
-// eslint-disable-next-line export-just-namespace
+// eslint-disable-next-line @definitelytyped/export-just-namespace
 export = React;
 export as namespace React;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
normalize has this so we might as well pass it on. This enables applying the [case of the missing id](https://dataclient.io/rest/guides/network-transform#case-of-the-missing-id) to entities and not just endpoints.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Entity.process() now gets an addition argument of 'args' (sent from endpoint)

```ts
class Stream extends Entity {
  username = '';
  title = '';
  game = '';
  currentViewers = 0;
  live = false;

  pk() {
    return this.username;
  }
  static key = 'Stream';

  process(value, parent, key, args) {
    const processed = super.process(value, parent, key, args);
    processed.username = args[0]?.username;
    return processed;
  }
}
```